### PR TITLE
Support for Ambient Weather devices

### DIFF
--- a/indi_allsky/config.py
+++ b/indi_allsky/config.py
@@ -214,11 +214,10 @@ class IndiAllSkyConfigBase(object):
             "LABEL"         : True,
             "HOUR_LINES"    : True,
             "DAY_COLOR"     : [150, 150, 150],
-            "DUSK_COLOR"    : [200, 100, 60],
             "NIGHT_COLOR"   : [30, 30, 30],
             "HOUR_COLOR"    : [100, 15, 15],
             "BORDER_COLOR"  : [1, 1, 1],
-            "NOW_COLOR"     : [120, 120, 200],
+            "NOW_COLOR"     : [200, 150, 15],
             "FONT_COLOR"    : [150, 150, 150],
             "OPACITY"       : 100,
             "PIL_FONT_SIZE" : 20,
@@ -531,6 +530,12 @@ class IndiAllSkyConfigBase(object):
             "WUNDERGROUND_APIKEY_E"  : "",
             "ASTROSPHERIC_APIKEY"    : "",
             "ASTROSPHERIC_APIKEY_E"  : "",
+            "AMBIENTWEATHER_APIKEY"          : "",
+            "AMBIENTWEATHER_APIKEY_E"        : "",
+            "AMBIENTWEATHER_APPLICATIONKEY"  : "",
+            "AMBIENTWEATHER_APPLICATIONKEY_E": "",
+            "AMBIENTWEATHER_MACADDRESS"      : "",
+            "AMBIENTWEATHER_MACADDRESS_E"    : "",
             "MQTT_TRANSPORT"         : "tcp",  # tcp or websockets
             "MQTT_HOST"              : "localhost",
             "MQTT_PORT"              : 8883,  # 1883 = mqtt, 8883 = TLS
@@ -759,6 +764,30 @@ class IndiAllSkyConfig(IndiAllSkyConfigBase):
                 temp_sensor__astrospheric_apikey = config.get('TEMP_SENSOR', {}).get('ASTROSPHERIC_APIKEY', '')
 
 
+            temp_sensor__ambientweather_apikey_e = config.get('TEMP_SENSOR', {}).get('AMBIENTWEATHER_APIKEY_E', '')
+            if temp_sensor__ambientweather_apikey_e:
+                # not catching InvalidToken
+                temp_sensor__ambientweather_apikey = f_key.decrypt(temp_sensor__ambientweather_apikey_e.encode()).decode()
+            else:
+                temp_sensor__ambientweather_apikey = config.get('TEMP_SENSOR', {}).get('AMBIENTWEATHER_APIKEY', '')
+
+
+            temp_sensor__ambientweather_applicationkey_e = config.get('TEMP_SENSOR', {}).get('AMBIENTWEATHER_APPLICATIONKEY_E', '')
+            if temp_sensor__ambientweather_applicationkey_e:
+                # not catching InvalidToken
+                temp_sensor__ambientweather_applicationkey = f_key.decrypt(temp_sensor__ambientweather_applicationkey_e.encode()).decode()
+            else:
+                temp_sensor__ambientweather_applicationkey = config.get('TEMP_SENSOR', {}).get('AMBIENTWEATHER_APPLICATIONKEY', '')
+
+
+            temp_sensor__ambientweather_macaddress_e = config.get('TEMP_SENSOR', {}).get('AMBIENTWEATHER_MACADDRESS_E', '')
+            if temp_sensor__ambientweather_macaddress_e:
+                # not catching InvalidToken
+                temp_sensor__ambientweather_macaddress = f_key.decrypt(temp_sensor__ambientweather_macaddress_e.encode()).decode()
+            else:
+                temp_sensor__ambientweather_macaddress = config.get('TEMP_SENSOR', {}).get('AMBIENTWEATHER_MACADDRESS', '')
+
+
             temp_sensor__mqtt_password_e = config.get('TEMP_SENSOR', {}).get('MQTT_PASSWORD_E', '')
             if temp_sensor__mqtt_password_e:
                 # not catching InvalidToken
@@ -784,6 +813,9 @@ class IndiAllSkyConfig(IndiAllSkyConfigBase):
             temp_sensor__openweathermap_apikey = config.get('TEMP_SENSOR', {}).get('OPENWEATHERMAP_APIKEY', '')
             temp_sensor__wunderground_apikey = config.get('TEMP_SENSOR', {}).get('WUNDERGROUND_APIKEY', '')
             temp_sensor__astrospheric_apikey = config.get('TEMP_SENSOR', {}).get('ASTROSPHERIC_APIKEY', '')
+            temp_sensor__ambientweather_apikey = config.get('TEMP_SENSOR', {}).get('AMBIENTWEATHER_APIKEY', '')
+            temp_sensor__ambientweather_applicationkey = config.get('TEMP_SENSOR', {}).get('AMBIENTWEATHER_APPLICATIONKEY', '')
+            temp_sensor__ambientweather_macaddress = config.get('TEMP_SENSOR', {}).get('AMBIENTWEATHER_MACADDRESS', '')
             temp_sensor__mqtt_password = config.get('TEMP_SENSOR', {}).get('MQTT_PASSWORD', '')
             adsb__password = config.get('ADSB', {}).get('PASSWORD', '')
 
@@ -804,6 +836,12 @@ class IndiAllSkyConfig(IndiAllSkyConfigBase):
         config['TEMP_SENSOR']['WUNDERGROUND_APIKEY_E'] = ''
         config['TEMP_SENSOR']['ASTROSPHERIC_APIKEY'] = temp_sensor__astrospheric_apikey
         config['TEMP_SENSOR']['ASTROSPHERIC_APIKEY_E'] = ''
+        config['TEMP_SENSOR']['AMBIENTWEATHER_APIKEY'] = temp_sensor__ambientweather_apikey
+        config['TEMP_SENSOR']['AMBIENTWEATHER_APIKEY_E'] = ''
+        config['TEMP_SENSOR']['AMBIENTWEATHER_APPLICATIONKEY'] = temp_sensor__ambientweather_applicationkey
+        config['TEMP_SENSOR']['AMBIENTWEATHER_APPLICATIONKEY_E'] = ''
+        config['TEMP_SENSOR']['AMBIENTWEATHER_MACADDRESS'] = temp_sensor__ambientweather_macaddress
+        config['TEMP_SENSOR']['AMBIENTWEATHER_MACADDRESS_E'] = ''
         config['TEMP_SENSOR']['MQTT_PASSWORD'] = temp_sensor__mqtt_password
         config['TEMP_SENSOR']['MQTT_PASSWORD_E'] = ''
         config['ADSB']['PASSWORD'] = adsb__password
@@ -907,6 +945,33 @@ class IndiAllSkyConfig(IndiAllSkyConfigBase):
                 temp_sensor__astrospheric_apikey = ''
 
 
+            temp_sensor__ambientweather_apikey = str(config['TEMP_SENSOR']['AMBIENTWEATHER_APIKEY'])
+            if temp_sensor__ambientweather_apikey:
+                temp_sensor__ambientweather_apikey_e = f_key.encrypt(temp_sensor__ambientweather_apikey.encode()).decode()
+                temp_sensor__ambientweather_apikey = ''
+            else:
+                temp_sensor__ambientweather_apikey_e = ''
+                temp_sensor__ambientweather_apikey = ''
+
+
+            temp_sensor__ambientweather_applicationkey = str(config['TEMP_SENSOR']['AMBIENTWEATHER_APPLICATIONKEY'])
+            if temp_sensor__ambientweather_applicationkey:
+                temp_sensor__ambientweather_applicationkey_e = f_key.encrypt(temp_sensor__ambientweather_applicationkey.encode()).decode()
+                temp_sensor__ambientweather_applicationkey = ''
+            else:
+                temp_sensor__ambientweather_applicationkey_e = ''
+                temp_sensor__ambientweather_applicationkey = ''
+
+
+            temp_sensor__ambientweather_macaddress = str(config['TEMP_SENSOR']['AMBIENTWEATHER_MACADDRESS'])
+            if temp_sensor__ambientweather_macaddress:
+                temp_sensor__ambientweather_macaddress_e = f_key.encrypt(temp_sensor__ambientweather_macaddress.encode()).decode()
+                temp_sensor__ambientweather_macaddress = ''
+            else:
+                temp_sensor__ambientweather_macaddress_e = ''
+                temp_sensor__ambientweather_macaddress = ''
+
+
             temp_sensor__mqtt_password = str(config['TEMP_SENSOR']['MQTT_PASSWORD'])
             if temp_sensor__mqtt_password:
                 temp_sensor__mqtt_password_e = f_key.encrypt(temp_sensor__mqtt_password.encode()).decode()
@@ -944,6 +1009,12 @@ class IndiAllSkyConfig(IndiAllSkyConfigBase):
             temp_sensor__wunderground_apikey_e = ''
             temp_sensor__astrospheric_apikey = str(config['TEMP_SENSOR']['ASTROSPHERIC_APIKEY'])
             temp_sensor__astrospheric_apikey_e = ''
+            temp_sensor__ambientweather_apikey = str(config['TEMP_SENSOR']['AMBIENTWEATHER_APIKEY'])
+            temp_sensor__ambientweather_apikey_e = ''
+            temp_sensor__ambientweather_applicationkey = str(config['TEMP_SENSOR']['AMBIENTWEATHER_APPLICATIONKEY'])
+            temp_sensor__ambientweather_applicationkey_e = ''
+            temp_sensor__ambientweather_macaddress = str(config['TEMP_SENSOR']['AMBIENTWEATHER_MACADDRESS'])
+            temp_sensor__ambientweather_macaddress_e = ''
             temp_sensor__mqtt_password = str(config['TEMP_SENSOR']['MQTT_PASSWORD'])
             temp_sensor__mqtt_password_e = ''
             adsb__password = str(config['ADSB']['PASSWORD'])

--- a/indi_allsky/devices/sensors/__init__.py
+++ b/indi_allsky/devices/sensors/__init__.py
@@ -45,6 +45,7 @@ from .tempSensorLm35_Ads1x15 import TempSensorLm35_Ads1115_I2C as cpads_temp_sen
 from .tempApiOpenWeatherMap import TempApiOpenWeatherMap as temp_api_openweathermap
 from .tempApiWeatherUnderground import TempApiWeatherUnderground as temp_api_weatherunderground
 from .tempApiAstrospheric import TempApiAstrospheric as temp_api_astrospheric
+from .tempApiAmbientWeather import TempApiAmbientWeather as temp_api_ambientweather
 
 from .tempSensorDs18x20 import TempSensorDs18x20 as kernel_temp_sensor_ds18x20_w1
 
@@ -85,4 +86,5 @@ __all__ = (
     'temp_api_openweathermap',
     'temp_api_weatherunderground',
     'temp_api_astrospheric',
+    'temp_api_ambientweather',
 )

--- a/indi_allsky/devices/sensors/sensorBase.py
+++ b/indi_allsky/devices/sensors/sensorBase.py
@@ -81,6 +81,12 @@ class SensorBase(object):
         return k - 273.15
 
 
+    def f2k(self, f):
+        # fahrenheit to kelvin
+        return (f - 32) * 5 / 9 + 273.15
+
+
+
     def hPa2psi(self, hpa):
         # hectopascals to pounds/sq in
         return hpa * 0.014503768077999999
@@ -94,6 +100,26 @@ class SensorBase(object):
     def hPa2mmHg(self, hpa):
         # hectopascals to millimeters mercury
         return hpa * 0.7500637554192107
+
+
+    def inHg2mb(self, inHg):
+        # inches mercurty to millibars mercury
+        return inHg * 0.029529983071445
+
+
+    def inHg2psi(self, inHg):
+        # inches mercurty to pounds/sq in
+        return inHg * 14.5037744
+
+
+    def inHg2hpa(self, inHg):
+        # inches mercurty to hectpascals
+        return inHg * 33.86389
+
+
+    def inHg2mmHg(self, inHg):
+        # inches mercury to millimeters mercury
+        return inHg * 25.400
 
 
     def mps2kmph(self, mps):
@@ -114,6 +140,21 @@ class SensorBase(object):
     def mps2knots(self, mps):
         # meters/sec to knots
         return mps * 1.9438445
+
+
+    def mph2knots(self, mph):
+        # miles/hour to knots
+        return mph * 0.8689762419
+
+
+    def mph2kph(self, mph):
+        # miles/hour to kilometers/hour
+        return mph * 1.609344
+
+
+    def mph2mps(self, mph):
+        # miles/hour to meters/second
+        return mph * 0.44704
 
 
     def mm2in(self, mm):

--- a/indi_allsky/devices/sensors/tempApiAmbientWeather.py
+++ b/indi_allsky/devices/sensors/tempApiAmbientWeather.py
@@ -1,0 +1,303 @@
+import socket
+import time
+import json
+import ssl
+import requests
+import logging
+
+from .sensorBase import SensorBase
+from ... import constants
+from ..exceptions import SensorReadException
+
+
+logger = logging.getLogger('indi_allsky')
+
+
+### Example
+###
+
+
+class TempApiAmbientWeather(SensorBase):
+
+    ### https://ambientweather.docs.apiary.io/#
+    ###
+    ### [ {
+    ###   "dateutc": 1515436500000,
+    ###   "date": "2018-01-08T18:35:00.000Z",
+    ###   "winddir": 58,
+    ###   "windspeedmph": 0.9,
+    ###   "windgustmph": 4,
+    ###   "maxdailygust": 5,
+    ###   "windgustdir": 61,
+    ###   "winddir_avg2m": 63,
+    ###   "windspdmph_avg2m": 0.9,
+    ###   "winddir_avg10m": 58,
+    ###   "windspdmph_avg10m": 0.9,
+    ###   "tempf": 66.9,
+    ###   "humidity": 30,
+    ###   "baromrelin": 30.05,
+    ###   "baromabsin": 28.71,
+    ###   "tempinf": 74.1,
+    ###   "humidityin": 30,
+    ###   "hourlyrainin": 0,
+    ###   "dailyrainin": 0,
+    ###   "monthlyrainin": 0,
+    ###   "yearlyrainin": 0,
+    ###   "feelsLike": 66.9,
+    ###   "dewPoint": 34.45380707462477
+    ### }, ... ]
+
+    URL_TEMPLATE = 'https://rt.ambientweather.net/v1/devices/{macaddress:s}?apiKey={apikey:s}&applicationKey={applicationkey:s}&limit=288'
+
+
+    METADATA = {
+        'name' : 'Ambient Weather API',
+        'description' : 'Ambient Weather Device API Sensor',
+        'count' : 9,
+        'labels' : (
+            'Temperature',
+            'Feels Like Temperature',
+            'Relative Humidity',
+            'Pressure',
+            'Wind Speed',
+            'Wind Gusts',
+            '1 Hour Rain',
+            'Solar Radiation',
+            'UV',
+        ),
+        'types' : (
+            constants.SENSOR_TEMPERATURE,
+            constants.SENSOR_TEMPERATURE,
+            constants.SENSOR_RELATIVE_HUMIDITY,
+            constants.SENSOR_ATMOSPHERIC_PRESSURE,
+            constants.SENSOR_WIND_SPEED,
+            constants.SENSOR_WIND_SPEED,
+            constants.SENSOR_PRECIPITATION,
+            constants.SENSOR_MISC,
+            constants.SENSOR_MISC,
+        ),
+    }
+
+
+    def __init__(self, *args, **kwargs):
+        super(TempApiAmbientWeather, self).__init__(*args, **kwargs)
+
+        stationId = kwargs['pin_1_name']
+
+        logger.warning('Initializing [%s] Ambient Weather API Sensor', self.name)
+
+        apikey = self.config.get('TEMP_SENSOR', {}).get('AMBIENTWEATHER_APIKEY', '')
+        applicationkey = self.config.get('TEMP_SENSOR', {}).get('AMBIENTWEATHER_APPLICATIONKEY', '')
+        macaddress = self.config.get('TEMP_SENSOR', {}).get('AMBIENTWEATHER_MACADDRESS', '')#.replace(':', '%3a')
+
+        if not apikey:
+            raise Exception('Ambient Weather API key is empty')
+        if not applicationkey:
+            raise Exception('Ambient Weather Application key is empty')
+        if not macaddress:
+            raise Exception('Ambient Weather Device MAC address is empty')
+
+
+        self.url = self.URL_TEMPLATE.format(**{
+            'macaddress' : macaddress,
+            'apikey'     : apikey,
+            'applicationkey'    : applicationkey,
+        })
+
+        self.data = {
+            'data' : tuple(),
+        }
+
+        self.next_run = time.time()  # run immediately
+        self.next_run_offset = 300  # five minutes
+
+
+    def update(self):
+        now = time.time()
+        if now < self.next_run:
+            # return cached data
+            return self.data
+
+
+        self.next_run = now + self.next_run_offset
+
+
+
+        try:
+            r = requests.get(self.url, verify=True, timeout=(5.0, 10.0))
+        except socket.gaierror as e:
+            raise SensorReadException(str(e)) from e
+        except socket.timeout as e:
+            raise SensorReadException(str(e)) from e
+        except requests.exceptions.ConnectTimeout as e:
+            raise SensorReadException(str(e)) from e
+        except requests.exceptions.ConnectionError as e:
+            raise SensorReadException(str(e)) from e
+        except requests.exceptions.ReadTimeout as e:
+            raise SensorReadException(str(e)) from e
+        except ssl.SSLCertVerificationError as e:
+            raise SensorReadException(str(e)) from e
+        except requests.exceptions.SSLError as e:
+            raise SensorReadException(str(e)) from e
+
+
+
+        if r.status_code >= 400:
+            raise SensorReadException('Ambient Weather API returned {0:d}'.format(r.status_code))
+
+
+        try:
+            r_data = r.json()
+        except json.JSONDecodeError as e:
+            raise SensorReadException(str(e)) from e
+
+
+        if r_data[0].get('tempf'):
+            temp_f = float(r_data[0]['tempf'])
+        else:
+            temp_f = 0.0
+
+
+        if r_data[0].get('feelsLike'):
+            feels_like_f = float(r_data[0]['feelsLike'])
+        else:
+            feels_like_f = 0.0
+
+
+        if r_data[0].get('humidity'):
+            rel_h = float(r_data[0]['humidity'])
+        else:
+            rel_h = 0.0
+
+
+        if r_data[0].get('baromrelin'):
+            pressure_in = float(r_data[0]['baromrelin'])
+        else:
+            pressure_in = 0.0
+
+
+        if r_data[0].get('windspeedmph'):
+            wind_speed_mph = float(r_data[0]['windspeedmph'])
+        else:
+            wind_speed_mph = 0.0
+
+
+        if r_data[0].get('windgustmph'):
+            wind_gust_mph = float(r_data[0]['windgustmph'])
+        else:
+            wind_gust_mph = 0.0
+
+
+        if r_data[0].get('winddir'):
+            wind_dir = float(r_data[0]['winddir'])
+        else:
+            wind_dir = 0.0
+
+
+        if r_data[0].get('hourlyrainin'):
+            rain_total = float(r_data[0]['hourlyrainin'])
+        else:
+            rain_total = 0.0
+
+
+        if r_data[0].get('solarradiation'):
+            solar_radiation = float(r_data[0]['solarradiation'])
+        else:
+            solar_radiation = 0.0
+
+
+        if r_data[0].get('uv'):
+            uv = float(r_data[0]['uv'])
+        else:
+            uv = 0.0
+
+
+        logger.info('[%s] Ambient Weather  API - temp: %0.1ff, feels like: %0.1ff humidity: %d%%', self.name, temp_f, feels_like_f, rel_h)
+
+
+        try:
+            dew_point_c = self.get_dew_point_c(self.f2c(temp_f), rel_h)
+            frost_point_c = self.get_frost_point_c(self.f2c(temp_f), dew_point_c)
+        except ValueError as e:
+            logger.error('Dew Point calculation error - ValueError: %s', str(e))
+            dew_point_c = 0.0
+            frost_point_c = 0.0
+
+
+        heat_index_c = self.get_heat_index_c(self.f2c(temp_f), rel_h)
+
+
+        if self.config.get('TEMP_DISPLAY') == 'f':
+            current_temp = temp_f
+            current_dp = self.c2f(dew_point_c)
+            current_fp = self.c2f(frost_point_c)
+            current_hi = self.c2f(heat_index_c)
+            current_fl = feels_like_f
+
+            ### assume inches if you are showing F
+            current_rain = rain_total
+        elif self.config.get('TEMP_DISPLAY') == 'k':
+            current_temp = self.f2k(temp_f)
+            current_dp = self.c2k(dew_point_c)
+            current_fp = self.c2k(frost_point_c)
+            current_hi = self.c2k(heat_index_c)
+            current_fl = self.f2k(feels_like_f)
+
+            current_rain = rain_total
+        else:
+            current_temp = self.f2c(temp_f)
+            current_dp = dew_point_c
+            current_fp = frost_point_c
+            current_hi = heat_index_c
+            current_fl = self.f2c(feels_like_f)
+
+
+            current_rain = rain_total
+
+
+        if self.config.get('WINDSPEED_DISPLAY') == 'mph':
+            current_wind_speed = wind_speed_mph
+            current_wind_gust = wind_gust_mph
+        elif self.config.get('WINDSPEED_DISPLAY') == 'knots':
+            current_wind_speed = self.mph2knots(wind_speed_mph)
+            current_wind_gust = self.mph2knots(wind_gust_mph)
+        elif self.config.get('WINDSPEED_DISPLAY') == 'kph':
+            current_wind_speed = self.mph2kmph(wind_speed_mph)
+            current_wind_gust = self.mph2kmph(wind_gust_mph)
+        else:
+            # ms meters/s
+            current_wind_speed = self.mph2mps(wind_speed_mph)
+            current_wind_gust = self.mph2mps(wind_gust_mph)
+
+
+        if self.config.get('PRESSURE_DISPLAY') == 'psi':
+            current_pressure = self.inHg2psi(pressure_in)
+        elif self.config.get('PRESSURE_DISPLAY') == 'inHg':
+            current_pressure = pressure_in
+        elif self.config.get('PRESSURE_DISPLAY') == 'mmHg':
+            current_pressure = self.inHg2mmHg(pressure_in)
+        else:
+            current_pressure = self.inHg2hpa(pressure_in)
+
+
+        self.data = {
+            'dew_point' : current_dp,
+            'frost_point' : current_fp,
+            'heat_index' : current_hi,
+            'wind_degrees' : wind_dir,
+            'data' : (
+                current_temp,
+                current_fl,
+                rel_h,
+                current_pressure,
+                current_wind_speed,
+                current_wind_gust,
+                current_rain,
+                solar_radiation,
+                uv,
+            ),
+        }
+
+        return self.data
+
+

--- a/indi_allsky/flask/templates/config.html
+++ b/indi_allsky/flask/templates/config.html
@@ -2005,19 +2005,6 @@ var camera_id = {{ camera_id }};
 
     <div class="form-group row">
         <div class="col-sm-2">
-            {{ form_config.LIGHTGRAPH_OVERLAY__DUSK_COLOR.label(class='col-form-label') }}
-        </div>
-        <div class="col-sm-2">
-            {{ form_config.LIGHTGRAPH_OVERLAY__DUSK_COLOR(class='form-control bg-secondary') }}
-            <div id="LIGHTGRAPH_OVERLAY__DUSK_COLOR-error" class="invalid-feedback text-danger" style="display: none;"></div>
-        </div>
-        <div class="col-sm-8">
-            <div></div>
-        </div>
-    </div>
-
-    <div class="form-group row">
-        <div class="col-sm-2">
             {{ form_config.LIGHTGRAPH_OVERLAY__NIGHT_COLOR.label(class='col-form-label') }}
         </div>
         <div class="col-sm-2">
@@ -5173,7 +5160,7 @@ var camera_id = {{ camera_id }};
             <div id="TEMP_SENSOR__A_I2C_ADDRESS-error" class="invalid-feedback text-danger" style="display: none;"></div>
         </div>
         <div class="col-sm-8">
-            <div>Hexadecimal address - Example: 0x77</div>
+            <div>Hexidecimal address - Example: 0x77</div>
         </div>
     </div>
 
@@ -5240,7 +5227,7 @@ var camera_id = {{ camera_id }};
             <div id="TEMP_SENSOR__B_I2C_ADDRESS-error" class="invalid-feedback text-danger" style="display: none;"></div>
         </div>
         <div class="col-sm-8">
-            <div>Hexadecimal address - Example: 0x76</div>
+            <div>Hexidecimal address - Example: 0x76</div>
         </div>
     </div>
 
@@ -5307,7 +5294,7 @@ var camera_id = {{ camera_id }};
             <div id="TEMP_SENSOR__C_I2C_ADDRESS-error" class="invalid-feedback text-danger" style="display: none;"></div>
         </div>
         <div class="col-sm-8">
-            <div>Hexadecimal address - Example: 0x40</div>
+            <div>Hexidecimal address - Example: 0x40</div>
         </div>
     </div>
 
@@ -5358,6 +5345,48 @@ var camera_id = {{ camera_id }};
         <div class="col-sm-4">
             {{ form_config.TEMP_SENSOR__ASTROSPHERIC_APIKEY(class='form-control bg-secondary') }}
             <div id="TEMP_SENSOR__ASTROSPHERIC_APIKEY-error" class="invalid-feedback text-danger" style="display: none;"></div>
+        </div>
+        <div class="col-sm-6">
+            <div></div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <div class="col-sm-2">
+            {{ form_config.TEMP_SENSOR__AMBIENTWEATHER_APIKEY.label(class='col-form-label') }}
+
+        </div>
+        <div class="col-sm-4">
+            {{ form_config.TEMP_SENSOR__AMBIENTWEATHER_APIKEY(class='form-control bg-secondary') }}
+            <div id="TEMP_SENSOR__AMBIENTWEATHER_APIKEY-error" class="invalid-feedback text-danger" style="display: none;"></div>
+        </div>
+        <div class="col-sm-6">
+            <div></div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <div class="col-sm-2">
+            {{ form_config.TEMP_SENSOR__AMBIENTWEATHER_APPLICATIONKEY.label(class='col-form-label') }}
+
+        </div>
+        <div class="col-sm-4">
+            {{ form_config.TEMP_SENSOR__AMBIENTWEATHER_APPLICATIONKEY(class='form-control bg-secondary') }}
+            <div id="TEMP_SENSOR__AMBIENTWEATHER_APPLICATIONKEY-error" class="invalid-feedback text-danger" style="display: none;"></div>
+        </div>
+        <div class="col-sm-6">
+            <div></div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <div class="col-sm-2">
+            {{ form_config.TEMP_SENSOR__AMBIENTWEATHER_MACADDRESS.label(class='col-form-label') }}
+
+        </div>
+        <div class="col-sm-4">
+            {{ form_config.TEMP_SENSOR__AMBIENTWEATHER_MACADDRESS(class='form-control bg-secondary') }}
+            <div id="TEMP_SENSOR__AMBIENTWEATHER_MACADDRESS-error" class="invalid-feedback text-danger" style="display: none;"></div>
         </div>
         <div class="col-sm-6">
             <div></div>
@@ -6734,7 +6763,6 @@ const field_names = [
     'LIGHTGRAPH_OVERLAY__OFFSET_X',
     'LIGHTGRAPH_OVERLAY__SCALE',
     'LIGHTGRAPH_OVERLAY__DAY_COLOR',
-    'LIGHTGRAPH_OVERLAY__DUSK_COLOR',
     'LIGHTGRAPH_OVERLAY__NIGHT_COLOR',
     'LIGHTGRAPH_OVERLAY__HOUR_COLOR',
     'LIGHTGRAPH_OVERLAY__BORDER_COLOR',
@@ -6945,6 +6973,9 @@ const field_names = [
     'TEMP_SENSOR__OPENWEATHERMAP_APIKEY',
     'TEMP_SENSOR__WUNDERGROUND_APIKEY',
     'TEMP_SENSOR__ASTROSPHERIC_APIKEY',
+    'TEMP_SENSOR__AMBIENTWEATHER_APIKEY',
+    'TEMP_SENSOR__AMBIENTWEATHER_APPLICATIONKEY',
+    'TEMP_SENSOR__AMBIENTWEATHER_MACADDRESS',
     'TEMP_SENSOR__MQTT_TRANSPORT',
     'TEMP_SENSOR__MQTT_HOST',
     'TEMP_SENSOR__MQTT_PORT',

--- a/indi_allsky/flask/views.py
+++ b/indi_allsky/flask/views.py
@@ -2105,6 +2105,9 @@ class ConfigView(FormView):
             'TEMP_SENSOR__OPENWEATHERMAP_APIKEY' : self.indi_allsky_config.get('TEMP_SENSOR', {}).get('OPENWEATHERMAP_APIKEY', ''),
             'TEMP_SENSOR__WUNDERGROUND_APIKEY'   : self.indi_allsky_config.get('TEMP_SENSOR', {}).get('WUNDERGROUND_APIKEY', ''),
             'TEMP_SENSOR__ASTROSPHERIC_APIKEY'   : self.indi_allsky_config.get('TEMP_SENSOR', {}).get('ASTROSPHERIC_APIKEY', ''),
+            'TEMP_SENSOR__AMBIENTWEATHER_APIKEY'           : self.indi_allsky_config.get('TEMP_SENSOR', {}).get('AMBIENTWEATHER_APIKEY', ''),
+            'TEMP_SENSOR__AMBIENTWEATHER_APPLICATIONKEY'   : self.indi_allsky_config.get('TEMP_SENSOR', {}).get('AMBIENTWEATHER_APPLICATIONKEY', ''),
+            'TEMP_SENSOR__AMBIENTWEATHER_MACADDRESS'       : self.indi_allsky_config.get('TEMP_SENSOR', {}).get('AMBIENTWEATHER_MACADDRESS', ''),
             'TEMP_SENSOR__MQTT_TRANSPORT'    : self.indi_allsky_config.get('TEMP_SENSOR', {}).get('MQTT_TRANSPORT', 'tcp'),
             'TEMP_SENSOR__MQTT_HOST'         : self.indi_allsky_config.get('TEMP_SENSOR', {}).get('MQTT_HOST', 'localhost'),
             'TEMP_SENSOR__MQTT_PORT'         : self.indi_allsky_config.get('TEMP_SENSOR', {}).get('MQTT_PORT', 8883),
@@ -2275,9 +2278,6 @@ class ConfigView(FormView):
         lightgraph_overlay__day_color = self.indi_allsky_config.get('LIGHTGRAPH_OVERLAY', {}).get('DAY_COLOR', [150, 150, 150])
         form_data['LIGHTGRAPH_OVERLAY__DAY_COLOR'] = ','.join([str(x) for x in lightgraph_overlay__day_color])
 
-        lightgraph_overlay__dusk_color = self.indi_allsky_config.get('LIGHTGRAPH_OVERLAY', {}).get('DUSK_COLOR', [200, 100, 60])
-        form_data['LIGHTGRAPH_OVERLAY__DUSK_COLOR'] = ','.join([str(x) for x in lightgraph_overlay__dusk_color])
-
         lightgraph_overlay__night_color = self.indi_allsky_config.get('LIGHTGRAPH_OVERLAY', {}).get('NIGHT_COLOR', [30, 30, 30])
         form_data['LIGHTGRAPH_OVERLAY__NIGHT_COLOR'] = ','.join([str(x) for x in lightgraph_overlay__night_color])
 
@@ -2287,7 +2287,7 @@ class ConfigView(FormView):
         lightgraph_overlay__border_color = self.indi_allsky_config.get('LIGHTGRAPH_OVERLAY', {}).get('BORDER_COLOR', [1, 1, 1])
         form_data['LIGHTGRAPH_OVERLAY__BORDER_COLOR'] = ','.join([str(x) for x in lightgraph_overlay__border_color])
 
-        lightgraph_overlay__now_color = self.indi_allsky_config.get('LIGHTGRAPH_OVERLAY', {}).get('NOW_COLOR', [120, 120, 200])
+        lightgraph_overlay__now_color = self.indi_allsky_config.get('LIGHTGRAPH_OVERLAY', {}).get('NOW_COLOR', [200, 150, 15])
         form_data['LIGHTGRAPH_OVERLAY__NOW_COLOR'] = ','.join([str(x) for x in lightgraph_overlay__now_color])
 
         lightgraph_overlay__font_color = self.indi_allsky_config.get('LIGHTGRAPH_OVERLAY', {}).get('FONT_COLOR', [150, 150, 150])
@@ -2893,6 +2893,9 @@ class AjaxConfigView(BaseView):
         self.indi_allsky_config['TEMP_SENSOR']['OPENWEATHERMAP_APIKEY'] = str(request.json['TEMP_SENSOR__OPENWEATHERMAP_APIKEY'])
         self.indi_allsky_config['TEMP_SENSOR']['WUNDERGROUND_APIKEY']   = str(request.json['TEMP_SENSOR__WUNDERGROUND_APIKEY'])
         self.indi_allsky_config['TEMP_SENSOR']['ASTROSPHERIC_APIKEY']   = str(request.json['TEMP_SENSOR__ASTROSPHERIC_APIKEY'])
+        self.indi_allsky_config['TEMP_SENSOR']['AMBIENTWEATHER_APIKEY']         = str(request.json['TEMP_SENSOR__AMBIENTWEATHER_APIKEY'])
+        self.indi_allsky_config['TEMP_SENSOR']['AMBIENTWEATHER_APPLICATIONKEY'] = str(request.json['TEMP_SENSOR__AMBIENTWEATHER_APPLICATIONKEY'])
+        self.indi_allsky_config['TEMP_SENSOR']['AMBIENTWEATHER_MACADDRESS']     = str(request.json['TEMP_SENSOR__AMBIENTWEATHER_MACADDRESS'])
         self.indi_allsky_config['TEMP_SENSOR']['MQTT_TRANSPORT']        = str(request.json['TEMP_SENSOR__MQTT_TRANSPORT'])
         self.indi_allsky_config['TEMP_SENSOR']['MQTT_HOST']             = str(request.json['TEMP_SENSOR__MQTT_HOST'])
         self.indi_allsky_config['TEMP_SENSOR']['MQTT_PORT']             = int(request.json['TEMP_SENSOR__MQTT_PORT'])
@@ -3023,9 +3026,6 @@ class AjaxConfigView(BaseView):
         # LIGHTGRAPH COLORS
         lightgraph_overlay__day_color_str = str(request.json['LIGHTGRAPH_OVERLAY__DAY_COLOR'])
         self.indi_allsky_config['LIGHTGRAPH_OVERLAY']['DAY_COLOR'] = [int(x) for x in lightgraph_overlay__day_color_str.split(',')]
-
-        lightgraph_overlay__dusk_color_str = str(request.json['LIGHTGRAPH_OVERLAY__DUSK_COLOR'])
-        self.indi_allsky_config['LIGHTGRAPH_OVERLAY']['DUSK_COLOR'] = [int(x) for x in lightgraph_overlay__dusk_color_str.split(',')]
 
         lightgraph_overlay__night_color_str = str(request.json['LIGHTGRAPH_OVERLAY__NIGHT_COLOR'])
         self.indi_allsky_config['LIGHTGRAPH_OVERLAY']['NIGHT_COLOR'] = [int(x) for x in lightgraph_overlay__night_color_str.split(',')]
@@ -5934,7 +5934,7 @@ class AjaxFocusControllerView(BaseView):
 
 
     def dispatch_request(self):
-        from ..focuser import IndiAllSkyFocuserInterface
+        from ..focuser import IndiAllSkyFocuser
         from ..devices.exceptions import DeviceControlException
 
 
@@ -5965,7 +5965,7 @@ class AjaxFocusControllerView(BaseView):
         app.logger.info('Focusing: {0:s}', direction)
 
         try:
-            focuser_interface = IndiAllSkyFocuserInterface(self.indi_allsky_config)
+            focuser = IndiAllSkyFocuser(self.indi_allsky_config)
         except SystemError as e:
             json_data = {
                 'focuser_error' : ['Error initializing focuser: {0:s}'.format(str(e))],
@@ -5984,7 +5984,7 @@ class AjaxFocusControllerView(BaseView):
 
 
         try:
-            steps_offset = focuser_interface.move(direction, degrees)
+            steps_offset = focuser.move(direction, degrees)
         except DeviceControlException as e:
             json_data = {
                 'focuser_error' : ['Error moving focuser: {0:s}'.format(str(e))],

--- a/misc/support_info.sh
+++ b/misc/support_info.sh
@@ -266,7 +266,7 @@ fi
 
 
 echo "libcamera packages"
-dpkg -l | grep -E "libcamera|rpicam" || true
+dpkg -l | grep libcamera || true
 echo
 
 echo "libcamera cameras"
@@ -333,7 +333,7 @@ if [ -d "${ALLSKY_DIRECTORY}/virtualenv/indi-allsky" ]; then
 
     echo "\`\`\`json"  # markdown
     # Remove all secrets from config
-    echo "$INDI_ALLSKY_CONFIG" | jq --arg redacted "REDACTED" '.OWNER = $redacted | .FILETRANSFER.PASSWORD = $redacted | .FILETRANSFER.PASSWORD_E = $redacted | .S3UPLOAD.SECRET_KEY = $redacted | .S3UPLOAD.SECRET_KEY_E = $redacted | .MQTTPUBLISH.PASSWORD = $redacted | .MQTTPUBLISH.PASSWORD_E = $redacted | .SYNCAPI.APIKEY = $redacted | .SYNCAPI.APIKEY_E = $redacted | .PYCURL_CAMERA.PASSWORD = $redacted | .PYCURL_CAMERA.PASSWORD_E = $redacted | .TEMP_SENSOR.OPENWEATHERMAP_APIKEY = $redacted | .TEMP_SENSOR.OPENWEATHERMAP_APIKEY_E = $redacted | .TEMP_SENSOR.WUNDERGROUND_APIKEY = $redacted | .TEMP_SENSOR.WUNDERGROUND_APIKEY_E = $redacted | .TEMP_SENSOR.ASTROSPHERIC_APIKEY = $redacted | .TEMP_SENSOR.ASTROSPHERIC_APIKEY_E = $redacted | .TEMP_SENSOR.MQTT_PASSWORD = $redacted | .TEMP_SENSOR.MQTT_PASSWORD_E = $redacted | .ADSB.PASSWORD = $redacted | .ADSB.PASSWORD_E = $redacted'
+    echo "$INDI_ALLSKY_CONFIG" | jq --arg redacted "REDACTED" '.OWNER = $redacted | .FILETRANSFER.PASSWORD = $redacted | .FILETRANSFER.PASSWORD_E = $redacted | .S3UPLOAD.SECRET_KEY = $redacted | .S3UPLOAD.SECRET_KEY_E = $redacted | .MQTTPUBLISH.PASSWORD = $redacted | .MQTTPUBLISH.PASSWORD_E = $redacted | .SYNCAPI.APIKEY = $redacted | .SYNCAPI.APIKEY_E = $redacted | .PYCURL_CAMERA.PASSWORD = $redacted | .PYCURL_CAMERA.PASSWORD_E = $redacted | .TEMP_SENSOR.OPENWEATHERMAP_APIKEY = $redacted | .TEMP_SENSOR.OPENWEATHERMAP_APIKEY_E = $redacted | .TEMP_SENSOR.WUNDERGROUND_APIKEY = $redacted | .TEMP_SENSOR.WUNDERGROUND_APIKEY_E = $redacted | .TEMP_SENSOR.ASTROSPHERIC_APIKEY = $redacted | .TEMP_SENSOR.ASTROSPHERIC_APIKEY_E = $redacted | .TEMP_SENSOR.AMBIENTWEATHER_APIKEY = $redacted | .TEMP_SENSOR.AMBIENTWEATHER_APIKEY_E = $redacted | .TEMP_SENSOR.AMBIENTWEATHER_APPLICATIONKEY = $redacted | .TEMP_SENSOR.AMBIENTWEATHER_APPLICATIONKEY_E = $redacted | .TEMP_SENSOR.AMBIENTWEATHER_MACADDRESS = $redacted | .TEMP_SENSOR.AMBIENTWEATHER_MACADDRESS_E = $redacted |.TEMP_SENSOR.MQTT_PASSWORD = $redacted | .TEMP_SENSOR.MQTT_PASSWORD_E = $redacted | .ADSB.PASSWORD = $redacted | .ADSB.PASSWORD_E = $redacted'
 
     deactivate
     echo


### PR DESCRIPTION
This commit adds support for Ambient Weather personal weather stations. The weather stations must be configured to report their data to https://ambientweather.net to be accessible.

Devices: https://ambientweather.com
Weather Console: https://ambientweather.net
API Documentation: https://ambientweather.docs.apiary.io/#

Related Sensors Wiki documentation -

```
### Ambient Weather ###
The Ambient Weather API may be used to query weather conditions provided by your local weather device.  This is not a physical sensor, but data is returned for your local weather conditions provided by your Ambient Weather internet connected device.

https://www.ambientweather.net/

The API is queried every 5 minutes.

Returns 9 values:
* `temperature`
* `feels like seeing`
* `relative humidity`
* `atmospheric pressure`
* `wind speed`
* `wind gust speed`
* `1hr rain`
* `solar radiation`
* `uv`

Additional values:
* `dew point`
* `frost point`
* `heat index`
* `wind direction`

Ambient Weather requires three values to access their API:
* API Key - Obtained from your ambientweather.net Dashboard, Account, then API Keys. Create a new API Key or re-use an existing one.
* Application Key - Obtained from the same page as the API Key. Create an Application key by clicking the Developers `Click here` link. You're asked to describe the application that you are developing. Indicate that you'll be using the API to get data for a personal All Sky camera.
* Device MAC Address - Obtained from the Devices page.

NOTE: Not all values will populate with data. Values will only be populated for the data sent by your weather station.
```