### PR TITLE
Fix issue with histogram chart due to keep_size change

### DIFF
--- a/indi_allsky/maskProcessing.py
+++ b/indi_allsky/maskProcessing.py
@@ -43,6 +43,7 @@ class MaskProcessor(object):
 
     def rotate_angle(self):
         angle = self.config.get('IMAGE_ROTATE_ANGLE')
+        keep_size = self.config.get('IMAGE_ROTATE_KEEP_SIZE')
 
         #rotate_start = time.time()
 
@@ -52,11 +53,15 @@ class MaskProcessor(object):
 
         rot = cv2.getRotationMatrix2D((center_x, center_y), int(angle), 1.0)
 
-        abs_cos = abs(rot[0, 0])
-        abs_sin = abs(rot[0, 1])
+        if keep_size:
+            bound_w = width
+            bound_h = height
+        else:
+            abs_cos = abs(rot[0, 0])
+            abs_sin = abs(rot[0, 1])
 
-        bound_w = int(height * abs_sin + width * abs_cos)
-        bound_h = int(height * abs_cos + width * abs_sin)
+            bound_w = int(height * abs_sin + width * abs_cos)
+            bound_h = int(height * abs_cos + width * abs_sin)
 
         rot[0, 2] += bound_w / 2 - center_x
         rot[1, 2] += bound_h / 2 - center_y


### PR DESCRIPTION
keep_size change introduced a regression in the histogram chart generation. The resulting image didn't match the image_mask being generated because of the new rotation logic.

```MainProcess-2203 app.log_exception() [875]: Exception on /indi-allsky/js/charts [GET]
Traceback (most recent call last):
  File "/home/admin/indi-allsky/virtualenv/indi-allsky/lib/python3.11/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/indi-allsky/virtualenv/indi-allsky/lib/python3.11/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/indi-allsky/virtualenv/indi-allsky/lib/python3.11/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/indi-allsky/virtualenv/indi-allsky/lib/python3.11/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/indi-allsky/indi_allsky/flask/misc.py", line 22, in decorated_view
    return app.ensure_sync(func)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/indi-allsky/virtualenv/indi-allsky/lib/python3.11/site-packages/flask/views.py", line 110, in view
    return current_app.ensure_sync(self.dispatch_request)(**kwargs)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/indi-allsky/indi_allsky/flask/base_views.py", line 1140, in dispatch_request
    json_data = self.get_objects()
                ^^^^^^^^^^^^^^^^^^
  File "/home/admin/indi-allsky/indi_allsky/flask/views.py", line 1262, in get_objects
    'chart_data' : self.getChartData(camera_id, ts_dt, history_seconds),
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/indi-allsky/indi_allsky/flask/views.py", line 1597, in getChartData
    col_ma = numpy.ma.masked_array(image_data[:, :, i], mask=numpy_mask)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/admin/indi-allsky/virtualenv/indi-allsky/lib/python3.11/site-packages/numpy/ma/core.py", line 2983, in __new__
    raise MaskError(msg % (nd, nm))
numpy.ma.core.MaskError: Mask and data not compatible: data size is 12616704, mask size is 18524416.```

This commit fixes the maskProcessing rotate_angle() function to match.