### PR TITLE
CRITICAL FIX:  force camera reconfigure on startup

### DIFF
--- a/indi_allsky/capture.py
+++ b/indi_allsky/capture.py
@@ -200,6 +200,7 @@ class CaptureWorker(Process):
         exposure_state = 'unset'
         check_exposure_state = time.time() + 300  # check in 5 minutes
 
+        self.reconfigure_camera = True  # reconfigure on first run
 
         next_forced_transition_time = self._dateCalcs.getNextDayNightTransition().timestamp()
         logger.warning(


### PR DESCRIPTION
This issue was causing moon mode gain to be -1 in certain situations.