### PR TITLE
Add date options to remote path

### DIFF
--- a/indi_allsky/flask/forms.py
+++ b/indi_allsky/flask/forms.py
@@ -1324,6 +1324,8 @@ def FILETRANSFER__REMOTE_IMAGE_NAME_validator(form, field):
         'timestamp'  : datetime.now(),
         'ts'         : datetime.now(),
         'ext'        : 'jpg',
+        'date'       : '2000-01-01',
+        'night_date' : '2000-01-01',
     }
 
     try:
@@ -1344,6 +1346,8 @@ def FILETRANSFER__REMOTE_METADATA_NAME_validator(form, field):
     test_data = {
         'timestamp'  : datetime.now(),
         'ts'         : datetime.now(),
+        'date'       : '2000-01-01',
+        'night_date' : '2000-01-01',
     }
 
     try:
@@ -1364,6 +1368,8 @@ def REMOTE_FOLDER_validator(form, field):
     test_data = {
         'timestamp'  : datetime.now(),
         'ts'         : datetime.now(),
+        'date'       : '2000-01-01',
+        'night_date' : '2000-01-01',
     }
 
     try:

--- a/indi_allsky/flask/templates/config.html
+++ b/indi_allsky/flask/templates/config.html
@@ -2116,7 +2116,7 @@
         </div>
         <div class="col-sm-6">
             <div>Remote folder to store images</div>
-            <div>Available variables: <pre>timestamp, ts, camera_uuid</pre></div>
+            <div>Available variables: <pre>timestamp, ts, camera_uuid, date, night_date</pre></div>
         </div>
     </div>
 

--- a/indi_allsky/image.py
+++ b/indi_allsky/image.py
@@ -736,11 +736,15 @@ class ImageWorker(Process):
             self.config['IMAGE_FILE_TYPE'],
         ]
 
+        now = datetime.now()
+
         file_data_dict = {
             'timestamp'    : i_ref['exp_date'],
             'ts'           : i_ref['exp_date'],  # shortcut
             'ext'          : self.config['IMAGE_FILE_TYPE'],
             'camera_uuid'  : camera.uuid,
+            'date'         : str(now.date()),
+            'night_date'   : str((now - timedelta(hours=12)).date()),
         }
 
 


### PR DESCRIPTION
This PR adds two additional options to the remote path to help facilitate more organized upload paths
- `date` - gives the date string of the current time
- `night_date` - gives the date corresponding to the beginning of the night