### PR TITLE
Add message that lat and lon fields will not update from GPS in the Config

### DIFF
--- a/indi_allsky/flask/templates/config.html
+++ b/indi_allsky/flask/templates/config.html
@@ -2591,7 +2591,7 @@
 
     <hr>
 
-    <div><span class="badge rounded-pill bg-info text-dark">Note</span> Changes to LATITUDE and LONGITUDE will not be immediately reflected in the status area.  A reload is necessary to update the camera metadata.</div>
+    <div><span class="badge rounded-pill bg-info text-dark">Note</span> Changes to LATITUDE and LONGITUDE will not be immediately reflected in the status area.  A reload is necessary to update the camera metadata. <be> The Latitude, Longitude, and Elevation fields will not update with the current location when GPS is enabled. The location can be seen in the status area in the sidebar.</div>
     <div>&nbsp;</div>
 
     <div class="form-group row">


### PR DESCRIPTION
It took me a couple of hours to troubleshoot this, and I hope this text will save others time.

Add message saying the location fields will not update when the GPS is enabled.