### PR TITLE
Replace rpicam-still/rpicam-vid with picamera2 daemon, add WebSocket …

### DIFF
--- a/indi_allsky/camera/libcamera.py
+++ b/indi_allsky/camera/libcamera.py
@@ -10,8 +10,16 @@ import psutil
 from pathlib import Path
 import logging
 
+import numpy as np
+
+try:
+    import cv2
+except ImportError:
+    cv2 = None
+
 from .indi import IndiClient
 from .fake_indi import FakeIndiCcd
+from .picamera2_client import Picamera2Client
 
 from .. import constants
 
@@ -38,7 +46,7 @@ class IndiClientLibCameraGeneric(IndiClient):
     def __init__(self, *args, **kwargs):
         super(IndiClientLibCameraGeneric, self).__init__(*args, **kwargs)
 
-        self.libcamera_process = None
+        self.libcamera_process = None  # kept for compat; unused with daemon
 
         self._temp_val = -273.15  # absolute zero  :-)
 
@@ -52,6 +60,9 @@ class IndiClientLibCameraGeneric(IndiClient):
         self.current_exposure_file_p = None
         self.current_metadata_file_p = None
 
+        # Picamera2 daemon client — replaces rpicam-still subprocess
+        self._picam2_client = Picamera2Client()
+
         memory_info = psutil.virtual_memory()
         self.memory_total_mb = memory_info[0] / 1024.0 / 1024.0
 
@@ -59,18 +70,16 @@ class IndiClientLibCameraGeneric(IndiClient):
         self.ccd_device_name = 'CHANGEME'
 
 
-        # pick correct executable
+        # pick correct executable (kept as fallback identifier)
         if shutil.which('rpicam-still'):
             self.ccd_driver_exec = 'rpicam-still'
         elif shutil.which('libcamera-still'):
             self.ccd_driver_exec = 'libcamera-still'
         else:
-            logger.warning('rpicam-still command not found')
-            self.ccd_driver_exec = self.libcamera_exec  # fallback
+            self.ccd_driver_exec = 'picamera2-daemon'
 
 
-        # this will fallback to the original self.ccd_driver_exec
-        logger.info('libcamera executable: %s', self.ccd_driver_exec)
+        logger.info('libcamera backend: picamera2 daemon')
 
 
         # override in subclass
@@ -145,49 +154,13 @@ class IndiClientLibCameraGeneric(IndiClient):
         if self.active_exposure:
             return
 
-
         self.exposure = exposure
         self.sqm_exposure = sqm_exposure
 
-
-        libcamera_camera_id = self.config.get('LIBCAMERA', {}).get('CAMERA_ID', 0)
-
-
         if self.night_av[constants.NIGHT_NIGHT]:
-            # night
             image_type = self.config.get('LIBCAMERA', {}).get('IMAGE_FILE_TYPE', 'jpg')
         else:
-            # day
             image_type = self.config.get('LIBCAMERA', {}).get('IMAGE_FILE_TYPE_DAY', 'jpg')
-
-
-        if image_type == 'dng' and self.memory_total_mb <= 768:
-            logger.warning('*** Capturing raw images (dng) with libcamera and less than 1gb of memory can result in out-of-memory errors ***')
-
-
-        try:
-            image_tmp_f = tempfile.NamedTemporaryFile(mode='w', suffix='.{0:s}'.format(image_type), delete=True)
-            image_tmp_f.close()
-            image_tmp_p = Path(image_tmp_f.name)
-
-            metadata_tmp_f = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=True)
-            metadata_tmp_f.close()
-            metadata_tmp_p = Path(metadata_tmp_f.name)
-        except OSError as e:
-            logger.error('OSError: %s', str(e))
-            return
-
-
-        try:
-            binmode_option = self._getBinModeOptions(int(binning))
-        except BinModeException as e:
-            logger.error('Invalid setting: %s', str(e))
-            binmode_option = ''
-
-
-        self.current_exposure_file_p = image_tmp_p
-        self.current_metadata_file_p = metadata_tmp_p
-
 
         if self.gain != float(round(gain, 2)):
             self.setCcdGain(gain)
@@ -195,356 +168,217 @@ class IndiClientLibCameraGeneric(IndiClient):
         if self.binning != int(binning):
             self.setCcdBinning(binning)
 
-
-        exposure_us = int(exposure * 1000000)
-
-        if image_type in ['dng']:
-            cmd = [
-                self.ccd_device.driver_exec,
-                '--nopreview',
-                '--camera', '{0:d}'.format(libcamera_camera_id),
-                '--raw',
-                '--denoise', 'off',
-                '--gain', '{0:0.2f}'.format(self.gain_av[constants.GAIN_CURRENT]),
-                '--shutter', '{0:d}'.format(exposure_us),
-                '--metadata', str(metadata_tmp_p),
-                '--metadata-format', 'json',
-            ]
-        elif image_type in ['jpg', 'png']:
-            #logger.warning('RAW frame mode disabled due to low memory resources')
-            cmd = [
-                self.ccd_device.driver_exec,
-                '--nopreview',
-                '--camera', '{0:d}'.format(libcamera_camera_id),
-                '--encoding', '{0:s}'.format(image_type),
-                '--quality', '95',
-                '--gain', '{0:0.2f}'.format(self.gain_av[constants.GAIN_CURRENT]),
-                '--shutter', '{0:d}'.format(exposure_us),
-                '--metadata', str(metadata_tmp_p),
-                '--metadata-format', 'json',
-            ]
+        # Determine AWB setting
+        is_night = bool(self.night_av[constants.NIGHT_NIGHT])
+        if is_night:
+            awb_enable = bool(self.config.get('LIBCAMERA', {}).get('AWB_ENABLE'))
         else:
-            raise Exception('Invalid image type')
+            awb_enable = bool(self.config.get('LIBCAMERA', {}).get('AWB_ENABLE_DAY'))
 
-
-
-        if self.night_av[constants.NIGHT_NIGHT]:
-            #  night
-
-            if self.config.get('LIBCAMERA', {}).get('IMMEDIATE', True):
-                cmd.insert(1, '--immediate')
-
-
-            # Auto white balance, AWB causes long exposure times at night
-            if self.config.get('LIBCAMERA', {}).get('AWB_ENABLE'):
-                awb = self.config.get('LIBCAMERA', {}).get('AWB', 'auto')
-                cmd.extend(['--awb', awb])
-            else:
-                # awb enabled by default, the following disables
-                cmd.extend(['--awbgains', '1,1'])
-
-
-            # CCM
-            if self.config.get('LIBCAMERA', {}).get('CCM_DISABLE'):
-                cmd.extend(['--ccm', '1,0,0,0,1,0,0,0,1'])
-
-        else:
-            # daytime
-
-            if self.config.get('LIBCAMERA', {}).get('IMMEDIATE_DAY', True):
-                cmd.insert(1, '--immediate')
-
-
-            # Auto white balance, AWB causes long exposure times at night
-            if self.config.get('LIBCAMERA', {}).get('AWB_ENABLE_DAY'):
-                awb = self.config.get('LIBCAMERA', {}).get('AWB_DAY', 'auto')
-                cmd.extend(['--awb', awb])
-            else:
-                # awb enabled by default, the following disables
-                cmd.extend(['--awbgains', '1,1'])
-
-
-            # CCM
-            if self.config.get('LIBCAMERA', {}).get('CCM_DISABLE_DAY'):
-                cmd.extend(['--ccm', '1,0,0,0,1,0,0,0,1'])
-
-
-        # add --mode flags for binning
-        if binmode_option:
-            cmd.extend(binmode_option.split(' '))
-
-
-        # extra options get added last
-        if self.night_av[constants.NIGHT_NIGHT]:
-            #  night
-            # Add extra config options
-            extra_options = self.config.get('LIBCAMERA', {}).get('EXTRA_OPTIONS')
-            if extra_options:
-                cmd.extend(extra_options.split(' '))
-
-        else:
-            # daytime
-
-            # Add extra config options
-            extra_options = self.config.get('LIBCAMERA', {}).get('EXTRA_OPTIONS_DAY')
-            if extra_options:
-                cmd.extend(extra_options.split(' '))
-
-
-        # Finally add output file
-        cmd.extend(['--output', str(image_tmp_p)])
-
-
-        ### testing an expoure that times out
-        #cmd = [
-        #    'sleep', '600',
-        #]
-
-
-        logger.info('image command: %s', ' '.join(cmd))
-
-
-        self.exposureStartTime = time.time()
-
-        self.libcamera_process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+        # Send controls to the picamera2 daemon
+        self._picam2_client.set_controls(
+            exposure=exposure,
+            gain=float(self.gain_av[constants.GAIN_CURRENT]),
+            awb=awb_enable,
         )
 
-        self.active_exposure = True
+        logger.info(
+            'Capturing via picamera2 daemon: %.4fs exposure, gain %.2f, bin %d, type %s',
+            exposure, self.gain_av[constants.GAIN_CURRENT], binning, image_type,
+        )
 
+        self.exposureStartTime = time.time()
+        self.active_exposure = True
+        self._pending_image_type = image_type
 
         # Update shared exposure value
         with self.exposure_av.get_lock():
             self.exposure_av[constants.EXPOSURE_CURRENT] = float(exposure)
 
-
         if sync:
-            try:
-                self.libcamera_process.wait(timeout=timeout)
-            except subprocess.TimeoutExpired:
-                logger.error('Exposure timeout')
-                raise TimeOutException('Timeout waiting for exposure')
+            capture_timeout = timeout if timeout else max(exposure * 3, 30)
 
+            if image_type == 'dng':
+                # DNG: daemon captures directly to file
+                try:
+                    dng_tmp = tempfile.NamedTemporaryFile(
+                        mode='w', suffix='.dng', delete=False,
+                    )
+                    dng_tmp.close()
+                    result = self._picam2_client.capture_dng(
+                        dng_tmp.name, timeout=capture_timeout,
+                    )
+                    if not result.get('ok'):
+                        logger.error('DNG capture failed: %s', result.get('error'))
+                except Exception as e:
+                    logger.error('DNG capture error: %s', str(e))
 
-            if self.libcamera_process.returncode != 0:
-                # log errors
-                stdout = self.libcamera_process.stdout
-                for line in stdout.readlines():
-                    logger.error('rpicam-still error: %s', line)
+                self.current_exposure_file_p = Path(dng_tmp.name)
+            else:
+                # JPG/PNG: grab frame from daemon, encode locally
+                try:
+                    result = self._picam2_client.capture_still(
+                        exposure=exposure,
+                        gain=float(self.gain_av[constants.GAIN_CURRENT]),
+                        timeout=capture_timeout,
+                    )
+                except Exception as e:
+                    logger.error('Capture error: %s', str(e))
+                    self.active_exposure = False
+                    return
 
-                # not returning, just log the error
+                if not result.get('ok'):
+                    logger.error('Capture failed: %s', result.get('error'))
+                    self.active_exposure = False
+                    return
+
+                # Load numpy frame and encode to image file
+                frame_path = result.get('frame_path', '')
+                self._last_daemon_metadata = result.get('metadata', {})
+
+                try:
+                    frame = np.load(frame_path)
+                except Exception as e:
+                    logger.error('Failed to load frame from %s: %s', frame_path, str(e))
+                    self.active_exposure = False
+                    return
+
+                # Save as JPG or PNG
+                image_tmp_f = tempfile.NamedTemporaryFile(
+                    mode='w', suffix='.{0:s}'.format(image_type), delete=False,
+                )
+                image_tmp_f.close()
+                self.current_exposure_file_p = Path(image_tmp_f.name)
+
+                if cv2 is not None:
+                    # Frame is RGB from picamera2, convert to BGR for cv2
+                    bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+                    if image_type == 'jpg':
+                        cv2.imwrite(str(self.current_exposure_file_p), bgr,
+                                    [cv2.IMWRITE_JPEG_QUALITY, 95])
+                    else:
+                        cv2.imwrite(str(self.current_exposure_file_p), bgr)
 
             self.active_exposure = False
-
             self._processMetadata()
-
             self._queueImage()
+
+        else:
+            # Async mode: start capture in background thread
+            import threading
+            self._async_thread = threading.Thread(
+                target=self._async_capture,
+                args=(exposure, gain, image_type),
+                daemon=True,
+            )
+            self._async_thread.start()
+
+
+    def _async_capture(self, exposure, gain, image_type):
+        """Background capture for async (non-sync) mode."""
+        try:
+            capture_timeout = max(exposure * 3, 30)
+            result = self._picam2_client.capture_still(
+                exposure=exposure, gain=gain, timeout=capture_timeout,
+            )
+            if not result.get('ok'):
+                logger.error('Async capture failed: %s', result.get('error'))
+                self.active_exposure = False
+                return
+
+            frame_path = result.get('frame_path', '')
+            self._last_daemon_metadata = result.get('metadata', {})
+
+            frame = np.load(frame_path)
+
+            image_tmp_f = tempfile.NamedTemporaryFile(
+                mode='w', suffix='.{0:s}'.format(image_type), delete=False,
+            )
+            image_tmp_f.close()
+            self.current_exposure_file_p = Path(image_tmp_f.name)
+
+            if cv2 is not None:
+                bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+                if image_type == 'jpg':
+                    cv2.imwrite(str(self.current_exposure_file_p), bgr,
+                                [cv2.IMWRITE_JPEG_QUALITY, 95])
+                else:
+                    cv2.imwrite(str(self.current_exposure_file_p), bgr)
+
+            # Mark as ready for getCcdExposureStatus to pick up
+            # active_exposure stays True until getCcdExposureStatus processes it
+        except Exception:
+            logger.exception('Async capture error')
+            self.active_exposure = False
 
 
     def getCcdExposureStatus(self):
         # returns camera_ready, exposure_state
-        if self._libCameraProcessRunning():
-            return False, 'BUSY'
-
 
         if self.active_exposure:
-            # if we get here, that means the camera is finished with the exposure
+            # Check if async capture thread is still running
+            if hasattr(self, '_async_thread') and self._async_thread is not None:
+                if self._async_thread.is_alive():
+                    return False, 'BUSY'
+
+            # Async capture finished — process the result
             self.active_exposure = False
-
-
-            if self.libcamera_process.returncode != 0:
-                # log errors
-                stdout = self.libcamera_process.stdout
-                for line in stdout.readlines():
-                    logger.error('rpicam-still error: %s', line)
-
-                # not returning, just log the error
-
+            self._async_thread = None
 
             self._processMetadata()
-
             self._queueImage()
-
 
         return True, 'READY'
 
 
     def _processMetadata(self):
-        # read metadata to get sensor temperature
-        if self.current_metadata_file_p:
-            try:
-                with io.open(self.current_metadata_file_p, 'r', encoding='utf-8') as f_metadata:
-                    metadata_dict = json.load(f_metadata, object_pairs_hook=OrderedDict)
-            except FileNotFoundError as e:
-                logger.error('Metadata file not found: %s', str(e))
-                metadata_dict = dict()
-            except PermissionError as e:
-                logger.error('Permission erro: %s', str(e))
-                metadata_dict = dict()
-            except json.JSONDecodeError as e:
-                logger.error('Error decoding json: %s', str(e))
-                metadata_dict = dict()
-
-
-        #logger.info('Metadata: %s', metadata_dict)
-
-
-        try:
-            self.current_metadata_file_p.unlink()
-        except FileNotFoundError:
-            pass
-
+        """Extract ISP metadata from the picamera2 daemon response."""
+        metadata_dict = getattr(self, '_last_daemon_metadata', {})
 
         ### Gain
-        try:
-            analogue_gain = float(metadata_dict[self._analogue_gain_metadata_key])
-        except KeyError:
-            #logger.error('libcamera camera analogue gain key not found')
-            analogue_gain = 0.0
-        except ValueError:
-            #logger.error('Unable to parse libcamera analogue gain')
-            analogue_gain = 0.0
-
-
-        try:
-            digital_gain = float(metadata_dict[self._digital_gain_metadata_key])
-        except KeyError:
-            #logger.error('libcamera camera digital gain key not found')
-            digital_gain = 0.0
-        except ValueError:
-            #logger.error('Unable to parse libcamera digital gain')
-            digital_gain = 0.0
-
+        analogue_gain = float(metadata_dict.get(self._analogue_gain_metadata_key, 0.0))
+        digital_gain = float(metadata_dict.get(self._digital_gain_metadata_key, 0.0))
 
         if analogue_gain:
             logger.info('libcamera reported gain: %0.2f/%0.2f', analogue_gain, digital_gain)
 
-
         ### Temperature
-        try:
-            self._temp_val = float(metadata_dict[self._sensor_temp_metadata_key])
-        except KeyError:
-            logger.error('libcamera camera temperature key not found')
-        except ValueError:
-            logger.error('Unable to parse libcamera camera temperature')
-
+        temp = metadata_dict.get(self._sensor_temp_metadata_key)
+        if temp is not None:
+            self._temp_val = float(temp)
 
         ### Auto white balance
-        # Only return these values when libcamera AWB is enabled
-        if self.night_av[constants.NIGHT_NIGHT]:
-            # night
-            if self.config.get('LIBCAMERA', {}).get('AWB_ENABLE'):
-                try:
-                    awb_gains = metadata_dict[self._awb_gains_metadata_key]
-                    self._awb_gains = [awb_gains[0], awb_gains[1]]
-                    logger.info('libcamera color gains: Red: %0.2f, Blue: %0.2f', *self._awb_gains)
-                except KeyError:
-                    logger.error('libcamera sensor AWB key not found')
-                    self._awb_gains = None
-                except IndexError:
-                    logger.error('Invalid color gain values')
-                    self._awb_gains = None
-
-
-                ### Color correction matrix
-                #try:
-                #    ccm = metadata_dict[self._ccm_metadata_key]
-                #    self._ccm = [
-                #        [ccm[8], ccm[7], ccm[6]],
-                #        [ccm[5], ccm[4], ccm[3]],
-                #        [ccm[2], ccm[1], ccm[0]],
-                #    ]
-                #except KeyError:
-                #    logger.error('libcamera CCM key not found')
-                #    self._ccm = None
-                #except IndexError:
-                #    logger.error('Invalid CCM values')
-                #    self._ccm = None
-
-            else:
-                self._awb_gains = None
-                #self._ccm = None
-
+        is_night = bool(self.night_av[constants.NIGHT_NIGHT])
+        if is_night:
+            awb_enabled = self.config.get('LIBCAMERA', {}).get('AWB_ENABLE')
         else:
-            # day
-            if self.config.get('LIBCAMERA', {}).get('AWB_ENABLE_DAY'):
-                try:
-                    awb_gains = metadata_dict[self._awb_gains_metadata_key]
-                    self._awb_gains = [awb_gains[0], awb_gains[1]]
-                    logger.info('libcamera color gains: Red: %0.2f, Blue: %0.2f', *self._awb_gains)
-                except KeyError:
-                    logger.error('libcamera sensor AWB key not found')
-                    self._awb_gains = None
-                except IndexError:
-                    logger.error('Invalid color gain values')
-                    self._awb_gains = None
+            awb_enabled = self.config.get('LIBCAMERA', {}).get('AWB_ENABLE_DAY')
 
-
-                ### Color correction matrix
-                #try:
-                #    ccm = metadata_dict[self._ccm_metadata_key]
-                #    self._ccm = [
-                #        [ccm[8], ccm[7], ccm[6]],
-                #        [ccm[5], ccm[4], ccm[3]],
-                #        [ccm[2], ccm[1], ccm[0]],
-                #    ]
-                #except KeyError:
-                #    logger.error('libcamera CCM key not found')
-                #    self._ccm = None
-                #except IndexError:
-                #    logger.error('Invalid CCM values')
-                #    self._ccm = None
-
+        if awb_enabled:
+            awb_gains = metadata_dict.get(self._awb_gains_metadata_key)
+            if awb_gains and isinstance(awb_gains, (list, tuple)) and len(awb_gains) >= 2:
+                self._awb_gains = [awb_gains[0], awb_gains[1]]
             else:
                 self._awb_gains = None
-                #self._ccm = None
-
+        else:
+            self._awb_gains = None
 
         ### Black Level
-        try:
-            black_level = metadata_dict[self._black_level_metadata_key]
-            self._black_level = black_level[0]  # Only going to use the first key for now
-            logger.info('libcamera black level: %d', self._black_level)
-        except KeyError:
-            logger.error('libcamera sensor black level key not found')
-            self._black_level = None
-        except IndexError:
-            logger.error('Invalid black level values')
+        black_level = metadata_dict.get(self._black_level_metadata_key)
+        if black_level and isinstance(black_level, (list, tuple)) and len(black_level) > 0:
+            self._black_level = black_level[0]
+        else:
             self._black_level = None
 
 
 
     def abortCcdExposure(self):
         logger.warning('Aborting exposure')
-
         self.active_exposure = False
-
-        for _ in range(5):
-            if not self._libCameraProcessRunning():
-                break
-
-            self.libcamera_process.terminate()
-            time.sleep(0.5)
-            continue
-
-
-        if self._libCameraProcessRunning():
-            self.libcamera_process.kill()
-            self.libcamera_process.poll()  # close out the process
-
 
         try:
             if self.current_exposure_file_p:
                 self.current_exposure_file_p.unlink()
-        except FileNotFoundError:
-            pass
-
-
-        try:
-            if self.current_metadata_file_p:
-                self.current_metadata_file_p.unlink()
         except FileNotFoundError:
             pass
 
@@ -574,18 +408,37 @@ class IndiClientLibCameraGeneric(IndiClient):
 
 
     def _libCameraProcessRunning(self):
-        if not self.libcamera_process:
-            return False
-
-        # poll returns None when process is active, rc (normally 0) when finished
-        poll = self.libcamera_process.poll()
-        if isinstance(poll, type(None)):
-            return True
-
+        # No longer uses subprocess — check async thread instead
+        if hasattr(self, '_async_thread') and self._async_thread is not None:
+            return self._async_thread.is_alive()
         return False
 
 
     def findCcd(self, *args, **kwargs):
+        # Try to get live sensor info from daemon, fall back to subclass camera_info
+        try:
+            info = self._picam2_client.get_sensor_info()
+            if info.get('ok'):
+                if info.get('width'):
+                    self.camera_info['width'] = info['width']
+                if info.get('height'):
+                    self.camera_info['height'] = info['height']
+                if info.get('pixel'):
+                    self.camera_info['pixel'] = info['pixel']
+                if info.get('min_gain'):
+                    self.camera_info['min_gain'] = info['min_gain']
+                if info.get('max_gain'):
+                    self.camera_info['max_gain'] = info['max_gain']
+                if info.get('min_exposure'):
+                    self.camera_info['min_exposure'] = info['min_exposure']
+                if info.get('max_exposure'):
+                    self.camera_info['max_exposure'] = info['max_exposure']
+                if info.get('cfa'):
+                    self.camera_info['cfa'] = info['cfa']
+                logger.info('Camera info from daemon: %s', info.get('sensor_name', 'unknown'))
+        except Exception as e:
+            logger.warning('Could not get sensor info from daemon, using defaults: %s', str(e))
+
         new_ccd = FakeIndiCcd()
         new_ccd.device_name = self.ccd_device_name
         new_ccd.driver_exec = self.ccd_driver_exec

--- a/indi_allsky/camera/picamera2_client.py
+++ b/indi_allsky/camera/picamera2_client.py
@@ -1,0 +1,139 @@
+"""Standalone picamera2 daemon client.
+
+Zero dependencies on indi_allsky — safe to import from any context
+(daemon, capture worker, Flask, standalone test scripts).
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import struct
+from multiprocessing import shared_memory
+from typing import Any, Optional
+
+SOCK_PATH = "/run/indi-allsky/picamera2.sock"
+SHM_NAME = "indi_allsky_frame"
+SHM_HEADER = 24
+SHM_JPEG_MAX = 2 * 1024 * 1024
+SHM_PATH_OFFSET = SHM_HEADER + SHM_JPEG_MAX
+SHM_PATH_SIZE = 512
+
+
+class Picamera2Client:
+    """Connect to the picamera2 daemon via Unix socket + shared memory."""
+
+    def __init__(self, sock_path: str = SOCK_PATH) -> None:
+        self._sock_path = sock_path
+        self._sock: Optional[socket.socket] = None
+        self._shm: Optional[shared_memory.SharedMemory] = None
+
+    def connect(self) -> None:
+        if self._sock is not None:
+            return
+        self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._sock.connect(self._sock_path)
+        self._sock.settimeout(120.0)
+
+    def close(self) -> None:
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except Exception:
+                pass
+            self._sock = None
+        if self._shm is not None:
+            try:
+                self._shm.close()
+            except Exception:
+                pass
+            self._shm = None
+
+    def _send(self, cmd: dict) -> dict:
+        self.connect()
+        msg = json.dumps(cmd).encode() + b"\n"
+        self._sock.sendall(msg)
+        buf = b""
+        while b"\n" not in buf:
+            data = self._sock.recv(4096)
+            if not data:
+                raise ConnectionError("Daemon closed connection")
+            buf += data
+        line = buf.split(b"\n", 1)[0]
+        return json.loads(line)
+
+    def ping(self) -> dict:
+        return self._send({"cmd": "ping"})
+
+    def get_sensor_info(self) -> dict:
+        return self._send({"cmd": "get_sensor_info"})
+
+    def get_metadata(self) -> dict:
+        return self._send({"cmd": "get_metadata"})
+
+    def set_controls(self, **kwargs) -> dict:
+        return self._send({"cmd": "set_controls", **kwargs})
+
+    def capture_still(self, exposure: float = None, gain: float = None,
+                      timeout: float = 120) -> dict:
+        cmd: dict[str, Any] = {"cmd": "capture_still", "timeout": timeout}
+        if exposure is not None:
+            cmd["exposure"] = exposure
+        if gain is not None:
+            cmd["gain"] = gain
+        return self._send(cmd)
+
+    def capture_dng(self, path: str, timeout: float = 120) -> dict:
+        return self._send({"cmd": "capture_dng", "path": path, "timeout": timeout})
+
+    def set_binning(self, level: int, width: int, height: int) -> dict:
+        return self._send({"cmd": "set_binning", "level": level,
+                           "width": width, "height": height})
+
+    def set_stream(self, width: int = None, height: int = None,
+                   quality: int = None) -> dict:
+        cmd: dict[str, Any] = {"cmd": "set_stream"}
+        if width is not None:
+            cmd["width"] = width
+        if height is not None:
+            cmd["height"] = height
+        if quality is not None:
+            cmd["quality"] = quality
+        return self._send(cmd)
+
+    # ------------------------------------------------------------------
+    # Shared memory frame reader
+    # ------------------------------------------------------------------
+
+    def _open_shm(self) -> None:
+        if self._shm is None:
+            self._shm = shared_memory.SharedMemory(name=SHM_NAME)
+
+    def get_stream_jpeg(self) -> Optional[tuple[bytes, int]]:
+        """Read the latest JPEG frame from shared memory.
+
+        Returns (jpeg_bytes, sequence_counter) or None.
+        """
+        try:
+            self._open_shm()
+        except FileNotFoundError:
+            return None
+
+        buf = self._shm.buf
+        seq, w, h, ch, jpeg_len = struct.unpack_from("<QIIiI", buf, 0)
+        if jpeg_len <= 0 or jpeg_len > SHM_JPEG_MAX:
+            return None
+        jpeg = bytes(buf[SHM_HEADER:SHM_HEADER + jpeg_len])
+        return jpeg, seq
+
+    def get_frame_path(self) -> Optional[str]:
+        """Read the latest full-res frame path from shared memory."""
+        try:
+            self._open_shm()
+        except FileNotFoundError:
+            return None
+
+        buf = self._shm.buf
+        raw = bytes(buf[SHM_PATH_OFFSET:SHM_PATH_OFFSET + SHM_PATH_SIZE])
+        path = raw.split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+        return path if path else None

--- a/indi_allsky/camera/picamera2_daemon.py
+++ b/indi_allsky/camera/picamera2_daemon.py
@@ -1,0 +1,658 @@
+"""Picamera2 single-process daemon with IPC.
+
+Owns the Picamera2 instance in a daemon thread, publishes frames via shared
+memory, and accepts control commands over a Unix socket.  Both the
+CaptureWorker (multiprocessing.Process) and gunicorn/Flask can connect as
+clients without ever touching the camera directly.
+
+Wire protocol (Unix stream socket, JSON-line):
+  Client sends: {"cmd": "...", ...}\n
+  Daemon replies: {"ok": true, ...}\n   or  {"ok": false, "error": "..."}\n
+
+Shared memory layout (name = "indi_allsky_frame"):
+  [0:8]       uint64  sequence counter
+  [8:12]      uint32  width
+  [12:16]     uint32  height
+  [16:20]     uint32  channels
+  [20:24]     uint32  jpeg_len
+  [24:24+ML]  JPEG bytes for streaming (max 2MB)
+  After JPEG region: raw frame path (UTF-8, null-terminated, 512 bytes)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import select
+import socket
+import struct
+import threading
+import time
+import traceback
+from multiprocessing import shared_memory
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+SOCK_PATH = "/run/indi-allsky/picamera2.sock"
+SHM_NAME = "indi_allsky_frame"
+SHM_HEADER = 24          # seq(8) + w(4) + h(4) + ch(4) + jpeg_len(4)
+SHM_JPEG_MAX = 2 * 1024 * 1024  # 2 MB for stream JPEG
+SHM_PATH_OFFSET = SHM_HEADER + SHM_JPEG_MAX
+SHM_PATH_SIZE = 512
+SHM_TOTAL = SHM_PATH_OFFSET + SHM_PATH_SIZE
+
+
+class Picamera2Daemon:
+    """Camera daemon that owns the Picamera2 instance.
+
+    Start with :meth:`run` (blocking) or :meth:`start` (background thread).
+    """
+
+    def __init__(
+        self,
+        camera_num: int = 0,
+        stream_width: int = 1920,
+        stream_height: int = 1080,
+        stream_quality: int = 75,
+    ) -> None:
+        self._camera_num = camera_num
+        self._stream_width = stream_width
+        self._stream_height = stream_height
+        self._stream_quality = stream_quality
+
+        self._picam2: Any = None
+        self._sensor_info: dict = {}
+        self._metadata: dict = {}
+        self._frame_count: int = 0
+        self._stop = threading.Event()
+
+        self._controls_lock = threading.Lock()
+        self._pending_controls: dict[str, Any] = {}
+
+        # Shared memory for frame distribution
+        self._shm: Optional[shared_memory.SharedMemory] = None
+
+        # Latest full-res frame path (written to temp file for capture worker)
+        self._latest_frame_path: str = ""
+        self._frame_lock = threading.Lock()
+        self._frame_event = threading.Event()
+
+        # For DNG capture requests
+        self._dng_request: Optional[dict] = None
+        self._dng_result: Optional[dict] = None
+        self._dng_event = threading.Event()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> threading.Thread:
+        """Start the daemon in a background thread."""
+        t = threading.Thread(target=self.run, name="picamera2-daemon", daemon=True)
+        t.start()
+        return t
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def run(self) -> None:
+        """Main entry point (blocking)."""
+        try:
+            self._init_camera()
+            self._init_shm()
+            self._start_socket_server()
+        except Exception:
+            logger.exception("Picamera2 daemon failed to start")
+            raise
+        finally:
+            self._cleanup()
+
+    # ------------------------------------------------------------------
+    # Camera init
+    # ------------------------------------------------------------------
+
+    def _init_camera(self) -> None:
+        from picamera2 import Picamera2
+
+        self._picam2 = Picamera2(self._camera_num)
+
+        # Detect sensor
+        props = self._picam2.camera_properties
+        sensor_name = props.get("Model", "unknown")
+        pixel_size = props.get("UnitCellSize", (0, 0))
+        pixel_um = pixel_size[0] / 1000.0 if pixel_size[0] else 0
+
+        # Configure: main (RGB for processing) + raw (for DNG)
+        config = self._picam2.create_still_configuration(
+            main={"format": "RGB888"},
+            buffer_count=2,
+        )
+        self._picam2.configure(config)
+        self._picam2.start()
+
+        # Read sensor limits from controls
+        controls = self._picam2.camera_controls
+        gain_info = controls.get("AnalogueGain", (1.0, 1.0, None))
+        exp_info = controls.get("ExposureTime", (1, 1000000, None))
+
+        sensor_config = self._picam2.camera_configuration()
+        main_cfg = sensor_config.get("main", {})
+        w = main_cfg.get("size", (0, 0))[0]
+        h = main_cfg.get("size", (0, 0))[1]
+
+        cfa_info = props.get("ColorFilterArrangement")
+        cfa_map = {0: "RGGB", 1: "GRBG", 2: "GBRG", 3: "BGGR"}
+        cfa = cfa_map.get(cfa_info, "RGGB")
+
+        self._sensor_info = {
+            "sensor_name": sensor_name,
+            "width": w,
+            "height": h,
+            "pixel": pixel_um,
+            "min_gain": float(gain_info[0]),
+            "max_gain": float(gain_info[1]),
+            "min_exposure": float(exp_info[0]) / 1e6,
+            "max_exposure": float(exp_info[1]) / 1e6,
+            "cfa": cfa,
+            "bit_depth": 10,  # most libcamera sensors are 10-bit raw
+        }
+
+        logger.info(
+            "Picamera2 daemon: sensor=%s %dx%d gain=%.1f-%.1f exp=%.6f-%.1fs",
+            sensor_name, w, h,
+            self._sensor_info["min_gain"], self._sensor_info["max_gain"],
+            self._sensor_info["min_exposure"], self._sensor_info["max_exposure"],
+        )
+
+    # ------------------------------------------------------------------
+    # Shared memory
+    # ------------------------------------------------------------------
+
+    def _init_shm(self) -> None:
+        try:
+            old = shared_memory.SharedMemory(name=SHM_NAME)
+            old.close()
+            old.unlink()
+        except FileNotFoundError:
+            pass
+
+        self._shm = shared_memory.SharedMemory(
+            name=SHM_NAME, create=True, size=SHM_TOTAL,
+        )
+        # Make shm world-readable so gunicorn/Flask workers can read frames
+        shm_path = f"/dev/shm/{SHM_NAME}"
+        try:
+            os.chmod(shm_path, 0o666)
+        except OSError:
+            pass
+        logger.info("Shared memory created: %s (%d bytes)", SHM_NAME, SHM_TOTAL)
+
+    def _publish_frame(self, jpeg_bytes: bytes, frame_path: str) -> None:
+        """Write a JPEG frame + metadata into shared memory."""
+        if self._shm is None:
+            return
+        buf = self._shm.buf
+        jpeg_len = min(len(jpeg_bytes), SHM_JPEG_MAX)
+        w = self._sensor_info.get("width", 0)
+        h = self._sensor_info.get("height", 0)
+
+        # Header
+        struct.pack_into("<QIIiI", buf, 0,
+                         self._frame_count, w, h, 3, jpeg_len)
+        # JPEG data
+        buf[SHM_HEADER:SHM_HEADER + jpeg_len] = jpeg_bytes[:jpeg_len]
+        # Frame path
+        path_bytes = frame_path.encode("utf-8")[:SHM_PATH_SIZE - 1] + b"\x00"
+        buf[SHM_PATH_OFFSET:SHM_PATH_OFFSET + len(path_bytes)] = path_bytes
+
+    # ------------------------------------------------------------------
+    # Grab loop
+    # ------------------------------------------------------------------
+
+    def _grab_loop(self) -> None:
+        """Daemon thread: continuous frame grab from picamera2."""
+        try:
+            import cv2
+        except ImportError:
+            cv2 = None
+
+        while not self._stop.is_set():
+            try:
+                # Apply pending controls
+                with self._controls_lock:
+                    if self._pending_controls:
+                        self._picam2.set_controls(dict(self._pending_controls))
+                        self._pending_controls.clear()
+
+                # Handle DNG capture request
+                if self._dng_request is not None:
+                    self._handle_dng_capture()
+                    continue
+
+                # Grab frame
+                array = self._picam2.capture_array("main")
+                metadata = self._picam2.capture_metadata()
+
+                self._metadata = metadata
+                self._frame_count += 1
+
+                # Save full-res frame to temp file for capture worker
+                frame_path = f"/tmp/indi_allsky_frame_{self._frame_count}.npy"
+                np.save(frame_path, array)
+
+                # Clean up old frame file
+                old_path = self._latest_frame_path
+                with self._frame_lock:
+                    self._latest_frame_path = frame_path
+                    self._frame_event.set()
+                if old_path and old_path != frame_path:
+                    try:
+                        os.unlink(old_path)
+                    except OSError:
+                        pass
+
+                # Encode stream JPEG
+                if cv2 is not None:
+                    stream_frame = cv2.resize(
+                        array,
+                        (self._stream_width, self._stream_height),
+                        interpolation=cv2.INTER_AREA,
+                    )
+                    # RGB → BGR for cv2
+                    stream_bgr = cv2.cvtColor(stream_frame, cv2.COLOR_RGB2BGR)
+                    ok, jpeg_buf = cv2.imencode(
+                        ".jpg", stream_bgr,
+                        [cv2.IMWRITE_JPEG_QUALITY, self._stream_quality],
+                    )
+                    if ok:
+                        self._publish_frame(bytes(jpeg_buf), frame_path)
+
+            except Exception:
+                logger.exception("Grab loop error")
+                time.sleep(1.0)
+
+    def _handle_dng_capture(self) -> None:
+        """Handle a DNG capture request from the control socket."""
+        req = self._dng_request
+        self._dng_request = None
+        try:
+            output_path = req.get("path", "/tmp/indi_allsky_capture.dng")
+            self._picam2.capture_file(output_path, format="dng")
+            self._dng_result = {"ok": True, "path": output_path}
+        except Exception as e:
+            self._dng_result = {"ok": False, "error": str(e)}
+        self._dng_event.set()
+
+    # ------------------------------------------------------------------
+    # Control socket
+    # ------------------------------------------------------------------
+
+    def _start_socket_server(self) -> None:
+        """Listen for control commands on a Unix socket."""
+        sock_dir = os.path.dirname(SOCK_PATH)
+        os.makedirs(sock_dir, exist_ok=True)
+        if os.path.exists(SOCK_PATH):
+            os.unlink(SOCK_PATH)
+
+        # Start grab loop in background
+        grab_thread = threading.Thread(
+            target=self._grab_loop, name="picam2-grab", daemon=True,
+        )
+        grab_thread.start()
+
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        srv.bind(SOCK_PATH)
+        os.chmod(SOCK_PATH, 0o666)
+        srv.listen(8)
+        srv.settimeout(1.0)
+
+        logger.info("Picamera2 daemon listening on %s", SOCK_PATH)
+
+        while not self._stop.is_set():
+            try:
+                readable, _, _ = select.select([srv], [], [], 1.0)
+            except (select.error, OSError):
+                break
+            if not readable:
+                continue
+            try:
+                conn, _ = srv.accept()
+            except socket.timeout:
+                continue
+            threading.Thread(
+                target=self._handle_client,
+                args=(conn,),
+                daemon=True,
+            ).start()
+
+        srv.close()
+        if os.path.exists(SOCK_PATH):
+            os.unlink(SOCK_PATH)
+
+    def _handle_client(self, conn: socket.socket) -> None:
+        """Handle one client connection (may send multiple commands)."""
+        conn.settimeout(30.0)
+        buf = b""
+        try:
+            while not self._stop.is_set():
+                try:
+                    data = conn.recv(4096)
+                except socket.timeout:
+                    continue
+                if not data:
+                    break
+                buf += data
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    try:
+                        cmd = json.loads(line)
+                        resp = self._dispatch(cmd)
+                    except Exception as e:
+                        resp = {"ok": False, "error": str(e)}
+                    conn.sendall(json.dumps(resp).encode() + b"\n")
+        except Exception:
+            pass
+        finally:
+            conn.close()
+
+    def _dispatch(self, cmd: dict) -> dict:
+        """Route a command to the appropriate handler."""
+        action = cmd.get("cmd", "")
+
+        if action == "get_sensor_info":
+            return {"ok": True, **self._sensor_info}
+
+        elif action == "get_metadata":
+            meta = dict(self._metadata)
+            meta["frame_count"] = self._frame_count
+            meta["latest_frame_path"] = self._latest_frame_path
+            return {"ok": True, "metadata": meta}
+
+        elif action == "set_controls":
+            controls: dict[str, Any] = {}
+            if "exposure" in cmd:
+                controls["ExposureTime"] = int(float(cmd["exposure"]) * 1e6)
+                controls["AeEnable"] = False
+            if "gain" in cmd:
+                controls["AnalogueGain"] = float(cmd["gain"])
+                controls["AeEnable"] = False
+            if "awb" in cmd:
+                controls["AwbEnable"] = bool(cmd["awb"])
+            if "ae_enable" in cmd:
+                controls["AeEnable"] = bool(cmd["ae_enable"])
+            if controls:
+                with self._controls_lock:
+                    self._pending_controls.update(controls)
+            return {"ok": True}
+
+        elif action == "capture_still":
+            # Wait for next frame after applying controls
+            if "exposure" in cmd or "gain" in cmd:
+                controls = {}
+                if "exposure" in cmd:
+                    controls["ExposureTime"] = int(float(cmd["exposure"]) * 1e6)
+                    controls["AeEnable"] = False
+                if "gain" in cmd:
+                    controls["AnalogueGain"] = float(cmd["gain"])
+                with self._controls_lock:
+                    self._pending_controls.update(controls)
+
+            # Wait for a fresh frame
+            self._frame_event.clear()
+            if not self._frame_event.wait(timeout=cmd.get("timeout", 120)):
+                return {"ok": False, "error": "Capture timeout"}
+
+            with self._frame_lock:
+                path = self._latest_frame_path
+
+            meta = dict(self._metadata)
+            return {
+                "ok": True,
+                "frame_path": path,
+                "metadata": meta,
+                "frame_count": self._frame_count,
+            }
+
+        elif action == "capture_dng":
+            self._dng_event.clear()
+            self._dng_request = cmd
+            if not self._dng_event.wait(timeout=cmd.get("timeout", 120)):
+                return {"ok": False, "error": "DNG capture timeout"}
+            result = self._dng_result or {"ok": False, "error": "No result"}
+            self._dng_result = None
+            return result
+
+        elif action == "set_binning":
+            level = int(cmd.get("level", 1))
+            width = int(cmd.get("width", 0))
+            height = int(cmd.get("height", 0))
+            if width and height:
+                try:
+                    self._stop_grab()
+                    config = self._picam2.create_still_configuration(
+                        main={"size": (width, height), "format": "RGB888"},
+                        buffer_count=2,
+                    )
+                    self._picam2.configure(config)
+                    self._picam2.start()
+                    self._sensor_info["width"] = width
+                    self._sensor_info["height"] = height
+                    self._restart_grab()
+                    return {"ok": True}
+                except Exception as e:
+                    return {"ok": False, "error": str(e)}
+            return {"ok": True}
+
+        elif action == "set_stream":
+            if "width" in cmd:
+                self._stream_width = int(cmd["width"])
+            if "height" in cmd:
+                self._stream_height = int(cmd["height"])
+            if "quality" in cmd:
+                self._stream_quality = int(cmd["quality"])
+            return {"ok": True}
+
+        elif action == "ping":
+            return {"ok": True, "frame_count": self._frame_count}
+
+        else:
+            return {"ok": False, "error": f"Unknown command: {action}"}
+
+    def _stop_grab(self) -> None:
+        """Temporarily stop camera for reconfiguration."""
+        self._picam2.stop()
+
+    def _restart_grab(self) -> None:
+        """Restart camera after reconfiguration."""
+        self._picam2.start()
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def _cleanup(self) -> None:
+        self._stop.set()
+        if self._picam2 is not None:
+            try:
+                self._picam2.stop()
+                self._picam2.close()
+            except Exception:
+                pass
+        if self._shm is not None:
+            try:
+                self._shm.close()
+                self._shm.unlink()
+            except Exception:
+                pass
+        if os.path.exists(SOCK_PATH):
+            try:
+                os.unlink(SOCK_PATH)
+            except OSError:
+                pass
+
+
+# ------------------------------------------------------------------
+# Client class (used by CaptureWorker and Flask)
+# ------------------------------------------------------------------
+
+class Picamera2Client:
+    """Connect to the picamera2 daemon via Unix socket + shared memory."""
+
+    def __init__(self, sock_path: str = SOCK_PATH) -> None:
+        self._sock_path = sock_path
+        self._sock: Optional[socket.socket] = None
+        self._shm: Optional[shared_memory.SharedMemory] = None
+
+    def connect(self) -> None:
+        if self._sock is not None:
+            return
+        self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._sock.connect(self._sock_path)
+        self._sock.settimeout(120.0)
+
+    def close(self) -> None:
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except Exception:
+                pass
+            self._sock = None
+        if self._shm is not None:
+            try:
+                self._shm.close()
+            except Exception:
+                pass
+            self._shm = None
+
+    def _send(self, cmd: dict) -> dict:
+        self.connect()
+        msg = json.dumps(cmd).encode() + b"\n"
+        self._sock.sendall(msg)
+        # Read response line
+        buf = b""
+        while b"\n" not in buf:
+            data = self._sock.recv(4096)
+            if not data:
+                raise ConnectionError("Daemon closed connection")
+            buf += data
+        line = buf.split(b"\n", 1)[0]
+        return json.loads(line)
+
+    def ping(self) -> dict:
+        return self._send({"cmd": "ping"})
+
+    def get_sensor_info(self) -> dict:
+        return self._send({"cmd": "get_sensor_info"})
+
+    def get_metadata(self) -> dict:
+        return self._send({"cmd": "get_metadata"})
+
+    def set_controls(self, **kwargs) -> dict:
+        return self._send({"cmd": "set_controls", **kwargs})
+
+    def capture_still(self, exposure: float = None, gain: float = None,
+                      timeout: float = 120) -> dict:
+        cmd: dict[str, Any] = {"cmd": "capture_still", "timeout": timeout}
+        if exposure is not None:
+            cmd["exposure"] = exposure
+        if gain is not None:
+            cmd["gain"] = gain
+        return self._send(cmd)
+
+    def capture_dng(self, path: str, timeout: float = 120) -> dict:
+        return self._send({"cmd": "capture_dng", "path": path, "timeout": timeout})
+
+    def set_binning(self, level: int, width: int, height: int) -> dict:
+        return self._send({"cmd": "set_binning", "level": level,
+                           "width": width, "height": height})
+
+    def set_stream(self, width: int = None, height: int = None,
+                   quality: int = None) -> dict:
+        cmd: dict[str, Any] = {"cmd": "set_stream"}
+        if width is not None:
+            cmd["width"] = width
+        if height is not None:
+            cmd["height"] = height
+        if quality is not None:
+            cmd["quality"] = quality
+        return self._send(cmd)
+
+    # ------------------------------------------------------------------
+    # Shared memory frame reader
+    # ------------------------------------------------------------------
+
+    def _open_shm(self) -> None:
+        if self._shm is None:
+            self._shm = shared_memory.SharedMemory(name=SHM_NAME)
+
+    def get_stream_jpeg(self) -> Optional[tuple[bytes, int]]:
+        """Read the latest JPEG frame from shared memory.
+
+        Returns (jpeg_bytes, sequence_counter) or None.
+        """
+        try:
+            self._open_shm()
+        except FileNotFoundError:
+            return None
+
+        buf = self._shm.buf
+        seq, w, h, ch, jpeg_len = struct.unpack_from("<QIIiI", buf, 0)
+        if jpeg_len <= 0 or jpeg_len > SHM_JPEG_MAX:
+            return None
+        jpeg = bytes(buf[SHM_HEADER:SHM_HEADER + jpeg_len])
+        return jpeg, seq
+
+    def get_frame_path(self) -> Optional[str]:
+        """Read the latest full-res frame path from shared memory."""
+        try:
+            self._open_shm()
+        except FileNotFoundError:
+            return None
+
+        buf = self._shm.buf
+        raw = bytes(buf[SHM_PATH_OFFSET:SHM_PATH_OFFSET + SHM_PATH_SIZE])
+        path = raw.split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+        return path if path else None
+
+
+# ------------------------------------------------------------------
+# Standalone entry point
+# ------------------------------------------------------------------
+
+def main():
+    """Run the daemon as a standalone process."""
+    import sys
+    # Remove this script's directory from sys.path to prevent
+    # indi_allsky/camera/libcamera.py from shadowing the system libcamera package.
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    sys.path = [p for p in sys.path if os.path.abspath(p) != script_dir]
+
+    import argparse
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    parser = argparse.ArgumentParser(description="Picamera2 daemon for indi-allsky")
+    parser.add_argument("--camera", type=int, default=0, help="Camera number")
+    parser.add_argument("--stream-width", type=int, default=1920)
+    parser.add_argument("--stream-height", type=int, default=1080)
+    parser.add_argument("--stream-quality", type=int, default=75)
+    args = parser.parse_args()
+
+    daemon = Picamera2Daemon(
+        camera_num=args.camera,
+        stream_width=args.stream_width,
+        stream_height=args.stream_height,
+        stream_quality=args.stream_quality,
+    )
+    try:
+        daemon.run()
+    except KeyboardInterrupt:
+        daemon.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/indi_allsky/flask/__init__.py
+++ b/indi_allsky/flask/__init__.py
@@ -19,6 +19,7 @@ from .views import bp_allsky  # noqa: E402
 from .auth_views import bp_auth_allsky  # noqa: E402
 from .syncapi_views import bp_syncapi_allsky  # noqa: E402
 from .actionapi_views import bp_actionapi_allsky  # noqa: E402
+from .captureapi_views import bp_captureapi_allsky, register_websocket  # noqa: E402
 
 
 dictConfig({
@@ -100,9 +101,14 @@ def create_app():
     app.register_blueprint(bp_auth_allsky)
     app.register_blueprint(bp_syncapi_allsky)
     app.register_blueprint(bp_actionapi_allsky)
+    app.register_blueprint(bp_captureapi_allsky)
 
     csrf.exempt(bp_syncapi_allsky)  # disable CSRF for syncapi views
     csrf.exempt(bp_actionapi_allsky)  # disable CSRF for actionapi views
+    csrf.exempt(bp_captureapi_allsky)
+
+    # Register WebSocket endpoints (requires flask-sock)
+    register_websocket(app)
 
     db.init_app(app)
     migrate.init_app(app, db, directory=app.config['MIGRATION_FOLDER'])

--- a/indi_allsky/flask/captureapi_views.py
+++ b/indi_allsky/flask/captureapi_views.py
@@ -1,0 +1,698 @@
+import subprocess
+import struct
+import threading
+import time
+import os
+import json
+import io
+
+from flask import Blueprint, jsonify, request, Response, current_app as app
+from flask.views import View
+from flask_login import login_required
+
+try:
+    from flask_sock import Sock
+    _has_flask_sock = True
+except ImportError:
+    _has_flask_sock = False
+
+bp_captureapi_allsky = Blueprint(
+    "captureapi_indi_allsky",
+    __name__,
+    url_prefix="/indi-allsky",
+)
+
+CAPTURE_CMD = "rpicam-still"
+STREAM_CMD = "rpicam-vid"
+CAMERA_ID = 0
+HTDOCS = "/var/www/html/allsky/images"
+DB_PATH = "/var/lib/indi-allsky/indi-allsky.sqlite"
+
+
+# ---------------------------------------------------------------------------
+# Allsky service helpers
+# ---------------------------------------------------------------------------
+
+LOCK_FILE = "/tmp/allsky-stream.lock"
+
+
+def _systemctl(*args):
+    """Run systemctl command, trying sudo (system) first, then --user."""
+    cmd = ["sudo", "systemctl"] + list(args)
+    r = subprocess.run(cmd, capture_output=True, timeout=10)
+    if r.returncode != 0:
+        cmd = ["systemctl", "--user"] + list(args)
+        r = subprocess.run(cmd, capture_output=True, timeout=10)
+    return r
+
+
+def _stop_allsky():
+    """No-op: picamera2 daemon owns the camera; no service contention."""
+    pass
+
+
+def _start_allsky():
+    """No-op: picamera2 daemon owns the camera; no service contention."""
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Single-shot capture (Capture One button)
+# ---------------------------------------------------------------------------
+
+def _capture(output_path, quality=90, width=None, height=None,
+             shutter=None, gain=None, awb=None, brightness=None,
+             contrast=None, saturation=None, sharpness=None,
+             denoise=None, ev=None, awbgains=None):
+    """Capture a single frame via the picamera2 daemon."""
+    from ..camera.picamera2_client import Picamera2Client
+    try:
+        client = Picamera2Client()
+        exposure = shutter / 1e6 if shutter else None
+        result = client.capture_still(exposure=exposure, gain=gain, timeout=30)
+        client.close()
+        if not result.get('ok'):
+            return False, result.get('error', 'Capture failed')
+
+        # Load the numpy frame and save as JPEG
+        import numpy as np
+        try:
+            import cv2
+        except ImportError:
+            return False, "OpenCV not available"
+
+        frame = np.load(result['frame_path'])
+        bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+        cv2.imwrite(output_path, bgr, [cv2.IMWRITE_JPEG_QUALITY, quality])
+        return True, ""
+    except Exception as e:
+        return False, str(e)
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+def _get_config():
+    import sqlite3
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT data FROM config ORDER BY createDate DESC LIMIT 1")
+    row = cur.fetchone()
+    conn.close()
+    if row:
+        return json.loads(row[0]) if isinstance(row[0], str) else row[0]
+    return {}
+
+
+def _save_config(config_data, note="slider update"):
+    import sqlite3
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    now = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
+    cur.execute(
+        "INSERT INTO config (createDate, level, encrypted, note, data) VALUES (?, 'user', 0, ?, ?)",
+        (now, note, json.dumps(config_data)),
+    )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# MJPEG Stream Manager - single rpicam-vid process, multiple clients
+# ---------------------------------------------------------------------------
+
+class MJPEGStreamManager:
+    """Reads JPEG frames from the picamera2 daemon's shared memory.
+
+    No subprocess — the daemon owns the camera and both capture and
+    streaming read from the same shared frame buffer.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._client = None
+        self._frame = None
+        self._frame_event = threading.Event()
+        self._client_count = 0
+        self._settings = {}
+        self._running = False
+        self._metadata = {}
+        self._frame_count = 0
+        self._start_time = 0
+        self._reader_thread = None
+        self._last_seq = -1
+
+    @property
+    def running(self):
+        return self._running
+
+    @property
+    def client_count(self):
+        return self._client_count
+
+    def start(self, settings=None):
+        """Connect to picamera2 daemon shared memory. Returns (ok, error_msg)."""
+        from ..camera.picamera2_client import Picamera2Client
+        with self._lock:
+            if settings is None:
+                settings = {}
+            self._settings = settings
+            self._running = True
+            self._frame_count = 0
+            self._start_time = time.monotonic()
+            self._client = Picamera2Client()
+            self._reader_thread = threading.Thread(
+                target=self._read_frames, daemon=True)
+            self._reader_thread.start()
+        # Wait for first frame (up to 5s)
+        for _ in range(50):
+            if self._frame is not None:
+                return True, ""
+            time.sleep(0.1)
+        if self._running:
+            return True, ""  # daemon running but slow
+        return False, "No frames from picamera2 daemon"
+
+    def stop(self):
+        with self._lock:
+            self._running = False
+            if self._client:
+                self._client.close()
+                self._client = None
+
+    def update_settings(self, settings):
+        """Send updated settings to the daemon. Returns (ok, error_msg)."""
+        self._settings.update(settings)
+        if self._client:
+            try:
+                s = settings
+                if s.get("shutter") or s.get("gain"):
+                    self._client.set_controls(
+                        exposure=float(s["shutter"]) / 1e6 if s.get("shutter") else None,
+                        gain=float(s["gain"]) if s.get("gain") else None,
+                    )
+                if s.get("width") or s.get("height") or s.get("quality"):
+                    self._client.set_stream(
+                        width=int(s["width"]) if s.get("width") else None,
+                        height=int(s["height"]) if s.get("height") else None,
+                        quality=int(s["quality"]) if s.get("quality") else None,
+                    )
+            except Exception:
+                pass
+        return True, ""
+
+    def _read_frames(self):
+        """Poll shared memory for new JPEG frames from the daemon."""
+        while self._running:
+            try:
+                result = self._client.get_stream_jpeg()
+                if result is not None:
+                    jpeg, seq = result
+                    if seq != self._last_seq:
+                        self._last_seq = seq
+                        self._frame = jpeg
+                        self._frame_count += 1
+                        self._frame_event.set()
+                        self._frame_event.clear()
+                # Also update metadata
+                try:
+                    meta_resp = self._client.get_metadata()
+                    if meta_resp.get('ok'):
+                        self._metadata = meta_resp.get('metadata', {})
+                except Exception:
+                    pass
+            except Exception:
+                pass
+            time.sleep(0.03)  # ~30Hz poll
+
+    def get_frame(self, timeout=5.0):
+        if self._frame is not None:
+            return self._frame
+        self._frame_event.wait(timeout=timeout)
+        return self._frame
+
+    def wait_new_frame(self, last_count, timeout=5.0):
+        deadline = time.monotonic() + timeout
+        while self._running and time.monotonic() < deadline:
+            if self._frame_count > last_count and self._frame is not None:
+                return self._frame, self._frame_count
+            time.sleep(0.02)
+        return None, last_count
+
+    def generate(self):
+        """Generator yielding multipart MJPEG frames for a streaming response."""
+        self._client_count += 1
+        try:
+            last_frame = None
+            while self._running:
+                frame = self._frame
+                if frame is not None and frame is not last_frame:
+                    last_frame = frame
+                    yield (b'--frame\r\n'
+                           b'Content-Type: image/jpeg\r\n'
+                           b'Content-Length: ' + str(len(frame)).encode() + b'\r\n'
+                           b'\r\n' + frame + b'\r\n')
+                else:
+                    time.sleep(0.03)
+        finally:
+            self._client_count -= 1
+
+    def get_settings(self):
+        return dict(self._settings)
+
+    def get_metadata(self):
+        """Return latest ISP metadata + stream stats."""
+        meta = dict(self._metadata)
+        elapsed = time.monotonic() - self._start_time if self._start_time else 0
+        meta["_stream"] = {
+            "frames": self._frame_count,
+            "elapsed": round(elapsed, 1),
+            "fps": round(self._frame_count / elapsed, 1) if elapsed > 1 else 0,
+            "clients": self._client_count,
+        }
+        # Normalize common ISP keys
+        if "ExposureTime" in meta:
+            meta["exposure"] = round(meta["ExposureTime"] / 1_000_000, 6)
+        if "AnalogueGain" in meta:
+            meta["gain"] = round(meta["AnalogueGain"], 2)
+        if "SensorTemperature" in meta:
+            meta["sensor_temp"] = meta["SensorTemperature"]
+        if "Lux" in meta:
+            meta["lux"] = round(meta["Lux"], 1)
+        if "ColourTemperature" in meta:
+            meta["colour_temp"] = meta["ColourTemperature"]
+        return meta
+
+
+# Global stream manager instance
+_stream = MJPEGStreamManager()
+
+
+# ---------------------------------------------------------------------------
+# Views
+# ---------------------------------------------------------------------------
+
+class ConfigGetMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        try:
+            cfg = _get_config()
+            ccd = cfg.get("CCD_CONFIG", {})
+            result = {
+                "NIGHT_GAIN": ccd.get("NIGHT", {}).get("GAIN", 0),
+                "MOONMODE_GAIN": ccd.get("MOONMODE", {}).get("GAIN", 0),
+                "DAY_GAIN": ccd.get("DAY", {}).get("GAIN", 0),
+                "CCD_EXPOSURE_MAX": cfg.get("CCD_EXPOSURE_MAX", 30),
+                "CCD_EXPOSURE_DEF": cfg.get("CCD_EXPOSURE_DEF", 5),
+                "TARGET_ADU": cfg.get("TARGET_ADU", 75),
+                "TARGET_ADU_DAY": cfg.get("TARGET_ADU_DAY", 100),
+                "SATURATION_FACTOR": cfg.get("SATURATION_FACTOR", 1.0),
+                "SATURATION_FACTOR_DAY": cfg.get("SATURATION_FACTOR_DAY", 1.0),
+                "GAMMA_CORRECTION": cfg.get("GAMMA_CORRECTION", 1.0),
+                "GAMMA_CORRECTION_DAY": cfg.get("GAMMA_CORRECTION_DAY", 1.0),
+                "SHARPEN_AMOUNT": cfg.get("SHARPEN_AMOUNT", 0.0),
+                "SHARPEN_AMOUNT_DAY": cfg.get("SHARPEN_AMOUNT_DAY", 0.0),
+                "IMAGE_FLIP_V": cfg.get("IMAGE_FLIP_V", False),
+                "IMAGE_FLIP_H": cfg.get("IMAGE_FLIP_H", False),
+                "EXPOSURE_PERIOD": cfg.get("EXPOSURE_PERIOD", 35),
+                "EXPOSURE_PERIOD_DAY": cfg.get("EXPOSURE_PERIOD_DAY", 15),
+            }
+            return jsonify(result), 200
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+
+class ConfigSetMethodView(View):
+    decorators = [login_required]
+    methods = ["POST"]
+
+    def dispatch_request(self):
+        try:
+            updates = request.get_json(force=True)
+            if not updates:
+                return jsonify({"error": "No data"}), 400
+            cfg = _get_config()
+            ccd = cfg.setdefault("CCD_CONFIG", {})
+            key_map = {
+                "NIGHT_GAIN": lambda v: ccd.setdefault("NIGHT", {}).update({"GAIN": float(v)}),
+                "MOONMODE_GAIN": lambda v: ccd.setdefault("MOONMODE", {}).update({"GAIN": float(v)}),
+                "DAY_GAIN": lambda v: ccd.setdefault("DAY", {}).update({"GAIN": float(v)}),
+            }
+            flat_keys = [
+                "CCD_EXPOSURE_MAX", "CCD_EXPOSURE_DEF", "EXPOSURE_PERIOD", "EXPOSURE_PERIOD_DAY",
+                "SATURATION_FACTOR", "SATURATION_FACTOR_DAY",
+                "GAMMA_CORRECTION", "GAMMA_CORRECTION_DAY",
+                "SHARPEN_AMOUNT", "SHARPEN_AMOUNT_DAY",
+            ]
+            int_keys = ["TARGET_ADU", "TARGET_ADU_DAY"]
+            bool_keys = ["IMAGE_FLIP_V", "IMAGE_FLIP_H"]
+            changed = []
+            for k, v in updates.items():
+                if k in key_map:
+                    key_map[k](v)
+                    changed.append(k)
+                elif k in flat_keys:
+                    cfg[k] = float(v)
+                    changed.append(k)
+                elif k in int_keys:
+                    cfg[k] = int(v)
+                    changed.append(k)
+                elif k in bool_keys:
+                    cfg[k] = bool(v)
+                    changed.append(k)
+            if changed:
+                _save_config(cfg, note="live slider: " + ", ".join(changed))
+            return jsonify({"message": "Config updated", "changed": changed}), 200
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+
+class CaptureOneMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        try:
+            dest = os.path.join(HTDOCS, "capture_one.jpg")
+
+            # If stream is running, grab a frame from it (no rpicam-still needed)
+            if _stream.running:
+                frame = _stream.get_frame(timeout=5)
+                if frame is None:
+                    return jsonify({"error": "Stream active but no frame available"}), 500
+                with open(dest, "wb") as f:
+                    f.write(frame)
+                return jsonify({
+                    "url": "/indi-allsky/images/capture_one.jpg?t=" + str(int(time.time())),
+                    "message": "Captured from stream",
+                }), 200
+
+            # No stream running - stop allsky, do a still capture, restart
+            _stop_allsky()
+            ok, err = _capture(dest, quality=90,
+                               shutter=request.args.get("shutter", None, type=int),
+                               gain=request.args.get("gain", None, type=float),
+                               awb=request.args.get("awb", None),
+                               brightness=request.args.get("brightness", None, type=float),
+                               contrast=request.args.get("contrast", None, type=float),
+                               saturation=request.args.get("saturation", None, type=float),
+                               sharpness=request.args.get("sharpness", None, type=float),
+                               awbgains=request.args.get("awbgains", None))
+            _start_allsky()
+
+            if not ok:
+                return jsonify({"error": err}), 500
+            return jsonify({
+                "url": "/indi-allsky/images/capture_one.jpg?t=" + str(int(time.time())),
+                "message": "Captured",
+            }), 200
+        except subprocess.TimeoutExpired:
+            _start_allsky()
+            return jsonify({"error": "Capture timed out"}), 500
+        except Exception as e:
+            _start_allsky()
+            return jsonify({"error": str(e)}), 500
+
+
+class StreamStartMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        settings = {}
+        for key in ["shutter", "gain", "brightness", "contrast",
+                     "saturation", "sharpness", "awb", "awbgains",
+                     "denoise", "framerate"]:
+            val = request.args.get(key, None)
+            if val is not None:
+                settings[key] = val
+        ok, err = _stream.start(settings)
+        if not ok:
+            return jsonify({"error": err}), 500
+        return jsonify({"message": "Stream started",
+                        "clients": _stream.client_count}), 200
+
+
+class StreamStopMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        _stream.stop()
+        return jsonify({"message": "Stream stopped, allsky restarting"}), 200
+
+
+class StreamUpdateMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        """Update stream settings on the fly - restarts rpicam-vid."""
+        settings = {}
+        for key in ["shutter", "gain", "brightness", "contrast",
+                     "saturation", "sharpness", "awb", "awbgains",
+                     "denoise", "framerate"]:
+            val = request.args.get(key, None)
+            if val is not None:
+                settings[key] = val
+        if not _stream.running:
+            return jsonify({"error": "Stream not running"}), 400
+        ok, err = _stream.update_settings(settings)
+        if not ok:
+            return jsonify({"error": err}), 500
+        return jsonify({"message": "Settings updated",
+                        "clients": _stream.client_count}), 200
+
+
+class StreamMJPEGMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        """MJPEG multipart stream - connect <img src> directly to this."""
+        # Wait up to 5s for stream to be ready
+        for _ in range(50):
+            if _stream.running and _stream._frame is not None:
+                break
+            time.sleep(0.1)
+        if not _stream.running:
+            return jsonify({"error": "Stream not running. Start it first."}), 400
+        return Response(
+            _stream.generate(),
+            mimetype='multipart/x-mixed-replace; boundary=frame',
+        )
+
+
+class StreamStatusMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        elapsed = time.monotonic() - _stream._start_time if _stream._start_time else 0
+        return jsonify({
+            "running": _stream.running,
+            "clients": _stream.client_count,
+            "frames": _stream._frame_count,
+            "fps": round(_stream._frame_count / elapsed, 1) if elapsed > 1 else 0,
+            "settings": _stream.get_settings(),
+        }), 200
+
+
+# Keep old endpoints for backwards compat (they still work)
+class LiveStartMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        settings = {}
+        for key in ["shutter", "gain", "brightness", "contrast",
+                     "saturation", "sharpness", "awb", "awbgains", "denoise"]:
+            val = request.args.get(key, None)
+            if val is not None:
+                settings[key] = val
+        ok, err = _stream.start(settings)
+        if not ok:
+            return jsonify({"error": err}), 500
+        return jsonify({"message": "Live mode started (MJPEG stream)"}), 200
+
+
+class LiveStopMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        _stream.stop()
+        return jsonify({"message": "Live mode stopped"}), 200
+
+
+class LiveFrameMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        """Legacy: return latest frame as a single JPEG URL."""
+        if not _stream.running:
+            return jsonify({"error": "Stream not active"}), 400
+        frame = _stream.get_frame(timeout=5)
+        if frame is None:
+            return jsonify({"error": "No frame available"}), 500
+        # Write frame to htdocs for URL access
+        dest = os.path.join(HTDOCS, "live_frame.jpg")
+        with open(dest, "wb") as f:
+            f.write(frame)
+        return jsonify({
+            "url": "/indi-allsky/images/live_frame.jpg?t=" + str(int(time.time())),
+            "message": "Live",
+        }), 200
+
+
+class StreamMetadataMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        """Return live ISP metadata from rpicam-vid (exposure, gain, temp, etc.)."""
+        if not _stream.running:
+            return jsonify({"error": "Stream not running"}), 400
+        return jsonify(_stream.get_metadata()), 200
+
+
+class SensorInfoMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        """Auto-detect camera sensor via picamera2 daemon."""
+        from ..camera.picamera2_client import Picamera2Client
+        try:
+            client = Picamera2Client()
+            info = client.get_sensor_info()
+            client.close()
+            if not info.get("ok"):
+                return jsonify({"error": "Daemon not available"}), 500
+            return jsonify({
+                "sensor": info.get("sensor_name", "unknown"),
+                "label": info.get("sensor_name", "unknown"),
+                "gain_min": info.get("min_gain", 0),
+                "gain_max": info.get("max_gain", 100),
+                "exposure_min": info.get("min_exposure", 0),
+                "exposure_max": info.get("max_exposure", 60),
+                "width": info.get("width", 0),
+                "height": info.get("height", 0),
+                "cfa": info.get("cfa", ""),
+            }), 200
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+
+# ---------------------------------------------------------------------------
+# URL rules
+# ---------------------------------------------------------------------------
+
+bp_captureapi_allsky.add_url_rule("/api/capture_one", view_func=CaptureOneMethodView.as_view("captureapi_capture_one"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/live_start", view_func=LiveStartMethodView.as_view("captureapi_live_start"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/live_stop", view_func=LiveStopMethodView.as_view("captureapi_live_stop"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/live_frame", view_func=LiveFrameMethodView.as_view("captureapi_live_frame"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/stream/start", view_func=StreamStartMethodView.as_view("captureapi_stream_start"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/stream/stop", view_func=StreamStopMethodView.as_view("captureapi_stream_stop"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/stream/update", view_func=StreamUpdateMethodView.as_view("captureapi_stream_update"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/stream/feed.mjpeg", view_func=StreamMJPEGMethodView.as_view("captureapi_stream_feed"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/stream/status", view_func=StreamStatusMethodView.as_view("captureapi_stream_status"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/stream/metadata", view_func=StreamMetadataMethodView.as_view("captureapi_stream_metadata"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/config_get", view_func=ConfigGetMethodView.as_view("captureapi_config_get"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/config_set", view_func=ConfigSetMethodView.as_view("captureapi_config_set"), methods=["POST"])
+bp_captureapi_allsky.add_url_rule("/api/sensor_info", view_func=SensorInfoMethodView.as_view("captureapi_sensor_info"), methods=["GET"])
+
+
+# ---------------------------------------------------------------------------
+# WebSocket stream (requires flask-sock)
+# ---------------------------------------------------------------------------
+
+def register_websocket(app):
+    """Register the WebSocket stream endpoint if flask-sock is available.
+
+    Call this from the Flask app factory after registering blueprints.
+    Wire format per frame (binary message):
+        [4 bytes]  uint32 big-endian — length of JSON header
+        [N bytes]  UTF-8 JSON metadata (ISP values, WB gains, mode, etc.)
+        [rest]     JPEG image data
+
+    This reads directly from the picamera2 daemon's shared memory,
+    so it works regardless of whether the MJPEG stream manager is running.
+    Both capture and streaming share the same camera — no contention.
+    """
+    if not _has_flask_sock:
+        return
+
+    sock = Sock(app)
+
+    @sock.route("/indi-allsky/api/stream/ws")
+    def stream_ws(ws):
+        """WebSocket endpoint: binary frames with per-frame metadata."""
+        from ..camera.picamera2_client import Picamera2Client
+
+        client = Picamera2Client()
+        last_seq = -1
+        frame_count = 0
+        start_time = time.monotonic()
+
+        try:
+            while True:
+                # Read JPEG frame from daemon shared memory
+                result = client.get_stream_jpeg()
+                if result is None:
+                    time.sleep(0.1)
+                    # Send keepalive every 5s
+                    try:
+                        ws.send(b"")
+                    except Exception:
+                        break
+                    continue
+
+                jpeg, seq = result
+                if seq == last_seq:
+                    time.sleep(0.02)  # ~50Hz poll
+                    continue
+                last_seq = seq
+                frame_count += 1
+
+                # Get metadata from daemon
+                meta = {}
+                try:
+                    meta_resp = client.get_metadata()
+                    if meta_resp.get("ok"):
+                        raw_meta = meta_resp.get("metadata", {})
+
+                        # Normalize ISP keys (same format as allsky-indie-ng)
+                        exp_us = raw_meta.get("ExposureTime", 0)
+                        meta["exposure"] = round(exp_us / 1_000_000, 6) if exp_us else 0
+                        meta["gain"] = round(raw_meta.get("AnalogueGain", 0), 2)
+                        meta["lux"] = round(raw_meta.get("Lux", 0), 1)
+                        meta["colour_temp"] = raw_meta.get("ColourTemperature", 0)
+                        meta["sensor_temp"] = raw_meta.get("SensorTemperature")
+                        meta["ae_state"] = raw_meta.get("AeState", -1)
+
+                        # White balance gains (red, blue relative to green)
+                        colour_gains = raw_meta.get("ColourGains", (1.0, 1.0))
+                        if isinstance(colour_gains, (list, tuple)) and len(colour_gains) >= 2:
+                            meta["red_gain"] = round(float(colour_gains[0]), 3)
+                            meta["blue_gain"] = round(float(colour_gains[1]), 3)
+
+                        elapsed = time.monotonic() - start_time
+                        meta["frame"] = frame_count
+                        meta["fps"] = round(frame_count / elapsed, 1) if elapsed > 1 else 0
+                except Exception:
+                    pass
+
+                # Pack: [4-byte JSON length][JSON bytes][JPEG bytes]
+                try:
+                    meta_bytes = json.dumps(meta, separators=(",", ":"), default=str).encode("utf-8")
+                    header = struct.pack(">I", len(meta_bytes))
+                    ws.send(header + meta_bytes + jpeg)
+                except Exception:
+                    break
+        finally:
+            client.close()

--- a/indi_allsky/flask/static/css/allsky_player.css
+++ b/indi_allsky/flask/static/css/allsky_player.css
@@ -1,0 +1,184 @@
+/* AllskyPlayer styles */
+
+.allsky-player {
+  position: relative;
+  width: 100%;
+}
+
+.allsky-player__inline {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border-radius: 6px;
+  background: #111;
+  min-height: 200px;
+}
+
+.allsky-player__img {
+  display: block;
+  width: 100%;
+  max-height: 85vh;
+  object-fit: contain;
+  background: #000;
+}
+
+/* Canvas for WebSocket mode */
+.allsky-player__canvas {
+  display: block;
+  width: 100%;
+  max-height: 85vh;
+  object-fit: contain;
+  background: #000;
+  cursor: pointer;
+}
+
+.allsky-player__offline {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 2;
+}
+
+.allsky-player__offline-title {
+  font-size: 1.1rem;
+  color: #999;
+  margin: 0;
+}
+
+.allsky-player__offline-sub {
+  font-size: 0.85rem;
+  color: #666;
+  margin: 4px 0 0;
+}
+
+/* Info bar */
+.allsky-player__info-bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 12px 6px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent);
+  font-family: monospace;
+  font-size: 11px;
+  color: #ccc;
+  z-index: 3;
+  pointer-events: none;
+}
+
+.allsky-player__info-left,
+.allsky-player__info-right {
+  white-space: nowrap;
+}
+
+/* Hover buttons */
+.allsky-player__hover-btns {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: flex;
+  gap: 6px;
+  opacity: 0;
+  transition: opacity 0.2s;
+  z-index: 4;
+}
+
+.allsky-player__inline:hover .allsky-player__hover-btns {
+  opacity: 1;
+}
+
+.allsky-player__btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: rgba(30, 30, 30, 0.8);
+  color: #aaa;
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+  transition: background 0.15s, color 0.15s;
+}
+
+.allsky-player__btn:hover {
+  background: rgba(60, 60, 60, 0.9);
+  color: #fff;
+}
+
+/* Modal */
+.allsky-player__modal {
+  position: fixed;
+  inset: 0;
+  z-index: 9990;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.92);
+  padding: 16px;
+}
+
+.allsky-player__modal-inner {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 95vw;
+  max-height: 95vh;
+}
+
+.allsky-player__modal-controls {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.allsky-player__modal-info {
+  font-family: monospace;
+  font-size: 11px;
+  color: #ccc;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 4px 10px;
+  border-radius: 4px;
+  backdrop-filter: blur(4px);
+}
+
+.allsky-player__modal-img {
+  max-width: 95vw;
+  max-height: 92vh;
+  object-fit: contain;
+}
+
+/* Canvas in modal for WebSocket mode */
+.allsky-player__modal-canvas {
+  max-width: 95vw;
+  max-height: 92vh;
+  object-fit: contain;
+}
+
+/* Fullscreen overrides */
+.allsky-player__modal-inner:fullscreen {
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.allsky-player__modal-inner:fullscreen .allsky-player__modal-img,
+.allsky-player__modal-inner:fullscreen .allsky-player__modal-canvas {
+  max-width: 100vw;
+  max-height: 100vh;
+}

--- a/indi_allsky/flask/static/js/allsky_player.js
+++ b/indi_allsky/flask/static/js/allsky_player.js
@@ -1,0 +1,476 @@
+/**
+ * AllskyPlayer - Live stream player with WebSocket + MJPEG fallback.
+ *
+ * WebSocket mode: binary frames with metadata header, rendered to <canvas>.
+ * MJPEG fallback: <img src="feed.mjpeg"> when WebSocket not available.
+ *
+ * Usage:
+ *   var player = new AllskyPlayer({
+ *     container: document.getElementById('player-container'),
+ *     wsUrl: '/indi-allsky/api/stream/ws',
+ *     feedUrl: '/indi-allsky/api/stream/feed.mjpeg',
+ *     metadataUrl: '/indi-allsky/api/stream/metadata',
+ *   });
+ *   player.connect();
+ *   player.disconnect();
+ */
+
+(function (window) {
+  "use strict";
+
+  function AllskyPlayer(opts) {
+    this.container = opts.container;
+    this.wsUrl = opts.wsUrl || "/indi-allsky/api/stream/ws";
+    this.feedUrl = opts.feedUrl || "/indi-allsky/api/stream/feed.mjpeg";
+    this.metadataUrl = opts.metadataUrl || "/indi-allsky/api/stream/metadata";
+    this.preferWs = opts.preferWs !== false; // default: try WebSocket first
+    this.onstatuschange = opts.onstatuschange || function () {};
+    this.onmetadata = opts.onmetadata || function () {};
+
+    this._connected = false;
+    this._expanded = false;
+    this._useWs = false; // true when WebSocket is active
+    this._ws = null;
+    this._reconnectTimer = null;
+    this._metaPollTimer = null;
+    this._metadata = null;
+    this._naturalWidth = 0;
+    this._naturalHeight = 0;
+
+    this._build();
+    this._bindEvents();
+  }
+
+  AllskyPlayer.prototype._build = function () {
+    var c = this.container;
+    c.classList.add("allsky-player");
+    c.innerHTML = "";
+
+    // Inline view wrapper
+    var inline = document.createElement("div");
+    inline.className = "allsky-player__inline";
+    c.appendChild(inline);
+    this._inlineWrap = inline;
+
+    // Canvas for WebSocket mode
+    var canvas = document.createElement("canvas");
+    canvas.className = "allsky-player__canvas";
+    canvas.style.display = "none";
+    inline.appendChild(canvas);
+    this._canvas = canvas;
+
+    // Image element for MJPEG fallback
+    var img = document.createElement("img");
+    img.className = "allsky-player__img";
+    img.alt = "Live stream";
+    img.style.display = "none";
+    inline.appendChild(img);
+    this._img = img;
+
+    // Offline overlay
+    var offline = document.createElement("div");
+    offline.className = "allsky-player__offline";
+    offline.innerHTML =
+      '<p class="allsky-player__offline-title">Stream offline</p>' +
+      '<p class="allsky-player__offline-sub">Click Live View to start</p>';
+    inline.appendChild(offline);
+    this._offline = offline;
+
+    // Info bar (bottom)
+    var infoBar = document.createElement("div");
+    infoBar.className = "allsky-player__info-bar";
+    infoBar.innerHTML =
+      '<span class="allsky-player__info-left"></span>' +
+      '<span class="allsky-player__info-right"></span>';
+    inline.appendChild(infoBar);
+    this._infoBar = infoBar;
+    this._infoLeft = infoBar.querySelector(".allsky-player__info-left");
+    this._infoRight = infoBar.querySelector(".allsky-player__info-right");
+
+    // Hover buttons (expand + fullscreen)
+    var btns = document.createElement("div");
+    btns.className = "allsky-player__hover-btns";
+    btns.innerHTML =
+      '<button class="allsky-player__btn" data-action="expand" title="Expand (or double-click)">' +
+      '<svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 3h6m0 0v6m0-6l-7 7M9 21H3m0 0v-6m0 6l7-7"/></svg>' +
+      "</button>" +
+      '<button class="allsky-player__btn" data-action="fullscreen" title="Fullscreen">' +
+      '<svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5"/></svg>' +
+      "</button>";
+    inline.appendChild(btns);
+    this._hoverBtns = btns;
+
+    // Modal overlay (hidden by default)
+    var modal = document.createElement("div");
+    modal.className = "allsky-player__modal";
+    modal.style.display = "none";
+    modal.innerHTML =
+      '<div class="allsky-player__modal-inner">' +
+      '<div class="allsky-player__modal-controls">' +
+      '<span class="allsky-player__modal-info"></span>' +
+      '<button class="allsky-player__btn" data-action="modal-fullscreen" title="Fullscreen">' +
+      '<svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5"/></svg>' +
+      "</button>" +
+      '<button class="allsky-player__btn" data-action="close" title="Close (Esc)">' +
+      '<svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>' +
+      "</button>" +
+      "</div>" +
+      '<canvas class="allsky-player__modal-canvas" style="display:none"></canvas>' +
+      '<img class="allsky-player__modal-img" alt="Live stream expanded" style="display:none">' +
+      "</div>";
+    document.body.appendChild(modal);
+    this._modal = modal;
+    this._modalInner = modal.querySelector(".allsky-player__modal-inner");
+    this._modalCanvas = modal.querySelector(".allsky-player__modal-canvas");
+    this._modalImg = modal.querySelector(".allsky-player__modal-img");
+    this._modalInfo = modal.querySelector(".allsky-player__modal-info");
+  };
+
+  AllskyPlayer.prototype._bindEvents = function () {
+    var self = this;
+
+    // Double-click to expand
+    this._canvas.addEventListener("dblclick", function () {
+      self.expand();
+    });
+    this._img.addEventListener("dblclick", function () {
+      self.expand();
+    });
+
+    // Hover button actions
+    this._hoverBtns.addEventListener("click", function (e) {
+      var btn = e.target.closest("[data-action]");
+      if (!btn) return;
+      var action = btn.dataset.action;
+      if (action === "expand") self.expand();
+      else if (action === "fullscreen") {
+        self.expand();
+        setTimeout(function () {
+          self._goFullscreen(self._modalInner);
+        }, 100);
+      }
+    });
+
+    // Modal actions
+    this._modal.addEventListener("click", function (e) {
+      if (e.target === self._modal) self.collapse();
+      var btn = e.target.closest("[data-action]");
+      if (!btn) return;
+      var action = btn.dataset.action;
+      if (action === "close") self.collapse();
+      else if (action === "modal-fullscreen")
+        self._goFullscreen(self._modalInner);
+    });
+
+    // Escape to close
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && self._expanded) self.collapse();
+    });
+
+    // MJPEG img events
+    this._img.addEventListener("error", function () {
+      if (self._connected && !self._useWs) {
+        self._connected = false;
+        self._showOffline(true);
+        self.onstatuschange(false);
+      }
+    });
+    this._img.addEventListener("load", function () {
+      if (!self._connected && !self._useWs) {
+        self._connected = true;
+        self._showOffline(false);
+        self.onstatuschange(true);
+      }
+    });
+  };
+
+  // ---- Connection ----
+
+  AllskyPlayer.prototype.connect = function () {
+    if (this.preferWs) {
+      this._connectWs();
+    } else {
+      this._connectMjpeg();
+    }
+  };
+
+  AllskyPlayer.prototype.disconnect = function () {
+    this._disconnectWs();
+    this._disconnectMjpeg();
+    this._stopMetaPoll();
+    this._connected = false;
+    this._showOffline(true);
+    this.onstatuschange(false);
+    if (this._expanded) this.collapse();
+  };
+
+  AllskyPlayer.prototype.reconnect = function () {
+    this.disconnect();
+    this.connect();
+  };
+
+  // ---- WebSocket mode ----
+
+  AllskyPlayer.prototype._connectWs = function () {
+    var self = this;
+    if (this._ws && (this._ws.readyState === 0 || this._ws.readyState === 1))
+      return;
+
+    var proto = location.protocol === "https:" ? "wss:" : "ws:";
+    var url = proto + "//" + location.host + this.wsUrl;
+
+    var ws = new WebSocket(url);
+    ws.binaryType = "arraybuffer";
+    this._ws = ws;
+
+    ws.onopen = function () {
+      self._useWs = true;
+      self._connected = true;
+      self._canvas.style.display = "";
+      self._img.style.display = "none";
+      self._showOffline(false);
+      self.onstatuschange(true);
+    };
+
+    ws.onclose = function () {
+      self._connected = false;
+      self.onstatuschange(false);
+      // Fallback to MJPEG or reconnect
+      self._scheduleReconnect();
+    };
+
+    ws.onerror = function () {
+      // WebSocket failed - fall back to MJPEG
+      if (!self._connected) {
+        self._useWs = false;
+        self._connectMjpeg();
+        return;
+      }
+      self._connected = false;
+      self.onstatuschange(false);
+    };
+
+    ws.onmessage = function (event) {
+      if (!(event.data instanceof ArrayBuffer) || event.data.byteLength < 4)
+        return;
+
+      var view = new DataView(event.data);
+      var jsonLen = view.getUint32(0);
+
+      // Parse metadata
+      if (jsonLen > 0 && jsonLen < event.data.byteLength) {
+        try {
+          var jsonBytes = new Uint8Array(event.data, 4, jsonLen);
+          var meta = JSON.parse(new TextDecoder().decode(jsonBytes));
+          self._metadata = meta;
+          self._updateInfoBar(meta);
+          self.onmetadata(meta);
+        } catch (e) {}
+      }
+
+      // JPEG data
+      var jpegOffset = 4 + jsonLen;
+      var jpegData = new Uint8Array(event.data, jpegOffset);
+      if (jpegData.byteLength < 2) return;
+
+      var blob = new Blob([jpegData], { type: "image/jpeg" });
+      var url = URL.createObjectURL(blob);
+      var img = new Image();
+      img.onload = function () {
+        self._naturalWidth = img.naturalWidth;
+        self._naturalHeight = img.naturalHeight;
+
+        // Draw to inline canvas
+        if (self._canvas) {
+          self._canvas.width = img.naturalWidth;
+          self._canvas.height = img.naturalHeight;
+          var ctx = self._canvas.getContext("2d");
+          ctx.drawImage(img, 0, 0);
+        }
+
+        // Draw to modal canvas if expanded
+        if (self._expanded && self._modalCanvas) {
+          self._modalCanvas.width = img.naturalWidth;
+          self._modalCanvas.height = img.naturalHeight;
+          var ctx2 = self._modalCanvas.getContext("2d");
+          ctx2.drawImage(img, 0, 0);
+        }
+
+        URL.revokeObjectURL(url);
+      };
+      img.src = url;
+    };
+  };
+
+  AllskyPlayer.prototype._disconnectWs = function () {
+    if (this._ws) {
+      this._ws.onclose = null;
+      this._ws.onerror = null;
+      this._ws.close();
+      this._ws = null;
+    }
+    this._useWs = false;
+    this._canvas.style.display = "none";
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+  };
+
+  AllskyPlayer.prototype._scheduleReconnect = function () {
+    var self = this;
+    if (this._reconnectTimer) clearTimeout(this._reconnectTimer);
+    this._reconnectTimer = setTimeout(function () {
+      self._connectWs();
+    }, 3000);
+  };
+
+  // ---- MJPEG fallback mode ----
+
+  AllskyPlayer.prototype._connectMjpeg = function () {
+    this._useWs = false;
+    this._canvas.style.display = "none";
+    this._img.style.display = "";
+    this._img.src = this.feedUrl + "?t=" + Date.now();
+    this._showOffline(false);
+    this._startMetaPoll();
+  };
+
+  AllskyPlayer.prototype._disconnectMjpeg = function () {
+    this._img.src = "";
+    this._img.style.display = "none";
+  };
+
+  // ---- Expand / Fullscreen ----
+
+  AllskyPlayer.prototype.expand = function () {
+    this._expanded = true;
+    this._modal.style.display = "";
+    if (this._useWs) {
+      this._modalCanvas.style.display = "";
+      this._modalImg.style.display = "none";
+    } else {
+      this._modalCanvas.style.display = "none";
+      this._modalImg.style.display = "";
+      this._modalImg.src = this.feedUrl + "?t=" + Date.now();
+    }
+  };
+
+  AllskyPlayer.prototype.collapse = function () {
+    this._expanded = false;
+    this._modal.style.display = "none";
+    this._modalImg.src = "";
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(function () {});
+    }
+  };
+
+  AllskyPlayer.prototype._goFullscreen = function (el) {
+    if (!el) return;
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(function () {});
+    } else {
+      el.requestFullscreen().catch(function () {});
+    }
+  };
+
+  AllskyPlayer.prototype._showOffline = function (show) {
+    this._offline.style.display = show ? "" : "none";
+    this._infoBar.style.display = show ? "none" : "";
+  };
+
+  // ---- Metadata polling (MJPEG mode only) ----
+
+  AllskyPlayer.prototype._startMetaPoll = function () {
+    var self = this;
+    this._stopMetaPoll();
+    this._pollMeta();
+    this._metaPollTimer = setInterval(function () {
+      self._pollMeta();
+    }, 1500);
+  };
+
+  AllskyPlayer.prototype._stopMetaPoll = function () {
+    if (this._metaPollTimer) {
+      clearInterval(this._metaPollTimer);
+      this._metaPollTimer = null;
+    }
+  };
+
+  AllskyPlayer.prototype._pollMeta = function () {
+    var self = this;
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", this.metadataUrl, true);
+    xhr.timeout = 3000;
+    xhr.onload = function () {
+      if (xhr.status === 200) {
+        try {
+          var data = JSON.parse(xhr.responseText);
+          self._metadata = data;
+          self._updateInfoBar(data);
+          self.onmetadata(data);
+        } catch (e) {}
+      }
+    };
+    xhr.send();
+  };
+
+  AllskyPlayer.prototype._updateInfoBar = function (meta) {
+    var left = "";
+    var right = "";
+
+    // Left side: exposure, gain, lux
+    if (meta.exposure != null) {
+      left += _formatExp(meta.exposure);
+    }
+    if (meta.gain != null) {
+      left += (left ? " \u00b7 " : "") + "gain " + meta.gain.toFixed(1);
+    }
+    if (meta.lux != null && meta.lux > 0) {
+      left += (left ? " \u00b7 " : "") + meta.lux.toFixed(0) + " lux";
+    }
+
+    // Right side: sensor temp, colour temp, fps, frames
+    if (meta.sensor_temp != null) {
+      right += parseFloat(meta.sensor_temp).toFixed(1) + "\u00b0C";
+    }
+    if (meta.colour_temp != null && meta.colour_temp > 0) {
+      right += (right ? " \u00b7 " : "") + meta.colour_temp + "K";
+    }
+    // Stream stats (from polling endpoint or WebSocket meta)
+    var s = meta._stream || meta;
+    if (s.fps != null) {
+      right += (right ? " \u00b7 " : "") + s.fps + " fps";
+    }
+    if (s.frame != null || s.frames != null) {
+      right += " \u00b7 #" + (s.frame || s.frames || 0);
+    }
+
+    this._infoLeft.textContent = left || "--";
+    this._infoRight.textContent = right || "--";
+
+    // Also update modal info
+    if (this._expanded && this._modalInfo) {
+      this._modalInfo.textContent =
+        left + (left && right ? "  |  " : "") + right;
+    }
+  };
+
+  // ---- Helpers ----
+
+  function _formatExp(v) {
+    if (v == null) return "--";
+    if (v < 0.001) return (v * 1000000).toFixed(0) + "\u00b5s";
+    if (v < 1) return (v * 1000).toFixed(1) + "ms";
+    return v.toFixed(2) + "s";
+  }
+
+  AllskyPlayer.prototype.destroy = function () {
+    this.disconnect();
+    if (this._modal && this._modal.parentNode) {
+      this._modal.parentNode.removeChild(this._modal);
+    }
+  };
+
+  window.AllskyPlayer = AllskyPlayer;
+})(window);

--- a/indi_allsky/flask/static/js/capture_buttons.js
+++ b/indi_allsky/flask/static/js/capture_buttons.js
@@ -1,0 +1,422 @@
+/* indi-allsky live capture controls with MJPEG streaming + config sliders */
+var liveLoopActive = false;
+var configLoaded = false;
+
+/* ---- Toast popup for errors ---- */
+function showToast(msg, type) {
+    type = type || "danger";
+    var toastId = "allsky-toast-" + Date.now();
+    var html = '<div id="' + toastId + '" class="toast align-items-center text-bg-' + type + ' border-0 show" role="alert" '
+        + 'style="position:fixed;top:20px;right:20px;z-index:9999;min-width:350px;max-width:500px">'
+        + '<div class="d-flex"><div class="toast-body" style="white-space:pre-wrap;font-size:0.85rem">' + msg + '</div>'
+        + '<button type="button" class="btn-close btn-close-white me-2 m-auto" onclick="document.getElementById(\'' + toastId + '\').remove()"></button>'
+        + '</div></div>';
+    var container = document.getElementById("allsky-toast-container");
+    if (!container) {
+        container = document.createElement("div");
+        container.id = "allsky-toast-container";
+        container.style.cssText = "position:fixed;top:20px;right:20px;z-index:9999;display:flex;flex-direction:column;gap:8px";
+        document.body.appendChild(container);
+    }
+    container.insertAdjacentHTML("beforeend", html);
+    setTimeout(function() {
+        var el = document.getElementById(toastId);
+        if (el) el.remove();
+    }, 15000);
+}
+
+/* ---- Slider definitions ---- */
+var sliderDefs = [
+    /* Config sliders (saved to indi-allsky config DB) */
+    {id: "NIGHT_GAIN",        label: "Night Gain",       min: 0, max: 22.26, step: 0.5,  dec: 1, group: "config"},
+    {id: "MOONMODE_GAIN",     label: "Moon Gain",        min: 0, max: 22.26, step: 0.5,  dec: 1, group: "config"},
+    {id: "DAY_GAIN",          label: "Day Gain",         min: 0, max: 22.26, step: 0.5,  dec: 1, group: "config"},
+    {id: "CCD_EXPOSURE_MAX",  label: "Exposure Max (s)", min: 0.1, max: 60, step: 0.5,   dec: 1, group: "config"},
+    {id: "CCD_EXPOSURE_DEF",  label: "Exposure Def (s)", min: 0.001, max: 30, step: 0.1, dec: 2, group: "config"},
+    {id: "TARGET_ADU",        label: "Target ADU Night", min: 10, max: 200, step: 5,     dec: 0, group: "config"},
+    {id: "TARGET_ADU_DAY",    label: "Target ADU Day",   min: 10, max: 200, step: 5,     dec: 0, group: "config"},
+    {id: "SATURATION_FACTOR", label: "Saturation",       min: 0, max: 3.0, step: 0.05,   dec: 2, group: "config"},
+    {id: "GAMMA_CORRECTION",  label: "Gamma",            min: 0.1, max: 3.0, step: 0.05, dec: 2, group: "config"},
+    {id: "SHARPEN_AMOUNT",    label: "Sharpen",          min: 0, max: 5.0, step: 0.1,    dec: 1, group: "config"},
+
+    /* Live-only sliders (passed to rpicam-vid, not saved to config) */
+    {id: "live_shutter",    label: "Shutter (us)",  min: 0, max: 30000000, step: 10000, dec: 0, group: "live"},
+    {id: "live_gain",       label: "Gain",          min: 0, max: 22.26,    step: 0.5,   dec: 1, group: "live"},
+    {id: "live_brightness", label: "Brightness",    min: -1.0, max: 1.0,   step: 0.05,  dec: 2, group: "live"},
+    {id: "live_contrast",   label: "Contrast",      min: 0, max: 3.0,      step: 0.1,   dec: 1, group: "live"},
+    {id: "live_saturation", label: "Saturation",    min: 0, max: 3.0,      step: 0.1,   dec: 1, group: "live"},
+    {id: "live_sharpness",  label: "Sharpness",     min: 0, max: 5.0,      step: 0.1,   dec: 1, group: "live"},
+];
+
+/* ---- Build slider UI ---- */
+function buildSliderPanel() {
+    var container = document.getElementById("slider-panel");
+    if (!container) return;
+
+    var html = "";
+
+    /* Config sliders section */
+    html += '<div class="mb-1"><strong class="text-info small">IMX415 Camera Settings</strong> <span class="text-muted small">(Allsky Config)</span>';
+    html += ' <button class="btn btn-outline-warning btn-sm ms-2 py-0 px-1" style="font-size:0.7rem" onclick="saveConfig()">Save</button>';
+    html += ' <button class="btn btn-outline-secondary btn-sm ms-2 py-0 px-1" style="font-size:0.7rem" onclick="loadConfig()">Reload</button>';
+    html += ' <span id="config-status" class="text-muted small ms-2"></span></div>';
+    html += '<div class="text-muted small mb-2" style="font-size:0.7rem">Gain range: 0&ndash;22.26 (analog max). Changes saved here persist and apply after allsky restart.</div>';
+    sliderDefs.forEach(function(s) {
+        if (s.group !== "config") return;
+        html += sliderRow(s);
+    });
+
+    /* Live sliders section */
+    html += '<div class="mt-3 mb-1"><strong class="text-success small">Live Camera Controls</strong> <span class="text-muted small">(rpicam-vid stream)</span>';
+    html += ' <label class="form-check-label text-muted small ms-3"><input type="checkbox" id="chk-manual-exp" class="form-check-input me-1" onchange="toggleManualExposure()">Manual Exposure</label>';
+    html += '</div>';
+    html += '<div class="text-muted small mb-2" style="font-size:0.7rem">Override camera params during Live View. Changes apply instantly (restarts stream). Not saved to config.</div>';
+    sliderDefs.forEach(function(s) {
+        if (s.group !== "live") return;
+        html += sliderRow(s);
+    });
+
+    /* AWB dropdown */
+    html += '<div class="row g-1 mb-1"><div class="col-3 text-end"><label class="form-label text-muted small mb-0">AWB</label></div>';
+    html += '<div class="col-6"><select id="live_awb" class="form-select form-select-sm bg-dark text-light py-0" style="font-size:0.75rem" disabled>';
+    ["auto","incandescent","tungsten","fluorescent","indoor","daylight","cloudy"].forEach(function(m) {
+        html += '<option value="' + m + '"' + (m === "auto" ? " selected" : "") + '>' + m + '</option>';
+    });
+    html += '</select></div></div>';
+
+    /* Denoise dropdown */
+    html += '<div class="row g-1 mb-1"><div class="col-3 text-end"><label class="form-label text-muted small mb-0">Denoise</label></div>';
+    html += '<div class="col-6"><select id="live_denoise" class="form-select form-select-sm bg-dark text-light py-0" style="font-size:0.75rem" disabled>';
+    ["auto","off","cdn_off","cdn_fast","cdn_hq"].forEach(function(m) {
+        html += '<option value="' + m + '"' + (m === "auto" ? " selected" : "") + '>' + m + '</option>';
+    });
+    html += '</select></div></div>';
+
+    /* Framerate */
+    html += '<div class="row g-1 mb-1"><div class="col-3 text-end"><label class="form-label text-muted small mb-0">Framerate</label></div>';
+    html += '<div class="col-6"><select id="live_framerate" class="form-select form-select-sm bg-dark text-light py-0" style="font-size:0.75rem">';
+    [1, 2, 5, 10, 15, 24, 30].forEach(function(f) {
+        html += '<option value="' + f + '"' + (f === 10 ? " selected" : "") + '>' + f + ' fps</option>';
+    });
+    html += '</select></div></div>';
+
+    /* Apply button for live settings */
+    html += '<div class="row g-1 mt-2"><div class="col-3"></div><div class="col-6">';
+    html += '<button class="btn btn-outline-success btn-sm w-100" onclick="applyLiveSettings()" id="btn-apply-live">Apply to Stream</button>';
+    html += '</div></div>';
+
+    container.innerHTML = html;
+
+    /* Disable live sliders initially */
+    sliderDefs.forEach(function(s) {
+        if (s.group === "live") {
+            var el = document.getElementById("slider-" + s.id);
+            if (el) el.disabled = true;
+        }
+    });
+}
+
+function sliderRow(s) {
+    var valId = "val-" + s.id;
+    var sliderId = "slider-" + s.id;
+    var defVal = s.min;
+    if (s.id === "live_contrast") defVal = 1.0;
+    if (s.id === "live_saturation") defVal = 1.0;
+    if (s.id === "live_sharpness") defVal = 1.0;
+
+    var h = '<div class="row g-1 mb-1 align-items-center">';
+    h += '<div class="col-3 text-end"><label class="form-label text-muted small mb-0" for="' + sliderId + '">' + s.label + '</label></div>';
+    h += '<div class="col-6"><input type="range" class="form-range" style="height:16px" id="' + sliderId + '" ';
+    h += 'min="' + s.min + '" max="' + s.max + '" step="' + s.step + '" value="' + defVal + '" ';
+    h += 'oninput="sliderChanged(\'' + s.id + '\')">';
+    h += '</div>';
+    h += '<div class="col-3"><span id="' + valId + '" class="text-light small">' + defVal.toFixed(s.dec) + '</span></div>';
+    h += '</div>';
+    return h;
+}
+
+function sliderChanged(id) {
+    var def = sliderDefs.find(function(s) { return s.id === id; });
+    if (!def) return;
+    var el = document.getElementById("slider-" + id);
+    var val = parseFloat(el.value);
+    document.getElementById("val-" + id).textContent = val.toFixed(def.dec);
+}
+
+function toggleManualExposure() {
+    var manual = document.getElementById("chk-manual-exp").checked;
+    sliderDefs.forEach(function(s) {
+        if (s.group === "live") {
+            var el = document.getElementById("slider-" + s.id);
+            if (el) el.disabled = !manual;
+        }
+    });
+    document.getElementById("live_awb").disabled = !manual;
+    document.getElementById("live_denoise").disabled = !manual;
+}
+
+/* ---- Config load/save ---- */
+function loadConfig() {
+    $.ajax({
+        type: "GET", url: "/indi-allsky/api/config_get", timeout: 10000,
+        success: function(data) {
+            sliderDefs.forEach(function(s) {
+                if (s.group !== "config") return;
+                if (data[s.id] !== undefined) {
+                    var el = document.getElementById("slider-" + s.id);
+                    if (el) {
+                        el.value = data[s.id];
+                        document.getElementById("val-" + s.id).textContent = parseFloat(data[s.id]).toFixed(s.dec);
+                    }
+                }
+            });
+            configLoaded = true;
+            $("#config-status").text("Loaded").fadeIn().delay(2000).fadeOut();
+        },
+        error: function() { $("#config-status").text("Load failed"); },
+    });
+}
+
+function saveConfig() {
+    var payload = {};
+    sliderDefs.forEach(function(s) {
+        if (s.group !== "config") return;
+        var el = document.getElementById("slider-" + s.id);
+        if (el) payload[s.id] = parseFloat(el.value);
+    });
+    $("#config-status").text("Saving...");
+    $.ajax({
+        type: "POST", url: "/indi-allsky/api/config_set",
+        contentType: "application/json", data: JSON.stringify(payload), timeout: 10000,
+        success: function() {
+            $("#config-status").text("Saved! Restart allsky to apply.").fadeIn();
+            setTimeout(function() { $("#config-status").text(""); }, 5000);
+        },
+        error: function() { $("#config-status").text("Save failed"); },
+    });
+}
+
+/* ---- Build live params query string ---- */
+function getLiveParams() {
+    var params = [];
+    var manual = document.getElementById("chk-manual-exp");
+    if (manual && manual.checked) {
+        sliderDefs.forEach(function(s) {
+            if (s.group !== "live") return;
+            var el = document.getElementById("slider-" + s.id);
+            if (!el) return;
+            var val = parseFloat(el.value);
+            var paramName = s.id.replace("live_", "");
+            if (paramName === "shutter" && val > 0) params.push(paramName + "=" + Math.round(val));
+            else if (paramName === "gain" && val > 0) params.push(paramName + "=" + val);
+            else if (paramName === "brightness" && val !== 0) params.push(paramName + "=" + val);
+            else if (paramName === "contrast" && val !== 1.0) params.push(paramName + "=" + val);
+            else if (paramName === "saturation" && val !== 1.0) params.push(paramName + "=" + val);
+            else if (paramName === "sharpness" && val !== 1.0) params.push(paramName + "=" + val);
+        });
+        var awb = document.getElementById("live_awb");
+        if (awb && awb.value !== "auto") params.push("awb=" + awb.value);
+        var denoise = document.getElementById("live_denoise");
+        if (denoise && denoise.value !== "auto") params.push("denoise=" + denoise.value);
+    }
+    var framerate = document.getElementById("live_framerate");
+    if (framerate) params.push("framerate=" + framerate.value);
+    return params.join("&");
+}
+
+/* ---- Apply live settings to running stream ---- */
+function applyLiveSettings() {
+    if (!liveLoopActive) {
+        $("#live-status").text("Start Live View first");
+        setTimeout(function() { $("#live-status").text(""); }, 3000);
+        return;
+    }
+    var params = getLiveParams();
+    $("#live-status").text("Updating stream...");
+    $.ajax({
+        type: "GET", url: "/indi-allsky/api/stream/update?" + params, timeout: 10000,
+        success: function(rdata) {
+            var mode = (typeof player !== "undefined" && player !== null) ? "WebSocket" : "MJPEG";
+            $("#live-status").text("Stream updated (" + (rdata.clients || 0) + " viewers)");
+            setTimeout(function() { if (liveLoopActive) $("#live-status").text("Live - " + mode + " stream"); }, 3000);
+            // Reconnect the player to pick up the restarted stream
+            if (typeof player !== "undefined" && player !== null) {
+                player.reconnect();
+            } else {
+                refreshStreamSrc();
+            }
+        },
+        error: function(xhr) {
+            var msg = xhr.responseJSON ? xhr.responseJSON.error : "Update failed (HTTP " + xhr.status + ")";
+            $("#live-status").text("Update failed");
+            showToast("Stream update failed:\n" + msg, "danger");
+        },
+    });
+}
+
+/* ---- Capture One ---- */
+function captureOne() {
+    var btn = document.getElementById("btn-capture-one");
+    btn.disabled = true;
+    btn.textContent = "Capturing...";
+    $("#live-status").text("Capturing...");
+    var params = getLiveParams();
+    $.ajax({
+        type: "GET", url: "/indi-allsky/api/capture_one?" + params, timeout: 45000,
+        success: function(rdata) {
+            btn.disabled = false; btn.textContent = "Capture One";
+            $("#live-status").text("");
+            if (rdata.url) {
+                var img = new Image();
+                img.onload = function() {
+                    $("#latest-image").attr("src", this.src);
+                    $("#loop-image").attr("src", this.src);
+                };
+                img.src = rdata.url;
+                $("#message").html("Manual capture complete");
+            }
+            // If stream was running, it will be restarted by the backend
+            if (liveLoopActive) {
+                setTimeout(function() { refreshStreamSrc(); }, 1000);
+            }
+        },
+        error: function(xhr) {
+            btn.disabled = false; btn.textContent = "Capture One";
+            var msg = xhr.responseJSON ? xhr.responseJSON.error : "Capture failed (HTTP " + xhr.status + ")";
+            $("#live-status").text("Capture failed");
+            showToast("Capture failed:\n" + msg, "danger");
+        },
+    });
+}
+
+/* ---- Live View (MJPEG stream) ---- */
+function toggleLiveLoop() {
+    if (liveLoopActive) { stopLive(); } else { startLive(); }
+}
+
+function refreshStreamSrc() {
+    // Use AllskyPlayer if available (WebSocket + canvas player)
+    if (typeof player !== "undefined" && player !== null) {
+        var playerEl = document.getElementById("allsky-player-container");
+        var staticImg = document.getElementById("latest-image");
+        if (playerEl) playerEl.style.display = "";
+        if (staticImg) staticImg.style.display = "none";
+        player.connect();
+        return;
+    }
+    // Fallback: plain MJPEG <img>
+    var streamUrl = "/indi-allsky/api/stream/feed.mjpeg?t=" + Date.now();
+    var target = document.getElementById("latest-image") || document.getElementById("loop-image");
+    if (target) {
+        target.onerror = function() {
+            if (liveLoopActive) {
+                showToast("MJPEG stream disconnected. The stream may have died.\nTry clicking Live View again.", "warning");
+                $("#live-status").text("Stream disconnected");
+            }
+        };
+        target.src = streamUrl;
+    }
+}
+
+function startLive(retryCount) {
+    retryCount = retryCount || 0;
+    $("#btn-live-loop").text("Starting...").prop("disabled", true);
+    $("#live-status").text(retryCount > 0 ? "Retrying (" + retryCount + ")..." : "Stopping allsky, starting stream...");
+    var params = getLiveParams();
+    $.ajax({
+        type: "GET", url: "/indi-allsky/api/stream/start?" + params, timeout: 30000,
+        success: function(rdata) {
+            liveLoopActive = true;
+            $("#btn-live-loop").text("Stop Live").removeClass("btn-outline-success").addClass("btn-success").prop("disabled", false);
+            var mode = (typeof player !== "undefined" && player !== null) ? "WebSocket" : "MJPEG";
+            $("#live-status").text("Live - " + mode + " stream");
+            refreshStreamSrc();
+        },
+        error: function(xhr) {
+            var msg = xhr.responseJSON ? xhr.responseJSON.error : "Failed to start stream (HTTP " + xhr.status + ")";
+            if (retryCount < 2) {
+                $("#live-status").text("Failed, retrying in 2s...");
+                showToast("Stream start failed (attempt " + (retryCount + 1) + "/3):\n" + msg + "\n\nRetrying...", "warning");
+                setTimeout(function() { startLive(retryCount + 1); }, 2000);
+            } else {
+                $("#btn-live-loop").text("Live View").prop("disabled", false);
+                $("#live-status").text("Failed to start stream");
+                showToast("Stream failed after 3 attempts:\n" + msg, "danger");
+            }
+        },
+    });
+}
+
+function stopLive() {
+    liveLoopActive = false;
+    $("#btn-live-loop").text("Stopping...").prop("disabled", true);
+    // Disconnect player and show static image
+    if (typeof player !== "undefined" && player !== null) {
+        player.disconnect();
+        var playerEl = document.getElementById("allsky-player-container");
+        var staticImg = document.getElementById("latest-image");
+        if (playerEl) playerEl.style.display = "none";
+        if (staticImg) staticImg.style.display = "";
+    } else {
+        var target = document.getElementById("latest-image") || document.getElementById("loop-image");
+        if (target) target.src = "";
+    }
+    $.ajax({
+        type: "GET", url: "/indi-allsky/api/stream/stop", timeout: 20000,
+        success: function() {
+            $("#btn-live-loop").text("Live View").removeClass("btn-success").addClass("btn-outline-success").prop("disabled", false);
+            $("#live-status").text("Allsky restarting...");
+            setTimeout(function() { $("#live-status").text(""); }, 5000);
+        },
+        error: function() {
+            $("#btn-live-loop").text("Live View").removeClass("btn-success").addClass("btn-outline-success").prop("disabled", false);
+            $("#live-status").text("");
+        },
+    });
+}
+
+/* ---- Auto-detect sensor and adjust gain ranges ---- */
+function detectSensor() {
+    $.ajax({
+        type: "GET", url: "/indi-allsky/api/sensor_info", timeout: 10000,
+        success: function(data) {
+            var gainMax = data.gain_max || 16.0;
+            var gainMin = data.gain_min || 0;
+            var label = data.label || data.sensor || "Camera";
+            // Update config section header
+            var hdr = document.querySelector("#slider-panel .text-info");
+            if (hdr) hdr.textContent = label + " Settings";
+            // Update gain slider ranges
+            ["NIGHT_GAIN", "MOONMODE_GAIN", "DAY_GAIN", "live_gain"].forEach(function(id) {
+                var el = document.getElementById("slider-" + id);
+                if (el) {
+                    el.min = gainMin;
+                    el.max = gainMax;
+                    // Update the def in sliderDefs too
+                    var def = sliderDefs.find(function(s) { return s.id === id; });
+                    if (def) { def.min = gainMin; def.max = gainMax; }
+                }
+            });
+        },
+    });
+}
+
+/* ---- Init ---- */
+$(document).ready(function() {
+    buildSliderPanel();
+    detectSensor();
+    loadConfig();
+    // Check if stream is already running (e.g. another tab started it)
+    $.ajax({
+        type: "GET", url: "/indi-allsky/api/stream/status", timeout: 5000,
+        success: function(data) {
+            if (data.running) {
+                liveLoopActive = true;
+                $("#btn-live-loop").text("Stop Live").removeClass("btn-outline-success").addClass("btn-success");
+                var mode = (typeof player !== "undefined" && player !== null) ? "WebSocket" : "MJPEG";
+                $("#live-status").text("Live - " + mode + " stream (" + (data.clients || 0) + " viewers)");
+                refreshStreamSrc();
+            }
+        },
+    });
+});

--- a/indi_allsky/flask/templates/index_img.html
+++ b/indi_allsky/flask/templates/index_img.html
@@ -4,6 +4,7 @@
 
 {% block head %}
 <meta charset="UTF-8">
+<link rel="stylesheet" href="{{ url_for('indi_allsky.static', filename='css/allsky_player.css', v='1') }}">
 <style>
 .fit {
     max-width: 100%;
@@ -28,6 +29,7 @@ var camera_id = {{ camera_id }};
 var refreshInterval = {{ refreshInterval | int }};
 var night = {{ night }};
 var fullscreen = false;  //initial state
+var player = null;  // AllskyPlayer instance
 
 function init() {
     loadNextImage();
@@ -43,9 +45,12 @@ async function loop() {
 
     img = new Image();
     img.onload = function() {
-        $('#latest-image').attr({
-            'src': this.src,
-        });
+        // Only update the static image if player is not in live mode
+        if (!liveLoopActive) {
+            $('#latest-image').attr({
+                'src': this.src,
+            });
+        }
     };
 
 
@@ -56,14 +61,18 @@ async function loop() {
 
 
 function showImage(entry) {
-    console.log('Showing image ' + entry["url"]);
-    img.src = entry["url"];
+    if (!liveLoopActive) {
+        console.log('Showing image ' + entry["url"]);
+        img.src = entry["url"];
+    }
 }
 
 
 function loadNextImage() {
-    console.log('Loading next image');
-    loadJS("{{ url_for(latest_image_view) }}", {'camera_id' : camera_id, 'limit_s' : max_age, 'night' : night}, function() {});
+    if (!liveLoopActive) {
+        console.log('Loading next image');
+        loadJS("{{ url_for(latest_image_view) }}", {'camera_id' : camera_id, 'limit_s' : max_age, 'night' : night}, function() {});
+    }
     setTimeout(loadNextImage, refreshInterval);
 }
 
@@ -150,14 +159,39 @@ function closeFullscreen() {
 
 
 $( document ).ready(function() {
+    // Initialize AllskyPlayer on the player container
+    var playerContainer = document.getElementById('allsky-player-container');
+    if (playerContainer) {
+        player = new AllskyPlayer({
+            container: playerContainer,
+            wsUrl: '/indi-allsky/api/stream/ws',
+            feedUrl: '/indi-allsky/api/stream/feed.mjpeg',
+            metadataUrl: '/indi-allsky/api/stream/metadata',
+            preferWs: true,
+            onstatuschange: function(online) {
+                if (!online && liveLoopActive) {
+                    $('#live-status').text('Stream disconnected');
+                }
+            },
+            onmetadata: function(meta) {
+                // Could update dashboard elements here
+            },
+        });
+    }
+
+    // Click on static image for fullscreen (when not in live mode)
     $('#latest-image').on("click", function() {
-        goFullscreen(this);
+        if (!liveLoopActive) {
+            goFullscreen(this);
+        }
     });
 
     init();
 });
 
 </script>
+<script src="{{ url_for('indi_allsky.static', filename='js/allsky_player.js', v='1') }}"></script>
+<script src="{{ url_for('indi_allsky.static', filename='js/capture_buttons.js', v='8') }}"></script>
 {% endblock %}
 
 {% block content %}
@@ -165,8 +199,24 @@ $( document ).ready(function() {
     <div class="row">
         <div class="text-muted text-center" id="message">Loading...</div>
     </div>
+    <div class="row mb-2">
+        <div class="col-12 text-center">
+            <button id="btn-capture-one" class="btn btn-outline-info btn-sm me-2" onclick="captureOne()">Capture One</button>
+            <button id="btn-live-loop" class="btn btn-outline-success btn-sm me-2" onclick="toggleLiveLoop()">Live View</button>
+            <button class="btn btn-outline-secondary btn-sm me-2" data-bs-toggle="collapse" data-bs-target="#slider-panel-wrap">Camera Settings</button>
+            <span id="live-status" class="text-muted small"></span>
+        </div>
+    </div>
+    <div class="collapse" id="slider-panel-wrap">
+        <div class="card card-body bg-dark border-secondary p-2 mb-2">
+            <div id="slider-panel"></div>
+        </div>
+    </div>
     <div class="row h-75 align-items-center">
         <div class="col-12 text-center">
+            <!-- AllskyPlayer container (used during live mode) -->
+            <div id="allsky-player-container" style="display:none"></div>
+            <!-- Static latest image (shown when not in live mode) -->
             <img id="latest-image" class="fit">
         </div>
     </div>

--- a/indi_allsky/flask/templates/loop_img.html
+++ b/indi_allsky/flask/templates/loop_img.html
@@ -244,6 +244,19 @@ $( document ).ready(function() {
 <div class="row">
     <div class="text-muted text-center" id="message"></div>
 </div>
+    <div class="row mb-2">
+        <div class="col-12 text-center">
+            <button id="btn-capture-one" class="btn btn-outline-info btn-sm me-2" onclick="captureOne()">Capture One</button>
+            <button id="btn-live-loop" class="btn btn-outline-success btn-sm me-2" onclick="toggleLiveLoop()">Live View</button>
+            <button class="btn btn-outline-secondary btn-sm me-2" data-bs-toggle="collapse" data-bs-target="#slider-panel-wrap">Camera Settings</button>
+            <span id="live-status" class="text-muted small"></span>
+        </div>
+    </div>
+    <div class="collapse" id="slider-panel-wrap">
+        <div class="card card-body bg-dark border-secondary p-2 mb-2">
+            <div id="slider-panel"></div>
+        </div>
+    </div>
 <div class="row h-75 align-items-center">
     <div class="col-12 text-center">
         <img id="loop-image" class="fit">
@@ -286,4 +299,5 @@ $("#ROCK_CHECKBOX").on("change", function() {
 
 </script>
 
+<script src="{{ url_for('indi_allsky.static', filename='js/capture_buttons.js', v='7') }}"></script>
 {% endblock %}

--- a/indi_allsky/wsgi.py
+++ b/indi_allsky/wsgi.py
@@ -10,6 +10,20 @@ import logging
 from indi_allsky.flask import create_app
 application = create_app()
 
+
+class _RootRedirect:
+    """WSGI middleware: redirect / to /indi-allsky/ when no reverse proxy."""
+    def __init__(self, app):
+        self._app = app
+    def __call__(self, environ, start_response):
+        if environ.get("PATH_INFO", "/") == "/":
+            start_response("302 Found", [("Location", "/indi-allsky/")])
+            return [b""]
+        return self._app(environ, start_response)
+
+
 gunicorn_logger = logging.getLogger('gunicorn.error')
 application.logger.handlers = gunicorn_logger.handlers
 application.logger.setLevel(gunicorn_logger.level)
+
+application = _RootRedirect(application)

--- a/requirements/requirements_latest.txt
+++ b/requirements/requirements_latest.txt
@@ -43,6 +43,7 @@ Flask-SQLAlchemy >= 3.1.1
 Flask-Migrate >= 4.0.5
 Flask-WTF >= 1.2.1
 Flask-Login >= 0.6.3
+flask-sock >= 0.7.0
 werkzeug >= 3.1.6
 is-safe-url
 certifi >= 2024.7.4

--- a/requirements/requirements_latest_web.txt
+++ b/requirements/requirements_latest_web.txt
@@ -27,6 +27,7 @@ Flask-SQLAlchemy >= 3.1.1
 Flask-Migrate >= 4.0.5
 Flask-WTF >= 1.2.1
 Flask-Login >= 0.6.2
+flask-sock >= 0.7.0
 werkzeug >= 3.1.6
 is-safe-url
 certifi >= 2023.7.22

--- a/service/picamera2-daemon.service
+++ b/service/picamera2-daemon.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Picamera2 Daemon for indi-allsky
+Before=indi-allsky.service
+After=network.target
+
+[Service]
+Type=simple
+User=root
+Group=video
+RuntimeDirectory=indi-allsky
+WorkingDirectory=/home/pi/indi-allsky
+ExecStart=${VENV}/bin/python3 ${INDI_DIR}/indi_allsky/camera/picamera2_daemon.py --camera 0
+Restart=on-failure
+RestartSec=3
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/setup.sh
+++ b/setup.sh
@@ -706,7 +706,7 @@ if [[ "$DISTRO" == "debian_13" ]]; then
         ca-certificates \
         avahi-daemon \
         swig \
-        libatlas-ecmwf-dev \
+         \
         libimath-dev \
         libopenexr-dev \
         libgtk-3-0t64 \


### PR DESCRIPTION
…live stream

Camera daemon (single-process, no contention):
- picamera2_daemon.py: standalone daemon owning Picamera2 instance
  - Continuous grab loop, shared memory (2MB) for JPEG stream
  - Unix socket IPC for controls, capture, metadata, sensor info
- picamera2_client.py: zero-dependency client for capture worker and Flask
- libcamera.py: setCcdExposure uses daemon client instead of rpicam-still
- captureapi_views.py: MJPEGStreamManager reads from daemon shared memory
  - _stop_allsky/_start_allsky removed (no camera contention)
  - SensorInfoMethodView queries daemon
- wsgi.py: root redirect middleware for direct SSL without reverse proxy
- picamera2-daemon.service: systemd unit

WebSocket live stream:
- Flask WebSocket endpoint reads directly from daemon shared memory
  - Binary frame protocol: [4B JSON len][metadata JSON][JPEG data]
  - Metadata: exposure, gain, lux, colour_temp, sensor_temp, WB gains
- AllskyPlayer JS: canvas-based WS player with MJPEG fallback, OSD bar
- AllskyPlayer CSS: info bar, hover buttons, modal, fullscreen
- flask-sock added to requirements

Runs directly on HTTPS/443 via gunicorn SSL — no Apache/nginx needed.