### PR TITLE
flask: allow gunicorn.error logger to be configured with GUNICORN_ERROR_LOG_HANDLER

### DIFF
--- a/indi_allsky/flask/__init__.py
+++ b/indi_allsky/flask/__init__.py
@@ -59,7 +59,7 @@ dictConfig({
         },
         'gunicorn.error' : {
             'level'      : 'INFO',
-            'handlers'   : ['syslog_local7'],
+            'handlers'   : [os.getenv('GUNICORN_ERROR_LOG_HANDLER', 'syslog_local7')],
             'propagate'  : False,
         },
         'indi_allsky' : {


### PR DESCRIPTION
In Docker, since syslog doesn't get piped to the stdout/stderr, error lines are unseen in the logs. This allows docker users to set `GUNICORN_ERROR_LOG_HANDLER` to `wgsi` to obtain logs in the standard output/error.