### PR TITLE
BREAKING CHANGE: Replace SyncAPI authorization with HMAC signing

### DIFF
--- a/indi_allsky/flask/syncapi_views.py
+++ b/indi_allsky/flask/syncapi_views.py
@@ -391,6 +391,19 @@ class SyncApiCameraView(SyncApiBaseView):
         return self.post(overwrite=overwrite)
 
 
+    def getEntry(self, entry_id):
+        try:
+            entry = self.model.query\
+                .filter(self.model.id == entry_id)\
+                .one()
+
+        except NoResultFound:
+            raise EntryMissing()
+
+
+        return entry
+
+
     def processPost(self, notUsed1, metadata, notUsed2, overwrite=True):
         addFunction_method = getattr(self._miscDb, self.add_function)
         entry = addFunction_method(

--- a/indi_allsky/flask/syncapi_views.py
+++ b/indi_allsky/flask/syncapi_views.py
@@ -138,7 +138,7 @@ class SyncApiBaseView(BaseView):
 
 
         try:
-            file_entry = self.getEntry(metadata['id'], camera.id)
+            file_entry = self.getEntry(metadata, camera)
         except EntryMissing:
             return jsonify({'error' : 'file_missing'}), 400
 
@@ -240,12 +240,12 @@ class SyncApiBaseView(BaseView):
             raise EntryMissing()
 
 
-    def getEntry(self, entry_id, camera_id):
+    def getEntry(self, metadata, camera):
         try:
             entry = self.model.query\
                 .join(IndiAllSkyDbCameraTable)\
-                .filter(IndiAllSkyDbCameraTable.id == camera_id)\
-                .filter(self.model.id == entry_id)\
+                .filter(IndiAllSkyDbCameraTable.id == camera.id)\
+                .filter(self.model.id == metadata['id'])\
                 .one()
 
         except NoResultFound:
@@ -364,10 +364,10 @@ class SyncApiCameraView(SyncApiBaseView):
 
 
     def get(self):
-        get_id = request.args.get('id')
+        metadata = self.saveMetadata()
 
         try:
-            file_entry = self.getEntry(get_id)
+            file_entry = self.getEntry(metadata)
         except EntryMissing:
             return jsonify({'error' : 'camera_missing'}), 400
 
@@ -391,10 +391,11 @@ class SyncApiCameraView(SyncApiBaseView):
         return self.post(overwrite=overwrite)
 
 
-    def getEntry(self, entry_id):
+    def getEntry(self, metadata):
         try:
             entry = self.model.query\
-                .filter(self.model.id == entry_id)\
+                .filter(self.model.id == metadata['id'])\
+                .filter(self.model.uuid == metadata['camera_uuid'])\
                 .one()
 
         except NoResultFound:

--- a/indi_allsky/flask/syncapi_views.py
+++ b/indi_allsky/flask/syncapi_views.py
@@ -92,7 +92,7 @@ class SyncApiBaseView(BaseView):
             camera = self.getCamera(metadata)
         except NoResultFound:
             app.logger.error('Camera not found: %s', metadata['camera_uuid'])
-            return jsonify({}), 400
+            return jsonify({'error' : 'camera not found'}), 400
 
 
         try:
@@ -119,7 +119,7 @@ class SyncApiBaseView(BaseView):
             camera = self.getCamera(metadata)
         except NoResultFound:
             app.logger.error('Camera not found: %s', metadata['camera_uuid'])
-            return jsonify({}), 400
+            return jsonify({'error' : 'camera not found'}), 400
 
 
         try:
@@ -138,7 +138,7 @@ class SyncApiBaseView(BaseView):
             camera = self.getCamera(metadata)
         except NoResultFound:
             app.logger.error('Camera not found: %s', metadata['camera_uuid'])
-            return jsonify({}), 400
+            return jsonify({'error' : 'camera not found'}), 400
 
 
         try:

--- a/indi_allsky/version.py
+++ b/indi_allsky/version.py
@@ -1,3 +1,3 @@
-__version__ = "7.3"
+__version__ = "7.4"
 __config_level__ = "20230720.0"
 

--- a/testing/hash_bench.py
+++ b/testing/hash_bench.py
@@ -80,6 +80,20 @@ pw = b'abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789'
 pbkdf2_sha512.hash(pw)
 '''
 
+        setup_6 = '''
+import hashlib
+import hmac
+pw = b'abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789'
+'''
+
+        s6 = '''
+message_hmac = hmac.new(
+    pw,
+    msg=pw,
+    digestmod=hashlib.sha3_512,
+)
+'''
+
 
 
         t_1 = timeit.timeit(stmt=s1, setup=setup_1, number=self.rounds)
@@ -99,6 +113,9 @@ pbkdf2_sha512.hash(pw)
 
         t_5 = timeit.timeit(stmt=s5, setup=setup_5, number=self.rounds)
         logger.info('pbdf2_sha512: %0.3fms', t_5 * 1000 / self.rounds)
+
+        t_6 = timeit.timeit(stmt=s6, setup=setup_6, number=self.rounds)
+        logger.info('hmac hash: %0.3fms', t_6 * 1000 / self.rounds)
 
 
 if __name__ == "__main__":

--- a/testing/requests_form_upload.py
+++ b/testing/requests_form_upload.py
@@ -39,8 +39,9 @@ class FormUploader(object):
     def main(self):
         endpoint_url = 'https://localhost/indi-allsky/sync/v1/image'
         #endpoint_url = 'https://localhost/indi-allsky/sync/v1/video'
-        username = 'foobar'
-        apikey = 'd8389bda9ac722e4619ca6d1dbe41cc8422d8fc26a111784b00617a87fe7889c'
+        username = 'foobar33'
+        apikey = '0000000000000000000000000000000000000000000000000000000000000000'
+        camera_uuid = '00000000-0000-0000-0000-000000000000'
         cert_bypass = True
 
         if cert_bypass:
@@ -69,8 +70,10 @@ class FormUploader(object):
             'calibrated'   : True,
             'stars'        : 0,
             'detections'   : 0,
+            'width'        : 1920,
+            'height'       : 1080,
             'process_elapsed' : 1.2,
-            'camera_uuid'  : '05415368-2ff1-4098-a1a6-5ff75e2b1330',
+            'camera_uuid'  : camera_uuid,
         }
 
 
@@ -79,7 +82,7 @@ class FormUploader(object):
             'createDate' : now.timestamp(),
             'dayDate'    : now.strftime('%Y%m%d'),
             'night'      : True,
-            'camera_uuid': '05415368-2ff1-4098-a1a6-5ff75e2b1330',
+            'camera_uuid': camera_uuid,
         }
 
 
@@ -111,9 +114,13 @@ class FormUploader(object):
 
         time_floor = math.floor(time.time() / 300)
 
+        # data is received as bytes
+        hmac_message = str(time_floor).encode() + json_metadata.encode()
+        #logger.info('Data: %s', str(hmac_message))
+
         message_hmac = hmac.new(
             apikey.encode(),
-            msg=(str(time_floor) + json_metadata).encode(),
+            msg=hmac_message,
             digestmod=hashlib.sha3_512,
         ).hexdigest()
 

--- a/testing/requests_form_upload.py
+++ b/testing/requests_form_upload.py
@@ -87,11 +87,13 @@ class FormUploader(object):
 
 
         get_params = {  # noqa: F841
-            'id' : 2,
+            'id'           : 2,
+            'camera_uuid'  : camera_uuid,
         }
 
         delete_metadata = {  # noqa: F841
-            'id' : 1,
+            'id'           : 1,
+            'camera_uuid'  : camera_uuid,
         }
 
 
@@ -101,6 +103,9 @@ class FormUploader(object):
 
 
         json_metadata = json.dumps(image_metadata)
+        #json_metadata = json.dumps(video_metadata)
+        #json_metadata = json.dumps(get_params)
+        #json_metadata = json.dumps(delete_metadata)
 
 
         files = [  # noqa: F841
@@ -127,6 +132,7 @@ class FormUploader(object):
 
         self.headers = {
             'Authorization' : 'Bearer {0:s}:{1:s}'.format(username, message_hmac),
+            'Connection'    : 'close',  # no need for keep alives
         }
 
 
@@ -134,10 +140,10 @@ class FormUploader(object):
 
         start = time.time()
 
-        #r = requests.get(endpoint_url, params=get_params, headers=self.headers, verify=verify)
+        #r = requests.get(endpoint_url, params=get_params, files=files, headers=self.headers, verify=verify)
         r = requests.post(endpoint_url, files=files, headers=self.headers, verify=verify)
         #r = requests.put(endpoint_url, files=files, headers=self.headers, verify=verify)
-        #r = requests.delete(endpoint_url, files=delete_metadata, headers=self.headers, verify=verify)
+        #r = requests.delete(endpoint_url, files=files, headers=self.headers, verify=verify)
 
         upload_elapsed_s = time.time() - start
         local_file_size = local_image_file_p.stat().st_size


### PR DESCRIPTION
Replaced my initial method of authorization with a more standard method using HMAC signing.

If you use SyncAPI, both local and remote installs need to be updated to continue to function.