### PR TITLE
Fix Celsius typo

### DIFF
--- a/indi_allsky/allsky.py
+++ b/indi_allsky/allsky.py
@@ -123,7 +123,7 @@ class IndiAllSky(object):
         ])
 
 
-        ### temperature values in this array should always be in Celcius
+        ### temperature values in this array should always be in Celsius
         # 0 ccd temp
         # 1-9 reserved for future use
         # 10-29 system temperatures

--- a/indi_allsky/config.py
+++ b/indi_allsky/config.py
@@ -94,7 +94,7 @@ class IndiAllSkyConfigBase(object):
         "SATURATION_FACTOR_DAY": 1.0,
         "CCD_COOLING"      : False,
         "CCD_TEMP"         : 15.0,
-        "TEMP_DISPLAY"     : "c",  # c = celcius, f = fahrenheit, k = kelvin",
+        "TEMP_DISPLAY"     : "c",  # c = celsius, f = fahrenheit, k = kelvin",
         "PRESSURE_DISPLAY" : "hPa",  # hPa = hectoPascals/millibars, psi = psi, inHg = inches of mercury, mmHg = mm of mercury
         "WINDSPEED_DISPLAY": "ms",  # ms = meters/s, mph = miles/hour, knots = knots, kph = km/hour
         "CCD_TEMP_SCRIPT"  : "",

--- a/indi_allsky/devices/sensors/sensorBase.py
+++ b/indi_allsky/devices/sensors/sensorBase.py
@@ -62,22 +62,22 @@ class SensorBase(object):
 
 
     def c2f(self, c):
-        # celcius to fahrenheit
+        # celsius to fahrenheit
         return (c * 9.0 / 5.0) + 32
 
 
     def f2c(self, f):
-        # fahrenheit to celcius
+        # fahrenheit to celsius
         return (f - 32) * 5.0 / 9.0
 
 
     def c2k(self, c):
-        # celcius to kelvin
+        # celsius to kelvin
         return c + 273.15
 
 
     def k2c(self, k):
-        # kelvin to celcius
+        # kelvin to celsius
         return k - 273.15
 
 

--- a/indi_allsky/flask/forms.py
+++ b/indi_allsky/flask/forms.py
@@ -2835,7 +2835,7 @@ class IndiAllskyConfigForm(FlaskForm):
     )
 
     TEMP_DISPLAY_choices = (
-        ('c', 'Celcius'),
+        ('c', 'Celsius'),
         ('f', 'Fahrenheit'),
         ('k', 'Kelvin'),
     )

--- a/indi_allsky/flask/templates/config.html
+++ b/indi_allsky/flask/templates/config.html
@@ -6117,7 +6117,7 @@ var camera_id = {{ camera_id }};
 
     <hr>
 
-    <div><span class="badge rounded-pill bg-info text-dark">Note</span> Sensor units may be in either Celcius or Fahrenheit based on the Temperature Display option on the Camera Tab</div>
+    <div><span class="badge rounded-pill bg-info text-dark">Note</span> Sensor units may be in either Celsius or Fahrenheit based on the Temperature Display option on the Camera Tab</div>
 
     <hr>
 

--- a/indi_allsky/image.py
+++ b/indi_allsky/image.py
@@ -868,7 +868,7 @@ class ImageWorker(Process):
 
 
                     # update share array
-                    # temperatures always Celcius here
+                    # temperatures always Celsius here
                     with self.sensors_temp_av.get_lock():
                         # index 0 is always ccd_temp
                         self.sensors_temp_av[10 + offset] = temp_c


### PR DESCRIPTION
There is a typo in the word 'Celcius'. It should be Celsius. source: https://en.wikipedia.org/wiki/Celsius