### PR TITLE
fix(docker): properly pass control down to processes

### DIFF
--- a/docker/start_gunicorn.sh
+++ b/docker/start_gunicorn.sh
@@ -134,7 +134,7 @@ fi
 
 
 # start the program
-gunicorn \
+exec gunicorn \
     --bind 0.0.0.0:8000 \
     --worker-class gthread \
     --threads 8 \

--- a/docker/start_indi_allsky.sh
+++ b/docker/start_indi_allsky.sh
@@ -148,13 +148,13 @@ fi
 if [ "${INDIALLSKY_DARK_CAPTURE_ENABLE:-false}" == "true" ]; then
     # take dark frames
     echo "*** Starting dark frame capture ***"
-    ./darks.py \
+    exec ./darks.py \
         --bitmax "${INDIALLSKY_DARK_CAPTURE_BITMAX:-16}" \
         "${INDIALLSKY_DARK_CAPTURE_DAYTIME:-}" \
         "${INDIALLSKY_DARK_CAPTURE_MODE:-average}"
 else
     # normal capture
-    ./allsky.py \
+    exec ./allsky.py \
         --log stderr \
         run
 fi

--- a/docker/start_indiserver.sh
+++ b/docker/start_indiserver.sh
@@ -16,7 +16,7 @@ fi
 
 
 if [ -n "${INDIALLSKY_INDI_GPS_DRIVER:-}" ]; then
-    "$INDISERVER" \
+    exec "$INDISERVER" \
         -v \
         -p 7624 \
         indi_simulator_telescope \
@@ -25,7 +25,7 @@ if [ -n "${INDIALLSKY_INDI_GPS_DRIVER:-}" ]; then
 
 else
     echo "No GPS driver configured"
-    "$INDISERVER" \
+    exec "$INDISERVER" \
         -v \
         -p 7624 \
         indi_simulator_telescope \


### PR DESCRIPTION
Without execing the process, the process will not be able to receive signals such as SIGINT from the parent process and instead the shell scripts receive the signal. This is important for the gunicorn/capture/indiserver processes to be able to receive signals to terminate gracefully, otherwise the shell script will exit leaving the gunicorn/capture/indiserver process, then eventually the timeout will be reached and the container will be killed forcefully.