### PR TITLE
Fix missing comma causing install failure

### DIFF
--- a/config.json_template
+++ b/config.json_template
@@ -128,7 +128,7 @@
     },
 
     "ORB_PROPERTIES" : {
-        "comment_MODE" : "ha = hour angle, az = azimuth, alt = altitude"
+        "comment_MODE" : "ha = hour angle, az = azimuth, alt = altitude",
         "MODE"        : "ha",
         "RADIUS"      : 9,
         "SUN_COLOR"   : [255, 255, 255],


### PR DESCRIPTION
L131 has a missing `,` at the end resulting in this not being valid for parsing.

This simply adds it, allowing new installs to work again 😸