### PR TITLE
docker: gunicorn: base on python:3.11 and shave 4gb off the image

### DIFF
--- a/docker/Dockerfile.gunicorn
+++ b/docker/Dockerfile.gunicorn
@@ -1,13 +1,78 @@
 
 # docker- prefix due to files in docker/ folder
-FROM docker-indi.allsky.base
+FROM python:3.11-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 USER root
-RUN apt-get update
-RUN apt-get -y upgrade
 
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get -y install \
+      --no-install-recommends \
+      --no-install-suggests \
+      iputils-ping \
+      iproute2 \
+      bind9-host \
+      locales \
+      tzdata \
+      procps \
+      netcat-traditional \
+      sudo \
+      git \
+      jq \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN groupadd --gid 10001 allsky \
+    && useradd --create-home --no-user-group --uid 10001 --gid allsky --home-dir /home/allsky --shell /bin/bash allsky
+
+USER allsky
+WORKDIR /home/allsky
+
+COPY requirements/requirements_latest.txt /home/allsky
+COPY requirements/requirements_optional.txt /home/allsky
+COPY requirements/requirements_gpio.txt /home/allsky
+
+USER root
+RUN apt-get update \
+    && apt-get -y install \
+        --no-install-recommends \
+        --no-install-suggests \
+        clang \
+        cmake \
+        build-essential \
+        pkg-config \
+        libdbus-1-dev \
+        libdbus-1-3 \
+        libglib2.0-dev\
+        libglib2.0-0 \
+        libcfitsio-dev \
+        libnova-dev \
+        python3-dev \
+        dbus-daemon \
+        swig \
+        libindi-dev \
+        libindiclient1 \
+    && export CC=clang \
+    && export CXX=clang++ \
+    && pip install --no-cache-dir -r requirements_latest.txt -r requirements_optional.txt -r requirements_gpio.txt \
+    && pip install --no-cache-dir "git+https://github.com/indilib/pyindi-client.git@674706f#egg=pyindi-client" \
+    && apt-get remove --purge -y \
+        clang \
+        cmake \
+        build-essential \
+        pkg-config \
+        libdbus-1-dev \
+        libglib2.0-dev \
+        libcfitsio-dev \
+        libnova-dev \
+        python3-dev \
+        dbus-daemon \
+        swig \
+        libindi-dev \
+    && apt-get autoremove --purge -y \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && chown -R allsky:allsky /home/allsky
 
 # redirect /dev/log to /dev/null
 RUN ln -s /dev/null /dev/log
@@ -29,6 +94,8 @@ RUN mkdir /home/allsky/indi-allsky
 COPY . /home/allsky/indi-allsky
 RUN chown -R allsky:allsky /home/allsky/indi-allsky
 
+RUN mkdir -m 750 /etc/indi-allsky
+RUN chown -R allsky:allsky /etc/indi-allsky
 
 USER allsky
 WORKDIR /home/allsky

--- a/docker/Dockerfile.gunicorn
+++ b/docker/Dockerfile.gunicorn
@@ -46,17 +46,10 @@ RUN apt-get update \
         libdbus-1-3 \
         libglib2.0-dev\
         libglib2.0-0 \
-        libcfitsio-dev \
-        libnova-dev \
-        python3-dev \
         dbus-daemon \
-        swig \
-        libindi-dev \
-        libindiclient1 \
     && export CC=clang \
     && export CXX=clang++ \
     && pip install --no-cache-dir -r requirements_latest.txt -r requirements_optional.txt -r requirements_gpio.txt \
-    && pip install --no-cache-dir "git+https://github.com/indilib/pyindi-client.git@674706f#egg=pyindi-client" \
     && apt-get remove --purge -y \
         clang \
         cmake \
@@ -64,12 +57,8 @@ RUN apt-get update \
         pkg-config \
         libdbus-1-dev \
         libglib2.0-dev \
-        libcfitsio-dev \
-        libnova-dev \
         python3-dev \
         dbus-daemon \
-        swig \
-        libindi-dev \
     && apt-get autoremove --purge -y \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && chown -R allsky:allsky /home/allsky

--- a/docker/Dockerfile.gunicorn
+++ b/docker/Dockerfile.gunicorn
@@ -73,15 +73,13 @@ RUN chown -R allsky:allsky /var/lib/indi-allsky
 VOLUME /var/lib/indi-allsky
 
 
-COPY docker/start_gunicorn.sh /home/allsky
-RUN chown allsky:allsky /home/allsky/start_gunicorn.sh
+COPY --chown=allsky:allsky docker/start_gunicorn.sh /home/allsky
 RUN chmod 755 /home/allsky/start_gunicorn.sh
 
 
 # installs latest code
 RUN mkdir /home/allsky/indi-allsky
-COPY . /home/allsky/indi-allsky
-RUN chown -R allsky:allsky /home/allsky/indi-allsky
+COPY --chown=allsky:allsky . /home/allsky/indi-allsky
 
 RUN mkdir -m 750 /etc/indi-allsky
 RUN chown -R allsky:allsky /etc/indi-allsky

--- a/docker/Dockerfile.gunicorn
+++ b/docker/Dockerfile.gunicorn
@@ -29,9 +29,7 @@ RUN groupadd --gid 10001 allsky \
 USER allsky
 WORKDIR /home/allsky
 
-COPY requirements/requirements_latest.txt /home/allsky
-COPY requirements/requirements_optional.txt /home/allsky
-COPY requirements/requirements_gpio.txt /home/allsky
+COPY requirements/requirements_latest_web.txt /home/allsky
 
 USER root
 RUN apt-get update \
@@ -49,7 +47,7 @@ RUN apt-get update \
         dbus-daemon \
     && export CC=clang \
     && export CXX=clang++ \
-    && pip install --no-cache-dir -r requirements_latest.txt -r requirements_optional.txt -r requirements_gpio.txt \
+    && pip install --no-cache-dir -r requirements_latest_web.txt \
     && apt-get remove --purge -y \
         clang \
         cmake \

--- a/docker/Dockerfile.gunicorn
+++ b/docker/Dockerfile.gunicorn
@@ -30,6 +30,7 @@ USER allsky
 WORKDIR /home/allsky
 
 COPY requirements/requirements_latest_web.txt /home/allsky
+COPY requirements/requirements_optional.txt /home/allsky
 
 USER root
 RUN apt-get update \
@@ -47,7 +48,7 @@ RUN apt-get update \
         dbus-daemon \
     && export CC=clang \
     && export CXX=clang++ \
-    && pip install --no-cache-dir -r requirements_latest_web.txt \
+    && pip install --no-cache-dir -r requirements_latest_web.txt -r requirements_optional.txt \
     && apt-get remove --purge -y \
         clang \
         cmake \

--- a/docker/start_gunicorn.sh
+++ b/docker/start_gunicorn.sh
@@ -4,10 +4,6 @@
 set -o errexit
 set -o nounset
 
-PATH=/usr/bin:/bin
-export PATH
-
-
 ALLSKY_DIRECTORY="/home/allsky/indi-allsky"
 ALLSKY_ETC="/etc/indi-allsky"
 DB_FOLDER="/var/lib/indi-allsky"
@@ -28,10 +24,6 @@ else
     SQLALCHEMY_DATABASE_URI="mysql+mysqlconnector://${MARIADB_USER}:${MARIADB_PASSWORD}@${INDIALLSKY_MARIADB_HOST}:${INDIALLSKY_MARIADB_PORT}/${MARIADB_DATABASE}?charset=${INDIALLSKY_MARIADB_CHARSET}&collation=${INDIALLSKY_MARIADB_COLLATION}"
     #SQLALCHEMY_DATABASE_URI="mysql+pymysql://${MARIADB_USER}:${MARIADB_PASSWORD}@${INDIALLSKY_MARIADB_HOST}:${INDIALLSKY_MARIADB_PORT}/${MARIADB_DATABASE}?charset=${INDIALLSKY_MARIADB_CHARSET}"
 fi
-
-
-# shellcheck disable=SC1091
-source /home/allsky/venv/bin/activate
 
 
 TMP_FLASK=$(mktemp --suffix=.json)


### PR DESCRIPTION
This patch reduces the final size of the gunicorn image from a whopping 5.4GB down to 1.4GB. The Python dependencies alone take up 1.1GB (`/usr/local/lib/python3.11/site-packages`).