### PR TITLE
FUNCTIONAL CHANGE - Save daytime images without timelapse

### DIFF
--- a/indi_allsky/capture.py
+++ b/indi_allsky/capture.py
@@ -331,7 +331,7 @@ class CaptureWorker(Process):
                 if self.night:
                     # always indicate timelapse generation at night
                     self.generate_timelapse_flag = True  # indicate images have been generated for timelapse
-                elif self.config['DAYTIME_CAPTURE'] and self.config['DAYTIME_TIMELAPSE']:
+                elif self.config['DAYTIME_CAPTURE'] and self.config.get('DAYTIME_CAPTURE_SAVE', True):
                     # must be day time
                     self.generate_timelapse_flag = True  # indicate images have been generated for timelapse
 
@@ -764,6 +764,7 @@ class CaptureWorker(Process):
             'nightSunAlt'     : self.config['NIGHT_SUN_ALT_DEG'],
 
             'daytime_capture'       : self.config.get('DAYTIME_CAPTURE', True),
+            'daytime_capture_save'  : self.config.get('DAYTIME_CAPTURE_SAVE', True),
             'daytime_timelapse'     : self.config.get('DAYTIME_TIMELAPSE', True),
 
             's3_prefix'             : s3_prefix,
@@ -1332,6 +1333,10 @@ class CaptureWorker(Process):
             logger.warning('Timelapse creation disabled')
             return
 
+        if not self.config.get('DAYTIME_TIMELAPSE', True):
+            logger.warning('Daytime Timelapse creation disabled')
+            return
+
 
         camera = IndiAllSkyDbCameraTable.query\
             .filter(IndiAllSkyDbCameraTable.id == camera_id)\
@@ -1471,6 +1476,10 @@ class CaptureWorker(Process):
     def _generateDayKeogram(self, timespec, camera_id, task_state=TaskQueueState.QUEUED):
         if not self.config.get('TIMELAPSE_ENABLE', True):
             logger.warning('Timelapse creation disabled')
+            return
+
+        if not self.config.get('DAYTIME_TIMELAPSE', True):
+            logger.warning('Daytime Timelapse creation disabled')
             return
 
 

--- a/indi_allsky/config.py
+++ b/indi_allsky/config.py
@@ -110,6 +110,7 @@ class IndiAllSkyConfigBase(object):
         "TIMELAPSE_ENABLE"         : True,
         "TIMELAPSE_SKIP_FRAMES"    : 4,
         "DAYTIME_CAPTURE"          : True,
+        "DAYTIME_CAPTURE_SAVE"     : True,
         "DAYTIME_TIMELAPSE"        : True,
         "DAYTIME_CONTRAST_ENHANCE" : False,
         "NIGHT_CONTRAST_ENHANCE"   : False,

--- a/indi_allsky/flask/base_views.py
+++ b/indi_allsky/flask/base_views.py
@@ -69,7 +69,7 @@ class BaseView(View):
         self.getSunSetDate()
 
         self.daytime_capture = self.camera.daytime_capture
-        self.daytime_timelapse = self.camera.daytime_timelapse
+        self.daytime_capture_save = self.camera.daytime_capture_save
 
         self.s3_prefix = self.camera.s3_prefix
         self.web_nonlocal_images = self.camera.web_nonlocal_images

--- a/indi_allsky/flask/forms.py
+++ b/indi_allsky/flask/forms.py
@@ -2913,6 +2913,7 @@ class IndiAllskyConfigForm(FlaskForm):
     TIMELAPSE_ENABLE                 = BooleanField('Enable Timelapse Creation')
     TIMELAPSE_SKIP_FRAMES            = IntegerField('Timelapse Skip Frames', validators=[TIMELAPSE_SKIP_FRAMES_validator])
     DAYTIME_CAPTURE                  = BooleanField('Daytime Capture')
+    DAYTIME_CAPTURE_SAVE             = BooleanField('Daytime Save Images')
     DAYTIME_TIMELAPSE                = BooleanField('Daytime Timelapse')
     DAYTIME_CONTRAST_ENHANCE         = BooleanField('Daytime Contrast Enhance')
     NIGHT_CONTRAST_ENHANCE           = BooleanField('Night time Contrast Enhance')

--- a/indi_allsky/flask/models.py
+++ b/indi_allsky/flask/models.py
@@ -77,6 +77,7 @@ class IndiAllSkyDbCameraTable(db.Model):
     lensImageCircle = db.Column(db.Integer, nullable=True)  # pixels
 
     daytime_capture = db.Column(db.Boolean, server_default=expression.true(), nullable=False)
+    daytime_capture_save = db.Column(db.Boolean, server_default=expression.true(), nullable=False)
     daytime_timelapse = db.Column(db.Boolean, server_default=expression.true(), nullable=False)
 
     s3_prefix = db.Column(db.String(length=255), nullable=True)

--- a/indi_allsky/flask/templates/config.html
+++ b/indi_allsky/flask/templates/config.html
@@ -682,7 +682,20 @@ var camera_id = {{ camera_id }};
         </div>
         <div class="col-sm-8">
             <div>Enable daytime image capture</div>
-            <div><span class="badge rounded-pill bg-info text-dark">Note</span> If Daytime Timelapse is disabled, no images will be saved</div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <div class="col-sm-2">
+            {{ form_config.DAYTIME_CAPTURE_SAVE.label }}
+        </div>
+        <div class="col-sm-2">
+            <div class="form-switch">
+                {{ form_config.DAYTIME_CAPTURE_SAVE(class='form-check-input') }}
+                <div id="DAYTIME_CAPTURE_SAVE-error" class="invalid-feedback text-danger" style="display: none;"></div>
+            </div>
+        </div>
+        <div class="col-sm-8">
         </div>
     </div>
 
@@ -5730,6 +5743,7 @@ const checkbox_field_names = [
     'DETECT_DRAW',
     'TIMELAPSE_ENABLE',
     'DAYTIME_CAPTURE',
+    'DAYTIME_CAPTURE_SAVE',
     'DAYTIME_TIMELAPSE',
     'DAYTIME_CONTRAST_ENHANCE',
     'NIGHT_CONTRAST_ENHANCE',
@@ -5896,9 +5910,42 @@ $('#form_config').on('submit', function() {
 });
 
 
+// Global timelapse
+$('#TIMELAPSE_ENABLE').on('change', function() {
+    if ($('#TIMELAPSE_ENABLE').prop('checked')) {
+        $('#DAYTIME_TIMELAPSE').prop('checked', true);
+        $('#DAYTIME_TIMELAPSE').removeAttr('readonly');
+        $('#DAYTIME_TIMELAPSE').removeAttr('disabled');
+    } else {
+        $('#DAYTIME_TIMELAPSE').prop('checked', false);
+        $('#DAYTIME_TIMELAPSE').attr('readonly', true);
+        $('#DAYTIME_TIMELAPSE').attr('disabled', true);
+    }
+});
+
 // Daytime timelapse
 $('#DAYTIME_CAPTURE').on('change', function() {
     if ($('#DAYTIME_CAPTURE').prop('checked')) {
+        $('#DAYTIME_CAPTURE_SAVE').prop('checked', true);
+        $('#DAYTIME_CAPTURE_SAVE').removeAttr('readonly');
+        $('#DAYTIME_CAPTURE_SAVE').removeAttr('disabled');
+
+        $('#DAYTIME_TIMELAPSE').prop('checked', true);
+        $('#DAYTIME_TIMELAPSE').removeAttr('readonly');
+        $('#DAYTIME_TIMELAPSE').removeAttr('disabled');
+    } else {
+        $('#DAYTIME_CAPTURE_SAVE').prop('checked', false);
+        $('#DAYTIME_CAPTURE_SAVE').attr('readonly', true);
+        $('#DAYTIME_CAPTURE_SAVE').attr('disabled', true);
+
+        $('#DAYTIME_TIMELAPSE').prop('checked', false);
+        $('#DAYTIME_TIMELAPSE').attr('readonly', true);
+        $('#DAYTIME_TIMELAPSE').attr('disabled', true);
+    }
+});
+
+$('#DAYTIME_CAPTURE_SAVE').on('change', function() {
+    if ($('#DAYTIME_CAPTURE_SAVE').prop('checked')) {
         $('#DAYTIME_TIMELAPSE').prop('checked', true);
         $('#DAYTIME_TIMELAPSE').removeAttr('readonly');
         $('#DAYTIME_TIMELAPSE').removeAttr('disabled');
@@ -5987,54 +6034,50 @@ $('#CARDINAL_DIRS__ENABLE').on('change', function() {
 
 
 $( document ).ready(function() {
+    // Global timelapse
+    if (!$('#TIMELAPSE_ENABLE').prop('checked')) {
+        $('#DAYTIME_TIMELAPSE').attr('readonly', true);
+        $('#DAYTIME_TIMELAPSE').attr('disabled', true);
+    }
+
     // Daytime timelapse
-    if ($('#DAYTIME_CAPTURE').prop('checked')) {
-        $('#DAYTIME_TIMELAPSE').removeAttr('readonly');
-        $('#DAYTIME_TIMELAPSE').removeAttr('disabled');
-    } else {
+    if (!$('#DAYTIME_CAPTURE').prop('checked')) {
+        $('#DAYTIME_CAPTURE_SAVE').attr('readonly', true);
+        $('#DAYTIME_CAPTURE_SAVE').attr('disabled', true);
+
+        $('#DAYTIME_TIMELAPSE').attr('readonly', true);
+        $('#DAYTIME_TIMELAPSE').attr('disabled', true);
+    }
+
+    if (!$('#DAYTIME_CAPTURE_SAVE').prop('checked')) {
         $('#DAYTIME_TIMELAPSE').attr('readonly', true);
         $('#DAYTIME_TIMELAPSE').attr('disabled', true);
     }
 
     // FOCUS_MODE
-    if ($('#FOCUS_MODE').prop('checked')) {
-        $('#FOCUS_DELAY').removeAttr('readonly');
-        $('#FOCUS_DELAY').removeAttr('disabled');
-    } else {
+    if (!$('#FOCUS_MODE').prop('checked')) {
         $('#FOCUS_DELAY').attr('readonly', true);
         $('#FOCUS_DELAY').attr('disabled', true);
     }
 
     // CCD_COOLING
-    if ($('#CCD_COOLING').prop('checked')) {
-        $('#CCD_TEMP').removeAttr('readonly');
-        $('#CCD_TEMP').removeAttr('disabled');
-    } else {
+    if (!$('#CCD_COOLING').prop('checked')) {
         $('#CCD_TEMP').attr('readonly', true);
         $('#CCD_TEMP').attr('disabled', true);
     }
 
     // libcamera AWB
-    if ($('#LIBCAMERA__AWB_ENABLE').prop('checked')) {
-        $('#LIBCAMERA__AWB').removeAttr('disabled');
-    } else {
+    if (!$('#LIBCAMERA__AWB_ENABLE').prop('checked')) {
         $('#LIBCAMERA__AWB').attr('disabled', true);
     }
 
     // libcamera AWB DAY
-    if ($('#LIBCAMERA__AWB_ENABLE_DAY').prop('checked')) {
-        $('#LIBCAMERA__AWB_DAY').removeAttr('disabled');
-    } else {
+    if (!$('#LIBCAMERA__AWB_ENABLE_DAY').prop('checked')) {
         $('#LIBCAMERA__AWB_DAY').attr('disabled', true);
     }
 
     // startrails moonmode
-    if ($('#STARTRAILS_MOONMODE_THOLD').prop('checked')) {
-        $('#STARTRAILS_MOON_ALT_THOLD').attr('disabled', true);
-        $('#STARTRAILS_MOON_ALT_THOLD').attr('readonly', true);
-        $('#STARTRAILS_MOON_PHASE_THOLD').attr('disabled', true);
-        $('#STARTRAILS_MOON_PHASE_THOLD').attr('readonly', true);
-    } else {
+    if (!$('#STARTRAILS_MOONMODE_THOLD').prop('checked')) {
         $('#STARTRAILS_MOON_ALT_THOLD').removeAttr('disabled');
         $('#STARTRAILS_MOON_ALT_THOLD').removeAttr('readonly');
         $('#STARTRAILS_MOON_PHASE_THOLD').removeAttr('disabled');
@@ -6042,19 +6085,12 @@ $( document ).ready(function() {
     }
 
     // nonlocal assets
-    if ($('#WEB_NONLOCAL_IMAGES').prop('checked')) {
-        $('#WEB_LOCAL_IMAGES_ADMIN').removeAttr('disabled');
-    } else {
-        $('#WEB_LOCAL_IMAGES_ADMIN').prop('checked', false);
+    if (!$('#WEB_NONLOCAL_IMAGES').prop('checked')) {
         $('#WEB_LOCAL_IMAGES_ADMIN').attr('disabled', true);
     }
 
     // cardinal dirs
-    if ($('#CARDINAL_DIRS__ENABLE').prop('checked')) {
-        $('#FISH2PANO__ENABLE_CARDINAL_DIRS').removeAttr('disabled');
-        $('#FISH2PANO__ENABLE_CARDINAL_DIRS').prop('checked', true);
-    } else {
-        $('#FISH2PANO__ENABLE_CARDINAL_DIRS').prop('checked', false);
+    if (!$('#CARDINAL_DIRS__ENABLE').prop('checked')) {
         $('#FISH2PANO__ENABLE_CARDINAL_DIRS').attr('disabled', true);
     }
 });

--- a/indi_allsky/image.py
+++ b/indi_allsky/image.py
@@ -1335,9 +1335,9 @@ class ImageWorker(Process):
             return None, None
 
 
-        ### Do not write daytime image files if daytime timelapse is disabled
-        if not self.night_v.value and not self.config['DAYTIME_TIMELAPSE']:
-            logger.info('Daytime timelapse is disabled')
+        ### Do not write daytime image files if daytime capture is disabled
+        if not self.night_v.value and self.config['DAYTIME_CAPTURE'] and not self.config.get('DAYTIME_CAPTURE_SAVE', True):
+            logger.info('Daytime capture is disabled')
             tmpfile_name.unlink()
             return latest_file, None
 
@@ -1488,8 +1488,8 @@ class ImageWorker(Process):
             return
 
 
-        ### Do not write daytime image files if daytime timelapse is disabled
-        if not self.night_v.value and not self.config['DAYTIME_TIMELAPSE']:
+        ### Do not write daytime image files if daytime capture is disabled
+        if not self.night_v.value and self.config['DAYTIME_CAPTURE'] and not self.config.get('DAYTIME_CAPTURE_SAVE', True):
             tmpfile_name.unlink()
             return
 

--- a/indi_allsky/version.py
+++ b/indi_allsky/version.py
@@ -1,2 +1,2 @@
 __version__ = "indi_v2024.05.1"
-__config_level__ = "20240806.0"
+__config_level__ = "20240824.0"


### PR DESCRIPTION
If you have Daytime timelapse disabled, this implied that images were not saved.  Now there is an explicit setting "Daytime Capture Save" that will have to be disabled to prevent images from being saved.