### PR TITLE
Replace rpicam-still/rpicam-vid with picamera2 daemon, add WebSocket …

### DIFF
--- a/indi_allsky/camera/camera_backend.py
+++ b/indi_allsky/camera/camera_backend.py
@@ -1,0 +1,672 @@
+"""Camera backend abstraction for the picamera2 daemon.
+
+Provides a common interface for both picamera2 (preferred on Pi)
+and raw libcamera Python bindings (fallback / non-Pi).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import mmap
+import os
+import re
+import selectors
+import shutil
+import struct
+import subprocess
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class CameraBackend:
+    """Abstract camera backend — subclass for each library."""
+
+    def __init__(self, camera_num: int = 0) -> None:
+        self._camera_num = camera_num
+        self.sensor_info: dict[str, Any] = {}
+
+    def start(self) -> None:
+        raise NotImplementedError
+
+    def stop(self) -> None:
+        raise NotImplementedError
+
+    def grab_frame(self) -> tuple[np.ndarray, dict]:
+        """Grab one frame. Returns (bgr_array, metadata_dict)."""
+        raise NotImplementedError
+
+    def set_controls(self, controls: dict[str, Any]) -> None:
+        raise NotImplementedError
+
+    def capture_dng(self, path: str) -> None:
+        raise NotImplementedError
+
+
+class Picamera2Backend(CameraBackend):
+    """Uses the picamera2 library (preferred on Raspberry Pi)."""
+
+    def __init__(self, camera_num: int = 0) -> None:
+        super().__init__(camera_num)
+        self._picam2: Any = None
+
+    def start(self) -> None:
+        from picamera2 import Picamera2
+
+        self._picam2 = Picamera2(self._camera_num)
+
+        props = self._picam2.camera_properties
+        sensor_name = props.get("Model", "unknown")
+        pixel_size = props.get("UnitCellSize", (0, 0))
+        pixel_um = pixel_size[0] / 1000.0 if pixel_size[0] else 0
+
+        config = self._picam2.create_still_configuration(
+            main={"format": "RGB888"},  # actually BGR
+            buffer_count=2,
+        )
+        self._picam2.configure(config)
+        self._picam2.start()
+
+        controls = self._picam2.camera_controls
+        gain_info = controls.get("AnalogueGain", (1.0, 1.0, None))
+        exp_info = controls.get("ExposureTime", (1, 1000000, None))
+
+        sensor_config = self._picam2.camera_configuration()
+        main_cfg = sensor_config.get("main", {})
+        w = main_cfg.get("size", (0, 0))[0]
+        h = main_cfg.get("size", (0, 0))[1]
+
+        cfa_info = props.get("ColorFilterArrangement")
+        cfa_map = {0: "RGGB", 1: "GRBG", 2: "GBRG", 3: "BGGR"}
+        cfa = cfa_map.get(cfa_info, "RGGB")
+
+        self.sensor_info = {
+            "sensor_name": sensor_name,
+            "width": w,
+            "height": h,
+            "pixel": pixel_um,
+            "min_gain": float(gain_info[0]),
+            "max_gain": float(gain_info[1]),
+            "min_exposure": float(exp_info[0]) / 1e6,
+            "max_exposure": float(exp_info[1]) / 1e6,
+            "cfa": cfa,
+            "bit_depth": 10,
+            "backend": "picamera2",
+        }
+
+        logger.info(
+            "Picamera2 backend: %s %dx%d gain=%.1f-%.1f exp=%.6f-%.1fs",
+            sensor_name, w, h,
+            self.sensor_info["min_gain"], self.sensor_info["max_gain"],
+            self.sensor_info["min_exposure"], self.sensor_info["max_exposure"],
+        )
+
+    def stop(self) -> None:
+        if self._picam2:
+            try:
+                self._picam2.stop()
+                self._picam2.close()
+            except Exception:
+                pass
+            self._picam2 = None
+
+    def grab_frame(self) -> tuple[np.ndarray, dict]:
+        array = self._picam2.capture_array("main")
+        metadata = self._picam2.capture_metadata()
+        return array, metadata
+
+    def set_controls(self, controls: dict[str, Any]) -> None:
+        self._picam2.set_controls(controls)
+
+    def capture_dng(self, path: str) -> None:
+        self._picam2.capture_file(path, format="dng")
+
+    @property
+    def sensor_modes(self) -> list:
+        if self._picam2:
+            return self._picam2.sensor_modes
+        return []
+
+
+class LibcameraBackend(CameraBackend):
+    """Uses raw libcamera Python bindings (works on non-Pi Linux)."""
+
+    def __init__(self, camera_num: int = 0) -> None:
+        super().__init__(camera_num)
+        self._cm: Any = None
+        self._camera: Any = None
+        self._allocator: Any = None
+        self._stream = None
+        self._buffers: list = []
+        self._sel: Any = None
+        self._pending_controls: dict = {}
+        self._started = False
+
+    def start(self) -> None:
+        import libcamera
+
+        self._cm = libcamera.CameraManager.singleton()
+        cameras = self._cm.cameras
+        if not cameras:
+            raise RuntimeError("No libcamera cameras found")
+        if self._camera_num >= len(cameras):
+            raise RuntimeError(f"Camera {self._camera_num} not found (have {len(cameras)})")
+
+        self._camera = cameras[self._camera_num]
+        self._camera.acquire()
+
+        # Configure for still capture (native resolution)
+        config = self._camera.generate_configuration(
+            [libcamera.StreamRole.StillCapture]
+        )
+        stream_cfg = config.at(0)
+
+        # Get sensor properties
+        props = self._camera.properties
+        model = props.get(libcamera.properties.Model, "unknown")
+        pixel_size = props.get(libcamera.properties.UnitCellSize, libcamera.Size(0, 0))
+        pixel_um = pixel_size.width / 1000.0 if hasattr(pixel_size, 'width') else 0
+
+        w = stream_cfg.size.width
+        h = stream_cfg.size.height
+
+        # Try to get control limits
+        ctrl_info = self._camera.controls
+        min_gain = 1.0
+        max_gain = 16.0
+        min_exp = 0.000001
+        max_exp = 60.0
+
+        for ctrl_id, ctrl_range in ctrl_info.items():
+            name = ctrl_id.name if hasattr(ctrl_id, 'name') else str(ctrl_id)
+            if name == "AnalogueGain":
+                min_gain = float(ctrl_range.min)
+                max_gain = float(ctrl_range.max)
+            elif name == "ExposureTime":
+                min_exp = float(ctrl_range.min) / 1e6
+                max_exp = float(ctrl_range.max) / 1e6
+
+        self.sensor_info = {
+            "sensor_name": model,
+            "width": w,
+            "height": h,
+            "pixel": pixel_um,
+            "min_gain": min_gain,
+            "max_gain": max_gain,
+            "min_exposure": min_exp,
+            "max_exposure": max_exp,
+            "cfa": "RGGB",
+            "bit_depth": 10,
+            "backend": "libcamera",
+        }
+
+        # Set pixel format to BGR (matching picamera2's RGB888 = BGR)
+        try:
+            stream_cfg.pixel_format = libcamera.formats.BGR888
+        except AttributeError:
+            # Older libcamera may not have BGR888, try RGB888
+            try:
+                stream_cfg.pixel_format = libcamera.formats.RGB888
+            except AttributeError:
+                pass  # use default
+
+        config.validate()
+        self._camera.configure(config)
+
+        # Allocate buffers
+        self._stream = config.at(0).stream
+        self._allocator = libcamera.FrameBufferAllocator(self._camera)
+        num_bufs = self._allocator.allocate(self._stream)
+        if num_bufs <= 0:
+            raise RuntimeError("Failed to allocate libcamera buffers")
+        self._buffers = self._allocator.buffers(self._stream)
+
+        # Start camera
+        self._camera.start()
+        self._started = True
+
+        # Queue all buffers
+        for buf in self._buffers:
+            req = self._camera.create_request()
+            req.add_buffer(self._stream, buf)
+            self._camera.queue_request(req)
+
+        # Selector for event-driven frame readout
+        self._sel = selectors.DefaultSelector()
+        self._sel.register(self._cm.event_fd, selectors.EVENT_READ)
+
+        logger.info(
+            "libcamera backend: %s %dx%d gain=%.1f-%.1f exp=%.6f-%.1fs",
+            model, w, h, min_gain, max_gain, min_exp, max_exp,
+        )
+
+    def stop(self) -> None:
+        if self._camera and self._started:
+            try:
+                self._camera.stop()
+            except Exception:
+                pass
+            self._started = False
+        if self._sel:
+            self._sel.close()
+            self._sel = None
+        if self._camera:
+            try:
+                self._camera.release()
+            except Exception:
+                pass
+            self._camera = None
+
+    def grab_frame(self) -> tuple[np.ndarray, dict]:
+        """Block until next frame, return (bgr_array, metadata)."""
+        import libcamera
+
+        # Wait for frame
+        events = self._sel.select(timeout=30)
+        if not events:
+            raise TimeoutError("libcamera frame timeout")
+
+        completed = self._cm.get_ready_requests()
+        if not completed:
+            raise RuntimeError("No completed requests")
+
+        req = completed[-1]  # latest
+
+        # Extract metadata — raw libcamera uses ControlId objects as keys
+        metadata = {}
+        try:
+            for key, value in req.metadata.items():
+                if hasattr(key, 'name'):
+                    metadata[key.name] = value
+                else:
+                    metadata[str(key)] = value
+        except Exception as e:
+            logger.debug("Metadata extraction error: %s", e)
+
+        # Extract frame data from buffer
+        fb = req.buffers[self._stream]
+        planes = fb.planes
+        if not planes:
+            raise RuntimeError("No planes in frame buffer")
+
+        plane = planes[0]
+        w = self.sensor_info["width"]
+        h = self.sensor_info["height"]
+
+        # mmap the buffer fd to get pixel data
+        with mmap.mmap(plane.fd, plane.length, mmap.MAP_SHARED, mmap.PROT_READ,
+                       offset=plane.offset) as mm:
+            array = np.frombuffer(mm[:w * h * 3], dtype=np.uint8).reshape(h, w, 3).copy()
+
+        # Re-queue the request's buffer
+        try:
+            new_req = self._camera.create_request()
+            new_req.add_buffer(self._stream, fb)
+            # Apply pending controls
+            if self._pending_controls:
+                for ctrl_name, val in self._pending_controls.items():
+                    try:
+                        ctrl_id = getattr(libcamera.controls, ctrl_name, None)
+                        if ctrl_id is not None:
+                            new_req.set_control(ctrl_id, val)
+                        else:
+                            logger.debug("libcamera: unknown control '%s'", ctrl_name)
+                    except Exception as e:
+                        logger.debug("libcamera: failed to set %s=%s: %s", ctrl_name, val, e)
+                self._pending_controls.clear()
+            self._camera.queue_request(new_req)
+        except Exception:
+            pass
+
+        # Release other completed requests
+        for r in completed[:-1]:
+            try:
+                buf = r.buffers[self._stream]
+                nr = self._camera.create_request()
+                nr.add_buffer(self._stream, buf)
+                self._camera.queue_request(nr)
+            except Exception:
+                pass
+
+        return array, metadata
+
+    def set_controls(self, controls: dict[str, Any]) -> None:
+        """Queue controls for next request."""
+        self._pending_controls.update(controls)
+
+    def capture_dng(self, path: str) -> None:
+        logger.warning("DNG capture not supported with raw libcamera backend")
+
+
+class LibcameraStillBackend(CameraBackend):
+    """Uses rpicam-still / libcamera-still subprocess for capture.
+
+    This is the subprocess-based fallback — no Python bindings required,
+    just the rpicam-still or libcamera-still binary on PATH.
+    """
+
+    def __init__(self, camera_num: int = 0) -> None:
+        super().__init__(camera_num)
+        self._exec: str = ""
+        self._pending_controls: dict = {}
+        self._capture_lock = threading.Lock()  # prevent concurrent subprocess calls
+        self._active_proc: Optional[subprocess.Popen] = None  # track active subprocess
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        if shutil.which("rpicam-still"):
+            self._exec = "rpicam-still"
+        elif shutil.which("libcamera-still"):
+            self._exec = "libcamera-still"
+        else:
+            raise RuntimeError("Neither rpicam-still nor libcamera-still found on PATH")
+
+        self._probe_sensor_info()
+
+    def _probe_sensor_info(self) -> None:
+        """Parse sensor model and resolution from --list-cameras output."""
+        model = "unknown"
+        w = h = 0
+
+        try:
+            result = subprocess.run(
+                [self._exec, "--list-cameras"],
+                capture_output=True, text=True, timeout=15,
+            )
+            output = result.stdout + result.stderr
+
+            # Format: "0 : imx415 [3864x2192 10-bit GBRG] (/base/...)"
+            for m in re.finditer(
+                r"^\s*(\d+)\s*:\s*(\S+)\s+\[(\d+)x(\d+)",
+                output, re.MULTILINE
+            ):
+                if int(m.group(1)) == self._camera_num:
+                    model = m.group(2)
+                    w, h = int(m.group(3)), int(m.group(4))
+                    break
+        except Exception as e:
+            logger.warning("libcamera-still: probe failed: %s", e)
+
+        self.sensor_info = {
+            "sensor_name": model,
+            "width": w,
+            "height": h,
+            "pixel": 0.0,
+            "min_gain": 1.0,
+            "max_gain": 16.0,
+            "min_exposure": 0.000001,
+            "max_exposure": 200.0,
+            "cfa": "RGGB",
+            "bit_depth": 10,
+            "backend": "libcamera-still",
+        }
+
+        logger.info(
+            "libcamera-still backend: %s %s %dx%d",
+            self._exec, model, w, h,
+        )
+
+    def stop(self) -> None:
+        pass  # no persistent process to stop
+
+    # ------------------------------------------------------------------
+    # Frame capture
+    # ------------------------------------------------------------------
+
+    def grab_frame(self) -> tuple[np.ndarray, dict]:
+        """Run rpicam-still, decode the JPEG output, return (bgr, metadata).
+
+        Uses a lock to prevent concurrent subprocess calls — only one
+        rpicam-still process at a time.
+        """
+        with self._capture_lock:
+            return self._grab_frame_locked()
+
+    def _kill_stale(self) -> None:
+        """Kill any active or orphaned rpicam-still / libcamera-still processes."""
+        # Kill tracked subprocess
+        if self._active_proc is not None:
+            try:
+                self._active_proc.kill()
+                self._active_proc.wait(timeout=3)
+            except Exception:
+                pass
+            self._active_proc = None
+
+        # Find and kill any orphaned still-capture processes (and their timeout wrappers)
+        try:
+            result = subprocess.run(
+                ["pgrep", "-a", "-f", self._exec],
+                capture_output=True, text=True, timeout=3,
+            )
+            if result.stdout.strip():
+                for line in result.stdout.strip().splitlines():
+                    logger.warning("Killing stale process: %s", line.strip())
+                # Kill both rpicam-still and any timeout wrapper
+                subprocess.run(["pkill", "-9", "-f", self._exec], capture_output=True, timeout=3)
+                subprocess.run(["pkill", "-9", "-f", f"timeout.*{self._exec}"], capture_output=True, timeout=3)
+                time.sleep(0.5)  # brief wait for camera release
+        except Exception:
+            pass
+
+    def _grab_frame_locked(self) -> tuple[np.ndarray, dict]:
+        img_path = "/tmp/indi_allsky_capture.jpg"
+        meta_path = "/tmp/indi_allsky_capture_meta.json"
+
+        # Kill any leaked subprocess before starting a new one
+        self._kill_stale()
+
+        # Timeout: rpicam-still needs ~3x shutter for ISP convergence + capture
+        exp_us = self._pending_controls.get("ExposureTime", 0)
+        exp_s = exp_us / 1e6 if exp_us else 5.0
+        timeout = max(60, exp_s * 4 + 30)
+
+        try:
+            cmd = self._build_cmd(img_path, meta_path)
+            logger.debug("libcamera-still: %s", " ".join(cmd))
+
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            self._active_proc = proc
+            try:
+                stdout, stderr = proc.communicate(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+                self._active_proc = None
+                raise
+            self._active_proc = None
+
+            if proc.returncode != 0:
+                stderr_str = stderr.decode(errors="replace")[:400]
+                raise RuntimeError(f"{self._exec} failed (rc={proc.returncode}): {stderr_str}")
+
+            # Do NOT clear _pending_controls — they must persist across
+            # frames since each rpicam-still subprocess starts fresh.
+
+            # Decode JPEG → BGR numpy array
+            frame = self._decode_jpeg(img_path)
+
+            # Parse JSON metadata (--metadata / --metadata-format json)
+            metadata = self._read_metadata(meta_path)
+
+            # Inject the actual shutter/gain args we passed to rpicam-still
+            if self._pending_controls.get("ExposureTime"):
+                metadata["requested_exposure"] = self._pending_controls["ExposureTime"]
+            if self._pending_controls.get("AnalogueGain"):
+                metadata["requested_gain"] = self._pending_controls["AnalogueGain"]
+
+            return frame, metadata
+
+        finally:
+            for p in (img_path, meta_path):
+                try:
+                    os.unlink(p)
+                except OSError:
+                    pass
+
+    def _build_cmd(self, img_path: str, meta_path: str) -> list[str]:
+        # Wrap with timeout(1) to guarantee rpicam-still gets killed if it hangs.
+        # timeout sends SIGTERM after DURATION; _kill_stale handles SIGKILL.
+        exp_us = self._pending_controls.get("ExposureTime", 0)
+        exp_s = exp_us / 1e6 if exp_us else 5.0
+        kill_timeout = int(max(60, exp_s * 4 + 30))
+
+        cmd = [
+            "timeout", str(kill_timeout),
+            self._exec,
+            "--immediate",
+            "--nopreview",
+            "--camera", str(self._camera_num),
+            "--output", img_path,
+        ]
+
+        # Metadata JSON — supported in newer rpicam-still builds; harmless if unsupported
+        cmd += ["--metadata", meta_path, "--metadata-format", "json"]
+
+        exp = self._pending_controls.get("ExposureTime")   # microseconds (int)
+        gain = self._pending_controls.get("AnalogueGain")  # float
+        awb = self._pending_controls.get("AwbEnable")      # bool or None
+
+        if exp is not None:
+            cmd += ["--shutter", str(int(exp))]
+        if gain is not None:
+            cmd += ["--gain", str(float(gain))]
+        if awb is False:
+            cmd += ["--awb", "off"]
+
+        return cmd
+
+    @staticmethod
+    def _decode_jpeg(path: str) -> np.ndarray:
+        """Decode JPEG file to BGR numpy array using cv2 or Pillow."""
+        try:
+            import cv2
+            frame = cv2.imread(path, cv2.IMREAD_COLOR)  # already BGR
+            if frame is not None:
+                return frame
+        except ImportError:
+            pass
+
+        # Pillow fallback — returns RGB; flip to BGR
+        try:
+            from PIL import Image
+            img = Image.open(path).convert("RGB")
+            rgb = np.array(img)
+            return rgb[:, :, ::-1].copy()
+        except Exception as e:
+            raise RuntimeError(f"Failed to decode JPEG {path}: {e}") from e
+
+    @staticmethod
+    def _read_metadata(path: str) -> dict:
+        try:
+            text = Path(path).read_text()
+            if text.strip():
+                return json.loads(text)
+        except Exception as e:
+            logger.debug("libcamera-still: metadata parse error: %s", e)
+        return {}
+
+    # ------------------------------------------------------------------
+    # Controls & DNG
+    # ------------------------------------------------------------------
+
+    def set_controls(self, controls: dict[str, Any]) -> None:
+        """Queue controls for the next grab_frame() call.
+
+        Thread-safe — serialized with grab_frame/capture_dng.
+        """
+        with self._capture_lock:
+            self._pending_controls.update(controls)
+
+    def capture_dng(self, path: str) -> None:
+        """Capture a DNG (raw) file directly to *path*.
+
+        Serialized — waits for any in-flight grab_frame to finish.
+        """
+        with self._capture_lock:
+            self._capture_dng_locked(path)
+
+    def _capture_dng_locked(self, path: str) -> None:
+        exp = self._pending_controls.get("ExposureTime")
+        exp_s = (exp / 1e6) if exp else 5.0
+        kill_timeout = int(max(60, exp_s * 4 + 30))
+
+        cmd = [
+            "timeout", str(kill_timeout),
+            self._exec,
+            "--immediate",
+            "--nopreview",
+            "--camera", str(self._camera_num),
+            "--raw",
+            "--output", path,
+        ]
+
+        exp = self._pending_controls.get("ExposureTime")
+        gain = self._pending_controls.get("AnalogueGain")
+
+        if exp is not None:
+            cmd += ["--shutter", str(int(exp))]
+        if gain is not None:
+            cmd += ["--gain", str(float(gain))]
+
+        exp_s = (exp / 1e6) if exp else 5.0
+        timeout = max(60, exp_s * 4 + 30)
+
+        result = subprocess.run(cmd, capture_output=True, timeout=timeout)
+        if result.returncode != 0:
+            stderr = result.stderr.decode(errors="replace")[:400]
+            raise RuntimeError(f"{self._exec} DNG capture failed: {stderr}")
+
+
+def create_backend(backend_type: str = "auto", camera_num: int = 0) -> CameraBackend:
+    """Factory: create camera backend.
+
+    backend_type:
+      "auto"            – prefer picamera2, then libcamera bindings, then subprocess
+      "picamera2"       – picamera2 Python library (preferred on Pi)
+      "libcamera"       – raw python3-libcamera bindings
+      "libcamera-still" – rpicam-still / libcamera-still subprocess
+    """
+    if backend_type == "picamera2":
+        return Picamera2Backend(camera_num)
+
+    if backend_type == "libcamera":
+        return LibcameraBackend(camera_num)
+
+    if backend_type == "libcamera-still":
+        return LibcameraStillBackend(camera_num)
+
+    # Auto: prefer picamera2 → libcamera bindings → subprocess
+    try:
+        import picamera2  # noqa: F401
+        logger.info("Auto-detected picamera2")
+        return Picamera2Backend(camera_num)
+    except ImportError:
+        pass
+
+    try:
+        import libcamera  # noqa: F401
+        logger.info("Auto: falling back to raw libcamera bindings")
+        return LibcameraBackend(camera_num)
+    except ImportError:
+        pass
+
+    if shutil.which("rpicam-still") or shutil.which("libcamera-still"):
+        logger.info("Auto: falling back to libcamera-still subprocess")
+        return LibcameraStillBackend(camera_num)
+
+    raise RuntimeError(
+        "No camera backend available: install picamera2, python3-libcamera, "
+        "or rpicam-still / libcamera-still"
+    )

--- a/indi_allsky/camera/libcamera.py
+++ b/indi_allsky/camera/libcamera.py
@@ -10,8 +10,16 @@ import psutil
 from pathlib import Path
 import logging
 
+import numpy as np
+
+try:
+    import cv2
+except ImportError:
+    cv2 = None
+
 from .indi import IndiClient
 from .fake_indi import FakeIndiCcd
+from .picamera2_client import Picamera2Client
 
 from .. import constants
 
@@ -38,7 +46,7 @@ class IndiClientLibCameraGeneric(IndiClient):
     def __init__(self, *args, **kwargs):
         super(IndiClientLibCameraGeneric, self).__init__(*args, **kwargs)
 
-        self.libcamera_process = None
+        self.libcamera_process = None  # kept for compat; unused with daemon
 
         self._temp_val = -273.15  # absolute zero  :-)
 
@@ -52,6 +60,9 @@ class IndiClientLibCameraGeneric(IndiClient):
         self.current_exposure_file_p = None
         self.current_metadata_file_p = None
 
+        # Picamera2 daemon client — replaces rpicam-still subprocess
+        self._picam2_client = Picamera2Client()
+
         memory_info = psutil.virtual_memory()
         self.memory_total_mb = memory_info[0] / 1024.0 / 1024.0
 
@@ -59,18 +70,16 @@ class IndiClientLibCameraGeneric(IndiClient):
         self.ccd_device_name = 'CHANGEME'
 
 
-        # pick correct executable
+        # pick correct executable (kept as fallback identifier)
         if shutil.which('rpicam-still'):
             self.ccd_driver_exec = 'rpicam-still'
         elif shutil.which('libcamera-still'):
             self.ccd_driver_exec = 'libcamera-still'
         else:
-            logger.warning('rpicam-still command not found')
-            self.ccd_driver_exec = self.libcamera_exec  # fallback
+            self.ccd_driver_exec = 'picamera2-daemon'
 
 
-        # this will fallback to the original self.ccd_driver_exec
-        logger.info('libcamera executable: %s', self.ccd_driver_exec)
+        logger.info('libcamera backend: picamera2 daemon')
 
 
         # override in subclass
@@ -145,49 +154,13 @@ class IndiClientLibCameraGeneric(IndiClient):
         if self.active_exposure:
             return
 
-
         self.exposure = exposure
         self.sqm_exposure = sqm_exposure
 
-
-        libcamera_camera_id = self.config.get('LIBCAMERA', {}).get('CAMERA_ID', 0)
-
-
         if self.night_av[constants.NIGHT_NIGHT]:
-            # night
             image_type = self.config.get('LIBCAMERA', {}).get('IMAGE_FILE_TYPE', 'jpg')
         else:
-            # day
             image_type = self.config.get('LIBCAMERA', {}).get('IMAGE_FILE_TYPE_DAY', 'jpg')
-
-
-        if image_type == 'dng' and self.memory_total_mb <= 768:
-            logger.warning('*** Capturing raw images (dng) with libcamera and less than 1gb of memory can result in out-of-memory errors ***')
-
-
-        try:
-            image_tmp_f = tempfile.NamedTemporaryFile(mode='w', suffix='.{0:s}'.format(image_type), delete=True)
-            image_tmp_f.close()
-            image_tmp_p = Path(image_tmp_f.name)
-
-            metadata_tmp_f = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=True)
-            metadata_tmp_f.close()
-            metadata_tmp_p = Path(metadata_tmp_f.name)
-        except OSError as e:
-            logger.error('OSError: %s', str(e))
-            return
-
-
-        try:
-            binmode_option = self._getBinModeOptions(int(binning))
-        except BinModeException as e:
-            logger.error('Invalid setting: %s', str(e))
-            binmode_option = ''
-
-
-        self.current_exposure_file_p = image_tmp_p
-        self.current_metadata_file_p = metadata_tmp_p
-
 
         if self.gain != float(round(gain, 2)):
             self.setCcdGain(gain)
@@ -195,356 +168,219 @@ class IndiClientLibCameraGeneric(IndiClient):
         if self.binning != int(binning):
             self.setCcdBinning(binning)
 
-
-        exposure_us = int(exposure * 1000000)
-
-        if image_type in ['dng']:
-            cmd = [
-                self.ccd_device.driver_exec,
-                '--nopreview',
-                '--camera', '{0:d}'.format(libcamera_camera_id),
-                '--raw',
-                '--denoise', 'off',
-                '--gain', '{0:0.2f}'.format(self.gain_av[constants.GAIN_CURRENT]),
-                '--shutter', '{0:d}'.format(exposure_us),
-                '--metadata', str(metadata_tmp_p),
-                '--metadata-format', 'json',
-            ]
-        elif image_type in ['jpg', 'png']:
-            #logger.warning('RAW frame mode disabled due to low memory resources')
-            cmd = [
-                self.ccd_device.driver_exec,
-                '--nopreview',
-                '--camera', '{0:d}'.format(libcamera_camera_id),
-                '--encoding', '{0:s}'.format(image_type),
-                '--quality', '95',
-                '--gain', '{0:0.2f}'.format(self.gain_av[constants.GAIN_CURRENT]),
-                '--shutter', '{0:d}'.format(exposure_us),
-                '--metadata', str(metadata_tmp_p),
-                '--metadata-format', 'json',
-            ]
+        # Determine AWB setting
+        is_night = bool(self.night_av[constants.NIGHT_NIGHT])
+        if is_night:
+            awb_enable = bool(self.config.get('LIBCAMERA', {}).get('AWB_ENABLE'))
         else:
-            raise Exception('Invalid image type')
+            awb_enable = bool(self.config.get('LIBCAMERA', {}).get('AWB_ENABLE_DAY'))
 
-
-
-        if self.night_av[constants.NIGHT_NIGHT]:
-            #  night
-
-            if self.config.get('LIBCAMERA', {}).get('IMMEDIATE', True):
-                cmd.insert(1, '--immediate')
-
-
-            # Auto white balance, AWB causes long exposure times at night
-            if self.config.get('LIBCAMERA', {}).get('AWB_ENABLE'):
-                awb = self.config.get('LIBCAMERA', {}).get('AWB', 'auto')
-                cmd.extend(['--awb', awb])
-            else:
-                # awb enabled by default, the following disables
-                cmd.extend(['--awbgains', '1,1'])
-
-
-            # CCM
-            if self.config.get('LIBCAMERA', {}).get('CCM_DISABLE'):
-                cmd.extend(['--ccm', '1,0,0,0,1,0,0,0,1'])
-
-        else:
-            # daytime
-
-            if self.config.get('LIBCAMERA', {}).get('IMMEDIATE_DAY', True):
-                cmd.insert(1, '--immediate')
-
-
-            # Auto white balance, AWB causes long exposure times at night
-            if self.config.get('LIBCAMERA', {}).get('AWB_ENABLE_DAY'):
-                awb = self.config.get('LIBCAMERA', {}).get('AWB_DAY', 'auto')
-                cmd.extend(['--awb', awb])
-            else:
-                # awb enabled by default, the following disables
-                cmd.extend(['--awbgains', '1,1'])
-
-
-            # CCM
-            if self.config.get('LIBCAMERA', {}).get('CCM_DISABLE_DAY'):
-                cmd.extend(['--ccm', '1,0,0,0,1,0,0,0,1'])
-
-
-        # add --mode flags for binning
-        if binmode_option:
-            cmd.extend(binmode_option.split(' '))
-
-
-        # extra options get added last
-        if self.night_av[constants.NIGHT_NIGHT]:
-            #  night
-            # Add extra config options
-            extra_options = self.config.get('LIBCAMERA', {}).get('EXTRA_OPTIONS')
-            if extra_options:
-                cmd.extend(extra_options.split(' '))
-
-        else:
-            # daytime
-
-            # Add extra config options
-            extra_options = self.config.get('LIBCAMERA', {}).get('EXTRA_OPTIONS_DAY')
-            if extra_options:
-                cmd.extend(extra_options.split(' '))
-
-
-        # Finally add output file
-        cmd.extend(['--output', str(image_tmp_p)])
-
-
-        ### testing an expoure that times out
-        #cmd = [
-        #    'sleep', '600',
-        #]
-
-
-        logger.info('image command: %s', ' '.join(cmd))
-
-
-        self.exposureStartTime = time.time()
-
-        self.libcamera_process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+        # Send controls to the picamera2 daemon
+        self._picam2_client.set_controls(
+            exposure=exposure,
+            gain=float(self.gain_av[constants.GAIN_CURRENT]),
+            awb=awb_enable,
         )
 
-        self.active_exposure = True
+        logger.info(
+            'Capturing via picamera2 daemon: %.4fs exposure, gain %.2f, bin %d, type %s',
+            exposure, self.gain_av[constants.GAIN_CURRENT], binning, image_type,
+        )
 
+        self.exposureStartTime = time.time()
+        self.active_exposure = True
+        self._pending_image_type = image_type
 
         # Update shared exposure value
         with self.exposure_av.get_lock():
             self.exposure_av[constants.EXPOSURE_CURRENT] = float(exposure)
 
-
         if sync:
-            try:
-                self.libcamera_process.wait(timeout=timeout)
-            except subprocess.TimeoutExpired:
-                logger.error('Exposure timeout')
-                raise TimeOutException('Timeout waiting for exposure')
+            capture_timeout = timeout if timeout else max(exposure * 3, 30)
 
+            if image_type == 'dng':
+                # DNG: daemon captures directly to file
+                try:
+                    dng_tmp = tempfile.NamedTemporaryFile(
+                        mode='w', suffix='.dng', delete=False,
+                    )
+                    dng_tmp.close()
+                    result = self._picam2_client.capture_dng(
+                        dng_tmp.name, timeout=capture_timeout,
+                    )
+                    if not result.get('ok'):
+                        logger.error('DNG capture failed: %s', result.get('error'))
+                except Exception as e:
+                    logger.error('DNG capture error: %s', str(e))
 
-            if self.libcamera_process.returncode != 0:
-                # log errors
-                stdout = self.libcamera_process.stdout
-                for line in stdout.readlines():
-                    logger.error('rpicam-still error: %s', line)
+                self.current_exposure_file_p = Path(dng_tmp.name)
+            else:
+                # JPG/PNG: grab frame from daemon, encode locally
+                try:
+                    result = self._picam2_client.capture_still(
+                        exposure=exposure,
+                        gain=float(self.gain_av[constants.GAIN_CURRENT]),
+                        timeout=capture_timeout,
+                    )
+                except Exception as e:
+                    logger.error('Capture error: %s', str(e))
+                    self.active_exposure = False
+                    return
 
-                # not returning, just log the error
+                if not result.get('ok'):
+                    logger.error('Capture failed: %s', result.get('error'))
+                    self.active_exposure = False
+                    return
+
+                # Load numpy frame and encode to image file
+                frame_path = result.get('frame_path', '')
+                self._last_daemon_metadata = result.get('metadata', {})
+
+                try:
+                    frame = np.load(frame_path)
+                except Exception as e:
+                    logger.error('Failed to load frame from %s: %s', frame_path, str(e))
+                    self.active_exposure = False
+                    return
+
+                # Save as JPG or PNG
+                image_tmp_f = tempfile.NamedTemporaryFile(
+                    mode='w', suffix='.{0:s}'.format(image_type), delete=False,
+                )
+                image_tmp_f.close()
+                self.current_exposure_file_p = Path(image_tmp_f.name)
+
+                if cv2 is not None:
+                    # Frame is RGB from picamera2, convert to BGR for cv2
+                    # picamera2 RGB888 is already BGR (OpenCV convention)
+                    bgr = frame
+                    if image_type == 'jpg':
+                        cv2.imwrite(str(self.current_exposure_file_p), bgr,
+                                    [cv2.IMWRITE_JPEG_QUALITY, 95])
+                    else:
+                        cv2.imwrite(str(self.current_exposure_file_p), bgr)
 
             self.active_exposure = False
-
             self._processMetadata()
-
             self._queueImage()
+
+        else:
+            # Async mode: start capture in background thread
+            import threading
+            self._async_thread = threading.Thread(
+                target=self._async_capture,
+                args=(exposure, gain, image_type),
+                daemon=True,
+            )
+            self._async_thread.start()
+
+
+    def _async_capture(self, exposure, gain, image_type):
+        """Background capture for async (non-sync) mode."""
+        try:
+            capture_timeout = max(exposure * 3, 30)
+            result = self._picam2_client.capture_still(
+                exposure=exposure, gain=gain, timeout=capture_timeout,
+            )
+            if not result.get('ok'):
+                logger.error('Async capture failed: %s', result.get('error'))
+                self.active_exposure = False
+                return
+
+            frame_path = result.get('frame_path', '')
+            self._last_daemon_metadata = result.get('metadata', {})
+
+            frame = np.load(frame_path)
+
+            image_tmp_f = tempfile.NamedTemporaryFile(
+                mode='w', suffix='.{0:s}'.format(image_type), delete=False,
+            )
+            image_tmp_f.close()
+            self.current_exposure_file_p = Path(image_tmp_f.name)
+
+            if cv2 is not None:
+                # picamera2 RGB888 is already BGR (OpenCV convention)
+                bgr = frame
+                if image_type == 'jpg':
+                    cv2.imwrite(str(self.current_exposure_file_p), bgr,
+                                [cv2.IMWRITE_JPEG_QUALITY, 95])
+                else:
+                    cv2.imwrite(str(self.current_exposure_file_p), bgr)
+
+            # Mark as ready for getCcdExposureStatus to pick up
+            # active_exposure stays True until getCcdExposureStatus processes it
+        except Exception:
+            logger.exception('Async capture error')
+            self.active_exposure = False
 
 
     def getCcdExposureStatus(self):
         # returns camera_ready, exposure_state
-        if self._libCameraProcessRunning():
-            return False, 'BUSY'
-
 
         if self.active_exposure:
-            # if we get here, that means the camera is finished with the exposure
+            # Check if async capture thread is still running
+            if hasattr(self, '_async_thread') and self._async_thread is not None:
+                if self._async_thread.is_alive():
+                    return False, 'BUSY'
+
+            # Async capture finished — process the result
             self.active_exposure = False
-
-
-            if self.libcamera_process.returncode != 0:
-                # log errors
-                stdout = self.libcamera_process.stdout
-                for line in stdout.readlines():
-                    logger.error('rpicam-still error: %s', line)
-
-                # not returning, just log the error
-
+            self._async_thread = None
 
             self._processMetadata()
-
             self._queueImage()
-
 
         return True, 'READY'
 
 
     def _processMetadata(self):
-        # read metadata to get sensor temperature
-        if self.current_metadata_file_p:
-            try:
-                with io.open(self.current_metadata_file_p, 'r', encoding='utf-8') as f_metadata:
-                    metadata_dict = json.load(f_metadata, object_pairs_hook=OrderedDict)
-            except FileNotFoundError as e:
-                logger.error('Metadata file not found: %s', str(e))
-                metadata_dict = dict()
-            except PermissionError as e:
-                logger.error('Permission erro: %s', str(e))
-                metadata_dict = dict()
-            except json.JSONDecodeError as e:
-                logger.error('Error decoding json: %s', str(e))
-                metadata_dict = dict()
-
-
-        #logger.info('Metadata: %s', metadata_dict)
-
-
-        try:
-            self.current_metadata_file_p.unlink()
-        except FileNotFoundError:
-            pass
-
+        """Extract ISP metadata from the picamera2 daemon response."""
+        metadata_dict = getattr(self, '_last_daemon_metadata', {})
 
         ### Gain
-        try:
-            analogue_gain = float(metadata_dict[self._analogue_gain_metadata_key])
-        except KeyError:
-            #logger.error('libcamera camera analogue gain key not found')
-            analogue_gain = 0.0
-        except ValueError:
-            #logger.error('Unable to parse libcamera analogue gain')
-            analogue_gain = 0.0
-
-
-        try:
-            digital_gain = float(metadata_dict[self._digital_gain_metadata_key])
-        except KeyError:
-            #logger.error('libcamera camera digital gain key not found')
-            digital_gain = 0.0
-        except ValueError:
-            #logger.error('Unable to parse libcamera digital gain')
-            digital_gain = 0.0
-
+        analogue_gain = float(metadata_dict.get(self._analogue_gain_metadata_key, 0.0))
+        digital_gain = float(metadata_dict.get(self._digital_gain_metadata_key, 0.0))
 
         if analogue_gain:
             logger.info('libcamera reported gain: %0.2f/%0.2f', analogue_gain, digital_gain)
 
-
         ### Temperature
-        try:
-            self._temp_val = float(metadata_dict[self._sensor_temp_metadata_key])
-        except KeyError:
-            logger.error('libcamera camera temperature key not found')
-        except ValueError:
-            logger.error('Unable to parse libcamera camera temperature')
-
+        temp = metadata_dict.get(self._sensor_temp_metadata_key)
+        if temp is not None:
+            self._temp_val = float(temp)
 
         ### Auto white balance
-        # Only return these values when libcamera AWB is enabled
-        if self.night_av[constants.NIGHT_NIGHT]:
-            # night
-            if self.config.get('LIBCAMERA', {}).get('AWB_ENABLE'):
-                try:
-                    awb_gains = metadata_dict[self._awb_gains_metadata_key]
-                    self._awb_gains = [awb_gains[0], awb_gains[1]]
-                    logger.info('libcamera color gains: Red: %0.2f, Blue: %0.2f', *self._awb_gains)
-                except KeyError:
-                    logger.error('libcamera sensor AWB key not found')
-                    self._awb_gains = None
-                except IndexError:
-                    logger.error('Invalid color gain values')
-                    self._awb_gains = None
-
-
-                ### Color correction matrix
-                #try:
-                #    ccm = metadata_dict[self._ccm_metadata_key]
-                #    self._ccm = [
-                #        [ccm[8], ccm[7], ccm[6]],
-                #        [ccm[5], ccm[4], ccm[3]],
-                #        [ccm[2], ccm[1], ccm[0]],
-                #    ]
-                #except KeyError:
-                #    logger.error('libcamera CCM key not found')
-                #    self._ccm = None
-                #except IndexError:
-                #    logger.error('Invalid CCM values')
-                #    self._ccm = None
-
-            else:
-                self._awb_gains = None
-                #self._ccm = None
-
+        is_night = bool(self.night_av[constants.NIGHT_NIGHT])
+        if is_night:
+            awb_enabled = self.config.get('LIBCAMERA', {}).get('AWB_ENABLE')
         else:
-            # day
-            if self.config.get('LIBCAMERA', {}).get('AWB_ENABLE_DAY'):
-                try:
-                    awb_gains = metadata_dict[self._awb_gains_metadata_key]
-                    self._awb_gains = [awb_gains[0], awb_gains[1]]
-                    logger.info('libcamera color gains: Red: %0.2f, Blue: %0.2f', *self._awb_gains)
-                except KeyError:
-                    logger.error('libcamera sensor AWB key not found')
-                    self._awb_gains = None
-                except IndexError:
-                    logger.error('Invalid color gain values')
-                    self._awb_gains = None
+            awb_enabled = self.config.get('LIBCAMERA', {}).get('AWB_ENABLE_DAY')
 
-
-                ### Color correction matrix
-                #try:
-                #    ccm = metadata_dict[self._ccm_metadata_key]
-                #    self._ccm = [
-                #        [ccm[8], ccm[7], ccm[6]],
-                #        [ccm[5], ccm[4], ccm[3]],
-                #        [ccm[2], ccm[1], ccm[0]],
-                #    ]
-                #except KeyError:
-                #    logger.error('libcamera CCM key not found')
-                #    self._ccm = None
-                #except IndexError:
-                #    logger.error('Invalid CCM values')
-                #    self._ccm = None
-
+        if awb_enabled:
+            awb_gains = metadata_dict.get(self._awb_gains_metadata_key)
+            if awb_gains and isinstance(awb_gains, (list, tuple)) and len(awb_gains) >= 2:
+                self._awb_gains = [awb_gains[0], awb_gains[1]]
             else:
                 self._awb_gains = None
-                #self._ccm = None
-
+        else:
+            self._awb_gains = None
 
         ### Black Level
-        try:
-            black_level = metadata_dict[self._black_level_metadata_key]
-            self._black_level = black_level[0]  # Only going to use the first key for now
-            logger.info('libcamera black level: %d', self._black_level)
-        except KeyError:
-            logger.error('libcamera sensor black level key not found')
-            self._black_level = None
-        except IndexError:
-            logger.error('Invalid black level values')
+        black_level = metadata_dict.get(self._black_level_metadata_key)
+        if black_level and isinstance(black_level, (list, tuple)) and len(black_level) > 0:
+            self._black_level = black_level[0]
+        else:
             self._black_level = None
 
 
 
     def abortCcdExposure(self):
         logger.warning('Aborting exposure')
-
         self.active_exposure = False
-
-        for _ in range(5):
-            if not self._libCameraProcessRunning():
-                break
-
-            self.libcamera_process.terminate()
-            time.sleep(0.5)
-            continue
-
-
-        if self._libCameraProcessRunning():
-            self.libcamera_process.kill()
-            self.libcamera_process.poll()  # close out the process
-
 
         try:
             if self.current_exposure_file_p:
                 self.current_exposure_file_p.unlink()
-        except FileNotFoundError:
-            pass
-
-
-        try:
-            if self.current_metadata_file_p:
-                self.current_metadata_file_p.unlink()
         except FileNotFoundError:
             pass
 
@@ -574,18 +410,37 @@ class IndiClientLibCameraGeneric(IndiClient):
 
 
     def _libCameraProcessRunning(self):
-        if not self.libcamera_process:
-            return False
-
-        # poll returns None when process is active, rc (normally 0) when finished
-        poll = self.libcamera_process.poll()
-        if isinstance(poll, type(None)):
-            return True
-
+        # No longer uses subprocess — check async thread instead
+        if hasattr(self, '_async_thread') and self._async_thread is not None:
+            return self._async_thread.is_alive()
         return False
 
 
     def findCcd(self, *args, **kwargs):
+        # Try to get live sensor info from daemon, fall back to subclass camera_info
+        try:
+            info = self._picam2_client.get_sensor_info()
+            if info.get('ok'):
+                if info.get('width'):
+                    self.camera_info['width'] = info['width']
+                if info.get('height'):
+                    self.camera_info['height'] = info['height']
+                if info.get('pixel'):
+                    self.camera_info['pixel'] = info['pixel']
+                if info.get('min_gain'):
+                    self.camera_info['min_gain'] = info['min_gain']
+                if info.get('max_gain'):
+                    self.camera_info['max_gain'] = info['max_gain']
+                if info.get('min_exposure'):
+                    self.camera_info['min_exposure'] = info['min_exposure']
+                if info.get('max_exposure'):
+                    self.camera_info['max_exposure'] = info['max_exposure']
+                if info.get('cfa'):
+                    self.camera_info['cfa'] = info['cfa']
+                logger.info('Camera info from daemon: %s', info.get('sensor_name', 'unknown'))
+        except Exception as e:
+            logger.warning('Could not get sensor info from daemon, using defaults: %s', str(e))
+
         new_ccd = FakeIndiCcd()
         new_ccd.device_name = self.ccd_device_name
         new_ccd.driver_exec = self.ccd_driver_exec

--- a/indi_allsky/camera/picamera2_client.py
+++ b/indi_allsky/camera/picamera2_client.py
@@ -1,0 +1,158 @@
+"""Standalone picamera2 daemon client.
+
+Zero dependencies on indi_allsky — safe to import from any context
+(daemon, capture worker, Flask, standalone test scripts).
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import struct
+from multiprocessing import shared_memory
+from typing import Any, Optional
+
+SOCK_PATH = "/run/indi-allsky/picamera2.sock"
+SHM_NAME = "indi_allsky_frame"
+SHM_HEADER = 24
+SHM_PATH_SIZE = 512
+# JPEG max and path offset are derived from actual shm size at runtime
+
+
+class Picamera2Client:
+    """Connect to the picamera2 daemon via Unix socket + shared memory."""
+
+    def __init__(self, sock_path: str = SOCK_PATH) -> None:
+        self._sock_path = sock_path
+        self._sock: Optional[socket.socket] = None
+        self._shm: Optional[shared_memory.SharedMemory] = None
+
+    def connect(self) -> None:
+        if self._sock is not None:
+            return
+        self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._sock.connect(self._sock_path)
+        self._sock.settimeout(120.0)
+
+    def close(self) -> None:
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except Exception:
+                pass
+            self._sock = None
+        if self._shm is not None:
+            try:
+                self._shm.close()
+            except Exception:
+                pass
+            self._shm = None
+
+    def _send(self, cmd: dict) -> dict:
+        self.connect()
+        msg = json.dumps(cmd).encode() + b"\n"
+        self._sock.sendall(msg)
+        buf = b""
+        while b"\n" not in buf:
+            data = self._sock.recv(4096)
+            if not data:
+                raise ConnectionError("Daemon closed connection")
+            buf += data
+        line = buf.split(b"\n", 1)[0]
+        return json.loads(line)
+
+    def ping(self) -> dict:
+        return self._send({"cmd": "ping"})
+
+    def get_sensor_info(self) -> dict:
+        return self._send({"cmd": "get_sensor_info"})
+
+    def get_metadata(self) -> dict:
+        return self._send({"cmd": "get_metadata"})
+
+    def get_modes(self) -> dict:
+        return self._send({"cmd": "get_modes"})
+
+    def get_backend(self) -> dict:
+        return self._send({"cmd": "get_backend"})
+
+    def set_controls(self, **kwargs) -> dict:
+        return self._send({"cmd": "set_controls", **kwargs})
+
+    def capture_still(self, exposure: float = None, gain: float = None,
+                      timeout: float = 120) -> dict:
+        cmd: dict[str, Any] = {"cmd": "capture_still", "timeout": timeout}
+        if exposure is not None:
+            cmd["exposure"] = exposure
+        if gain is not None:
+            cmd["gain"] = gain
+        return self._send(cmd)
+
+    def capture_dng(self, path: str, timeout: float = 120) -> dict:
+        return self._send({"cmd": "capture_dng", "path": path, "timeout": timeout})
+
+    def set_binning(self, level: int, width: int, height: int) -> dict:
+        return self._send({"cmd": "set_binning", "level": level,
+                           "width": width, "height": height})
+
+    def set_stream(self, width: int = None, height: int = None,
+                   quality: int = None, osd: bool = None) -> dict:
+        cmd: dict[str, Any] = {"cmd": "set_stream"}
+        if width is not None:
+            cmd["width"] = width
+        if height is not None:
+            cmd["height"] = height
+        if quality is not None:
+            cmd["quality"] = quality
+        if osd is not None:
+            cmd["osd"] = osd
+        return self._send(cmd)
+
+    # ------------------------------------------------------------------
+    # Shared memory frame reader
+    # ------------------------------------------------------------------
+
+    def _open_shm(self) -> None:
+        if self._shm is None:
+            self._shm = shared_memory.SharedMemory(name=SHM_NAME)
+            # Prevent Python's resource tracker from unlinking shm we don't own.
+            # The daemon creates and owns the shm; clients are read-only.
+            try:
+                from multiprocessing import resource_tracker
+                resource_tracker.unregister(
+                    "/" + SHM_NAME, "shared_memory",
+                )
+            except Exception:
+                pass
+            # Derive JPEG max and path offset from actual shm size
+            self._shm_jpeg_max = self._shm.size - SHM_HEADER - SHM_PATH_SIZE
+            self._shm_path_offset = SHM_HEADER + self._shm_jpeg_max
+
+    def get_stream_jpeg(self) -> Optional[tuple[bytes, int]]:
+        """Read the latest JPEG frame from shared memory.
+
+        Returns (jpeg_bytes, sequence_counter) or None.
+        """
+        try:
+            self._open_shm()
+        except FileNotFoundError:
+            return None
+
+        buf = self._shm.buf
+        seq, w, h, ch, jpeg_len = struct.unpack_from("<QIIiI", buf, 0)
+        if jpeg_len <= 0 or jpeg_len > self._shm_jpeg_max:
+            return None
+        jpeg = bytes(buf[SHM_HEADER:SHM_HEADER + jpeg_len])
+        return jpeg, seq
+
+    def get_frame_path(self) -> Optional[str]:
+        """Read the latest full-res frame path from shared memory."""
+        try:
+            self._open_shm()
+        except FileNotFoundError:
+            return None
+
+        buf = self._shm.buf
+        raw = bytes(buf[self._shm_path_offset:self._shm_path_offset + SHM_PATH_SIZE])
+        path = raw.split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+        return path if path else None

--- a/indi_allsky/camera/picamera2_daemon.py
+++ b/indi_allsky/camera/picamera2_daemon.py
@@ -1,0 +1,958 @@
+"""Picamera2 single-process daemon with IPC.
+
+Owns the Picamera2 instance in a daemon thread, publishes frames via shared
+memory, and accepts control commands over a Unix socket.  Both the
+CaptureWorker (multiprocessing.Process) and gunicorn/Flask can connect as
+clients without ever touching the camera directly.
+
+Wire protocol (Unix stream socket, JSON-line):
+  Client sends: {"cmd": "...", ...}\n
+  Daemon replies: {"ok": true, ...}\n   or  {"ok": false, "error": "..."}\n
+
+Shared memory layout (name = "indi_allsky_frame"):
+  [0:8]       uint64  sequence counter
+  [8:12]      uint32  width
+  [12:16]     uint32  height
+  [16:20]     uint32  channels
+  [20:24]     uint32  jpeg_len
+  [24:24+ML]  JPEG bytes for streaming (max 2MB)
+  After JPEG region: raw frame path (UTF-8, null-terminated, 512 bytes)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import select
+import socket
+import struct
+import threading
+import time
+import traceback
+from multiprocessing import shared_memory
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+SOCK_PATH = "/run/indi-allsky/picamera2.sock"
+SHM_NAME = "indi_allsky_frame"
+SHM_HEADER = 24          # seq(8) + w(4) + h(4) + ch(4) + jpeg_len(4)
+SHM_PATH_SIZE = 512
+
+
+def _calc_shm_jpeg_max(width: int, height: int) -> int:
+    """Estimate max JPEG size for a given resolution.
+
+    JPEG compression at quality 95 typically produces ~1 byte per 3-4 pixels.
+    We use 1 byte per pixel as a conservative upper bound, with a 4MB floor.
+    """
+    return max(4 * 1024 * 1024, width * height)
+
+
+# Module-level defaults (overridden per-instance in _init_shm)
+SHM_JPEG_MAX = 4 * 1024 * 1024
+SHM_PATH_OFFSET = SHM_HEADER + SHM_JPEG_MAX
+SHM_TOTAL = SHM_PATH_OFFSET + SHM_PATH_SIZE
+
+
+class Picamera2Daemon:
+    """Camera daemon that owns the Picamera2 instance.
+
+    Start with :meth:`run` (blocking) or :meth:`start` (background thread).
+    """
+
+    def __init__(
+        self,
+        camera_num: int = 0,
+        stream_width: int = 1920,
+        stream_height: int = 1080,
+        stream_quality: int = 75,
+        latitude: float = 0.0,
+        longitude: float = 0.0,
+        elevation: float = 0.0,
+        backend_type: str = "auto",
+    ) -> None:
+        self._camera_num = camera_num
+        self._backend_type = backend_type
+        self._stream_width = stream_width
+        self._stream_height = stream_height
+        self._stream_quality = stream_quality
+        self._osd_enabled = True
+
+        # Stream overlay
+        self._overlay: Any = None
+        try:
+            from .stream_overlay import StreamOverlay
+            self._overlay = StreamOverlay(
+                latitude=latitude,
+                longitude=longitude,
+                elevation=elevation,
+            )
+            logger.info("Stream overlay enabled (lat=%.2f lon=%.2f)", latitude, longitude)
+        except ImportError:
+            try:
+                # Standalone mode — import from same directory
+                import importlib.util
+                spec = importlib.util.spec_from_file_location(
+                    "stream_overlay",
+                    os.path.join(os.path.dirname(os.path.abspath(__file__)), "stream_overlay.py"),
+                )
+                mod = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(mod)
+                self._overlay = mod.StreamOverlay(
+                    latitude=latitude,
+                    longitude=longitude,
+                    elevation=elevation,
+                )
+                logger.info("Stream overlay enabled (standalone, lat=%.2f lon=%.2f)", latitude, longitude)
+            except Exception as e:
+                logger.warning("Stream overlay not available: %s", e)
+
+        self._picam2: Any = None
+        self._sensor_info: dict = {}
+        self._metadata: dict = {}
+        self._frame_count: int = 0
+        self._stop = threading.Event()
+        self._grab_stop = threading.Event()  # stop grab loop without killing daemon
+        self._grab_thread: Optional[threading.Thread] = None
+
+        self._controls_lock = threading.Lock()
+        self._pending_controls: dict[str, Any] = {}
+        self._is_subprocess_backend = False
+
+        # Shared memory for frame distribution
+        self._shm: Optional[shared_memory.SharedMemory] = None
+
+        # Latest full-res frame path (written to temp file for capture worker)
+        self._latest_frame_path: str = ""
+        self._frame_lock = threading.Lock()
+        self._frame_event = threading.Event()
+
+        # For DNG capture requests
+        self._dng_request: Optional[dict] = None
+        self._dng_result: Optional[dict] = None
+        self._dng_event = threading.Event()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> threading.Thread:
+        """Start the daemon in a background thread."""
+        t = threading.Thread(target=self.run, name="picamera2-daemon", daemon=True)
+        t.start()
+        return t
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def run(self) -> None:
+        """Main entry point (blocking)."""
+        try:
+            self._init_camera()
+            self._init_shm()
+            self._start_socket_server()
+        except Exception:
+            logger.exception("Picamera2 daemon failed to start")
+            raise
+        finally:
+            self._cleanup()
+
+    # ------------------------------------------------------------------
+    # Camera init
+    # ------------------------------------------------------------------
+
+    def _init_camera(self) -> None:
+        try:
+            from .camera_backend import create_backend
+        except ImportError:
+            # Standalone mode — import from same directory
+            import importlib.util
+            spec = importlib.util.spec_from_file_location(
+                "camera_backend",
+                os.path.join(os.path.dirname(os.path.abspath(__file__)), "camera_backend.py"),
+            )
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            create_backend = mod.create_backend
+
+        self._backend = create_backend(self._backend_type, self._camera_num)
+        self._backend.start()
+        self._is_subprocess_backend = self._backend_type == "libcamera-still" or \
+            type(self._backend).__name__ == "LibcameraStillBackend"
+        self._sensor_info = dict(self._backend.sensor_info)
+
+        logger.info(
+            "Camera daemon: backend=%s sensor=%s %dx%d gain=%.1f-%.1f exp=%.6f-%.1fs",
+            self._sensor_info.get("backend", "?"),
+            self._sensor_info.get("sensor_name", "?"),
+            self._sensor_info.get("width", 0), self._sensor_info.get("height", 0),
+            self._sensor_info["min_gain"], self._sensor_info["max_gain"],
+            self._sensor_info["min_exposure"], self._sensor_info["max_exposure"],
+        )
+
+    # ------------------------------------------------------------------
+    # Shared memory
+    # ------------------------------------------------------------------
+
+    def _init_shm(self) -> None:
+        global SHM_JPEG_MAX, SHM_PATH_OFFSET, SHM_TOTAL
+
+        # Size the JPEG buffer based on stream resolution
+        SHM_JPEG_MAX = _calc_shm_jpeg_max(self._stream_width, self._stream_height)
+        SHM_PATH_OFFSET = SHM_HEADER + SHM_JPEG_MAX
+        SHM_TOTAL = SHM_PATH_OFFSET + SHM_PATH_SIZE
+
+        try:
+            old = shared_memory.SharedMemory(name=SHM_NAME)
+            old.close()
+            old.unlink()
+        except FileNotFoundError:
+            pass
+
+        self._shm = shared_memory.SharedMemory(
+            name=SHM_NAME, create=True, size=SHM_TOTAL,
+        )
+        # Make shm world-readable so gunicorn/Flask workers can read frames
+        shm_path = f"/dev/shm/{SHM_NAME}"
+        try:
+            os.chmod(shm_path, 0o666)
+        except OSError:
+            pass
+        logger.info(
+            "Shared memory created: %s (%d bytes, JPEG max %d for %dx%d stream)",
+            SHM_NAME, SHM_TOTAL, SHM_JPEG_MAX,
+            self._stream_width, self._stream_height,
+        )
+
+    def _publish_frame(self, jpeg_bytes: bytes, frame_path: str) -> None:
+        """Write a JPEG frame + metadata into shared memory."""
+        if self._shm is None:
+            return
+        buf = self._shm.buf
+        if len(jpeg_bytes) > SHM_JPEG_MAX:
+            logger.warning(
+                "JPEG frame (%d bytes) exceeds SHM buffer (%d bytes), truncating. "
+                "Increase stream resolution buffer or reduce stream quality.",
+                len(jpeg_bytes), SHM_JPEG_MAX,
+            )
+        jpeg_len = min(len(jpeg_bytes), SHM_JPEG_MAX)
+        w = self._sensor_info.get("width", 0)
+        h = self._sensor_info.get("height", 0)
+
+        # Header
+        struct.pack_into("<QIIiI", buf, 0,
+                         self._frame_count, w, h, 3, jpeg_len)
+        # JPEG data
+        buf[SHM_HEADER:SHM_HEADER + jpeg_len] = jpeg_bytes[:jpeg_len]
+        # Frame path
+        path_bytes = frame_path.encode("utf-8")[:SHM_PATH_SIZE - 1] + b"\x00"
+        buf[SHM_PATH_OFFSET:SHM_PATH_OFFSET + len(path_bytes)] = path_bytes
+
+    # ------------------------------------------------------------------
+    # Grab loop
+    # ------------------------------------------------------------------
+
+    def _grab_loop(self) -> None:
+        """Daemon thread: continuous frame grab from picamera2."""
+        try:
+            import cv2
+        except ImportError:
+            cv2 = None
+
+        # Detect subprocess backend — needs throttled grab loop
+        try:
+            from .camera_backend import LibcameraStillBackend
+        except ImportError:
+            LibcameraStillBackend = type(None)  # never matches
+        is_subprocess = isinstance(self._backend, LibcameraStillBackend)
+
+        while not self._stop.is_set() and not self._grab_stop.is_set():
+            try:
+                # Apply pending controls to backend
+                with self._controls_lock:
+                    if self._pending_controls:
+                        self._last_applied = dict(self._pending_controls)
+                        self._backend.set_controls(dict(self._pending_controls))
+                        if not is_subprocess:
+                            self._pending_controls.clear()
+
+                # Handle DNG capture request
+                if self._dng_request is not None:
+                    self._handle_dng_capture()
+                    continue
+
+                # Grab frame from backend
+                array, metadata = self._backend.grab_frame()
+
+                # Subprocess backends: throttle to avoid overlapping calls
+                if is_subprocess:
+                    self._stop.wait(1.0)
+
+                metadata["_capture_time"] = time.time()
+                # Inject requested values so OSD/UI shows what was asked for
+                applied = getattr(self, '_last_applied', {})
+                req_exp = applied.get("ExposureTime")
+                req_gain = applied.get("AnalogueGain")
+                if req_exp is not None:
+                    metadata["requested_exposure"] = req_exp
+                if req_gain is not None:
+                    metadata["requested_gain"] = req_gain
+                self._metadata = metadata
+                self._frame_count += 1
+
+                # Save full-res frame to temp file for capture worker
+                frame_path = "/tmp/indi_allsky_frame.npy"
+                np.save(frame_path, array)
+
+                with self._frame_lock:
+                    self._latest_frame_path = frame_path
+                    self._frame_event.set()
+
+                # Encode stream JPEG with overlay
+                if cv2 is not None:
+                    stream_frame = cv2.resize(
+                        array,
+                        (self._stream_width, self._stream_height),
+                        interpolation=cv2.INTER_AREA,
+                    )
+                    # picamera2 RGB888 actually outputs BGR (OpenCV convention)
+                    stream_bgr = stream_frame
+
+                    # Apply OSD overlay (text, cardinals, moon)
+                    if self._overlay is not None and self._osd_enabled:
+                        try:
+                            stream_bgr = self._overlay.apply(stream_bgr, metadata)
+                        except Exception:
+                            pass  # non-fatal
+
+                    ok, jpeg_buf = cv2.imencode(
+                        ".jpg", stream_bgr,
+                        [cv2.IMWRITE_JPEG_QUALITY, self._stream_quality],
+                    )
+                    if ok:
+                        self._publish_frame(bytes(jpeg_buf), frame_path)
+
+            except Exception:
+                logger.exception("Grab loop error")
+                time.sleep(1.0)
+
+    def _handle_dng_capture(self) -> None:
+        """Handle a DNG capture request from the control socket."""
+        req = self._dng_request
+        self._dng_request = None
+        try:
+            output_path = req.get("path", "/tmp/indi_allsky_capture.dng")
+            self._backend.capture_dng(output_path)
+            self._dng_result = {"ok": True, "path": output_path}
+        except Exception as e:
+            self._dng_result = {"ok": False, "error": str(e)}
+        self._dng_event.set()
+
+    def _watchdog(self) -> None:
+        """Monitor grab loop health; restart backend if frames stall."""
+        STALL_TIMEOUT = 120  # seconds with no new frame before restart
+        last_count = 0
+        last_change = time.time()
+
+        while not self._stop.is_set():
+            self._stop.wait(10)  # check every 10s
+            count = self._frame_count
+            if count != last_count:
+                last_count = count
+                last_change = time.time()
+            else:
+                stall = time.time() - last_change
+                if stall > STALL_TIMEOUT:
+                    logger.warning(
+                        "Watchdog: no new frames in %ds (count=%d), restarting backend",
+                        int(stall), count,
+                    )
+                    try:
+                        self._grab_stop.set()
+                        if self._grab_thread is not None:
+                            self._grab_thread.join(timeout=5)
+                        self._backend.stop()
+                        time.sleep(1)
+                        self._backend.start()
+                        self._sensor_info = dict(self._backend.sensor_info)
+                        self._grab_stop.clear()
+                        self._grab_thread = threading.Thread(
+                            target=self._grab_loop, name="picam2-grab", daemon=True,
+                        )
+                        self._grab_thread.start()
+                        last_count = self._frame_count
+                        last_change = time.time()
+                        logger.info("Watchdog: backend restarted successfully")
+                    except Exception:
+                        logger.exception("Watchdog: backend restart failed")
+
+    # ------------------------------------------------------------------
+    # Control socket
+    # ------------------------------------------------------------------
+
+    def _start_socket_server(self) -> None:
+        """Listen for control commands on a Unix socket."""
+        sock_dir = os.path.dirname(SOCK_PATH)
+        os.makedirs(sock_dir, exist_ok=True)
+        if os.path.exists(SOCK_PATH):
+            os.unlink(SOCK_PATH)
+
+        # Start grab loop in background
+        self._grab_stop.clear()
+        self._grab_thread = threading.Thread(
+            target=self._grab_loop, name="picam2-grab", daemon=True,
+        )
+        self._grab_thread.start()
+
+        # Watchdog: restart backend if grab loop stalls
+        self._watchdog_thread = threading.Thread(
+            target=self._watchdog, name="watchdog", daemon=True,
+        )
+        self._watchdog_thread.start()
+
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        srv.bind(SOCK_PATH)
+        os.chmod(SOCK_PATH, 0o666)
+        srv.listen(8)
+        srv.settimeout(1.0)
+
+        logger.info("Picamera2 daemon listening on %s", SOCK_PATH)
+
+        while not self._stop.is_set():
+            try:
+                readable, _, _ = select.select([srv], [], [], 1.0)
+            except (select.error, OSError):
+                break
+            if not readable:
+                continue
+            try:
+                conn, _ = srv.accept()
+            except socket.timeout:
+                continue
+            threading.Thread(
+                target=self._handle_client,
+                args=(conn,),
+                daemon=True,
+            ).start()
+
+        srv.close()
+        if os.path.exists(SOCK_PATH):
+            os.unlink(SOCK_PATH)
+
+    def _handle_client(self, conn: socket.socket) -> None:
+        """Handle one client connection (may send multiple commands)."""
+        conn.settimeout(30.0)
+        buf = b""
+        try:
+            while not self._stop.is_set():
+                try:
+                    data = conn.recv(4096)
+                except socket.timeout:
+                    continue
+                if not data:
+                    break
+                buf += data
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    try:
+                        cmd = json.loads(line)
+                        resp = self._dispatch(cmd)
+                    except Exception as e:
+                        resp = {"ok": False, "error": str(e)}
+                    conn.sendall(json.dumps(resp).encode() + b"\n")
+        except Exception:
+            pass
+        finally:
+            conn.close()
+
+    def _dispatch(self, cmd: dict) -> dict:
+        """Route a command to the appropriate handler."""
+        action = cmd.get("cmd", "")
+
+        if action == "get_sensor_info":
+            return {"ok": True, **self._sensor_info}
+
+        elif action == "get_modes":
+            # Return available sensor modes + current stream size
+            modes = []
+            try:
+                for mode in self._picam2.sensor_modes:
+                    modes.append({
+                        "width": mode.get("size", (0, 0))[0],
+                        "height": mode.get("size", (0, 0))[1],
+                        "fps": mode.get("fps", 0),
+                        "format": str(mode.get("format", "")),
+                        "bit_depth": mode.get("bit_depth", 0),
+                    })
+            except Exception:
+                pass
+            return {
+                "ok": True,
+                "modes": modes,
+                "stream_width": self._stream_width,
+                "stream_height": self._stream_height,
+                "stream_quality": self._stream_quality,
+                "capture_width": self._sensor_info.get("width", 0),
+                "capture_height": self._sensor_info.get("height", 0),
+            }
+
+        elif action == "get_metadata":
+            # Sanitize metadata values for JSON serialization
+            meta = {}
+            for k, v in self._metadata.items():
+                try:
+                    json.dumps(v)  # test if serializable
+                    meta[k] = v
+                except (TypeError, ValueError):
+                    meta[k] = str(v)
+            meta["frame_count"] = self._frame_count
+            meta["latest_frame_path"] = self._latest_frame_path
+            return {"ok": True, "metadata": meta}
+
+        elif action == "set_controls":
+            controls: dict[str, Any] = {}
+            if "exposure" in cmd:
+                controls["ExposureTime"] = int(float(cmd["exposure"]) * 1e6)
+                controls["AeEnable"] = False
+            if "gain" in cmd:
+                controls["AnalogueGain"] = float(cmd["gain"])
+                controls["AeEnable"] = False
+            if "awb" in cmd:
+                controls["AwbEnable"] = bool(cmd["awb"])
+            if "ae_enable" in cmd:
+                controls["AeEnable"] = bool(cmd["ae_enable"])
+
+            if controls:
+                with self._controls_lock:
+                    self._pending_controls.update(controls)
+            return {"ok": True}
+
+        elif action == "capture_still":
+            # Apply controls, wait for the grab loop to deliver a frame
+            if "exposure" in cmd or "gain" in cmd:
+                controls = {}
+                if "exposure" in cmd:
+                    controls["ExposureTime"] = int(float(cmd["exposure"]) * 1e6)
+                    controls["AeEnable"] = False
+                if "gain" in cmd:
+                    controls["AnalogueGain"] = float(cmd["gain"])
+                with self._controls_lock:
+                    self._pending_controls.update(controls)
+
+            self._frame_event.clear()
+            if not self._frame_event.wait(timeout=cmd.get("timeout", 120)):
+                return {"ok": False, "error": "Capture timeout"}
+
+            with self._frame_lock:
+                path = self._latest_frame_path
+
+            meta = dict(self._metadata)
+            return {
+                "ok": True,
+                "frame_path": path,
+                "metadata": meta,
+                "frame_count": self._frame_count,
+            }
+
+        elif action == "capture_dng":
+            self._dng_event.clear()
+            self._dng_request = cmd
+            if not self._dng_event.wait(timeout=cmd.get("timeout", 120)):
+                return {"ok": False, "error": "DNG capture timeout"}
+            result = self._dng_result or {"ok": False, "error": "No result"}
+            self._dng_result = None
+            return result
+
+        elif action == "set_binning":
+            level = int(cmd.get("level", 1))
+            width = int(cmd.get("width", 0))
+            height = int(cmd.get("height", 0))
+            if width and height:
+                try:
+                    self._stop_grab()
+                    config = self._picam2.create_still_configuration(
+                        main={"size": (width, height), "format": "RGB888"},
+                        buffer_count=2,
+                    )
+                    self._picam2.configure(config)
+                    self._picam2.start()
+                    self._sensor_info["width"] = width
+                    self._sensor_info["height"] = height
+                    self._restart_grab()
+                    return {"ok": True}
+                except Exception as e:
+                    return {"ok": False, "error": str(e)}
+            return {"ok": True}
+
+        elif action == "set_stream":
+            if "width" in cmd:
+                self._stream_width = int(cmd["width"])
+            if "height" in cmd:
+                self._stream_height = int(cmd["height"])
+            if "quality" in cmd:
+                self._stream_quality = int(cmd["quality"])
+            if "osd" in cmd:
+                self._osd_enabled = bool(cmd["osd"])
+            # Persist to DB so it survives restarts
+            try:
+                import sqlite3
+                conn = sqlite3.connect("/var/lib/indi-allsky/indi-allsky.sqlite")
+                row = conn.execute("SELECT data FROM config ORDER BY id DESC LIMIT 1").fetchone()
+                if row:
+                    cfg = json.loads(row[0])
+                    cfg["STREAM_WIDTH"] = self._stream_width
+                    cfg["STREAM_HEIGHT"] = self._stream_height
+                    cfg["STREAM_QUALITY"] = self._stream_quality
+                    cfg["STREAM_OSD"] = self._osd_enabled
+                    conn.execute("UPDATE config SET data=? WHERE id=(SELECT id FROM config ORDER BY id DESC LIMIT 1)",
+                                 [json.dumps(cfg)])
+                    conn.commit()
+                conn.close()
+            except Exception:
+                pass
+            return {"ok": True}
+
+        elif action == "set_backend":
+            new_backend = cmd.get("backend", "auto")
+            return self._switch_backend(new_backend)
+
+        elif action == "get_backend":
+            return {
+                "ok": True,
+                "backend": self._sensor_info.get("backend", "unknown"),
+                "backend_type": self._backend_type,
+                "sensor_info": self._sensor_info,
+            }
+
+        elif action == "ping":
+            return {"ok": True, "frame_count": self._frame_count}
+
+        else:
+            return {"ok": False, "error": f"Unknown command: {action}"}
+
+    def _stop_grab(self) -> None:
+        """Temporarily stop camera for reconfiguration."""
+        self._backend.stop()
+
+    def _restart_grab(self) -> None:
+        """Restart camera after reconfiguration."""
+        self._backend.start()
+
+    def _switch_backend(self, new_backend_type: str) -> dict:
+        """Hot-switch to a different camera backend."""
+        old_type = self._backend_type
+        logger.info("Switching backend: %s -> %s", old_type, new_backend_type)
+
+        try:
+            from .camera_backend import create_backend
+        except ImportError:
+            import importlib.util
+            spec = importlib.util.spec_from_file_location(
+                "camera_backend",
+                os.path.join(os.path.dirname(os.path.abspath(__file__)), "camera_backend.py"),
+            )
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            create_backend = mod.create_backend
+
+        # Stop the grab thread so it doesn't touch the old backend
+        self._grab_stop.set()
+        if hasattr(self, '_grab_thread') and self._grab_thread is not None:
+            self._grab_thread.join(timeout=5.0)
+
+        # Stop old backend
+        try:
+            self._backend.stop()
+        except Exception:
+            logger.exception("Error stopping old backend")
+
+        # Create and start new backend
+        try:
+            self._backend = create_backend(new_backend_type, self._camera_num)
+            self._backend.start()
+            self._backend_type = new_backend_type
+            self._sensor_info = dict(self._backend.sensor_info)
+        except Exception as e:
+            logger.exception("Failed to start new backend '%s', reverting to '%s'",
+                             new_backend_type, old_type)
+            try:
+                self._backend = create_backend(old_type, self._camera_num)
+                self._backend.start()
+                self._sensor_info = dict(self._backend.sensor_info)
+            except Exception:
+                logger.exception("Failed to revert backend!")
+                return {"ok": False, "error": f"Backend switch failed and revert failed: {e}"}
+            return {"ok": False, "error": f"Failed to start '{new_backend_type}': {e}"}
+
+        # Restart grab thread
+        self._grab_stop.clear()
+        self._grab_thread = threading.Thread(
+            target=self._grab_loop, name="grab-loop", daemon=True,
+        )
+        self._grab_thread.start()
+
+        # Persist to DB
+        try:
+            import sqlite3
+            conn = sqlite3.connect("/var/lib/indi-allsky/indi-allsky.sqlite")
+            row = conn.execute("SELECT data FROM config ORDER BY id DESC LIMIT 1").fetchone()
+            if row:
+                cfg = json.loads(row[0])
+                cfg.setdefault("LIBCAMERA", {})["BACKEND"] = new_backend_type
+                conn.execute(
+                    "UPDATE config SET data=? WHERE id=(SELECT id FROM config ORDER BY id DESC LIMIT 1)",
+                    [json.dumps(cfg)],
+                )
+                conn.commit()
+            conn.close()
+        except Exception:
+            logger.exception("Failed to persist backend change to DB")
+
+        logger.info(
+            "Backend switched: %s -> %s (%s %dx%d)",
+            old_type, new_backend_type,
+            self._sensor_info.get("sensor_name", "?"),
+            self._sensor_info.get("width", 0), self._sensor_info.get("height", 0),
+        )
+        return {"ok": True, "backend": new_backend_type, "sensor_info": self._sensor_info}
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def _cleanup(self) -> None:
+        self._stop.set()
+        if hasattr(self, '_backend') and self._backend is not None:
+            try:
+                self._backend.stop()
+            except Exception:
+                pass
+        if self._shm is not None:
+            try:
+                self._shm.close()
+                self._shm.unlink()
+            except Exception:
+                pass
+        if os.path.exists(SOCK_PATH):
+            try:
+                os.unlink(SOCK_PATH)
+            except OSError:
+                pass
+
+
+# ------------------------------------------------------------------
+# Client class (used by CaptureWorker and Flask)
+# ------------------------------------------------------------------
+
+class Picamera2Client:
+    """Connect to the picamera2 daemon via Unix socket + shared memory."""
+
+    def __init__(self, sock_path: str = SOCK_PATH) -> None:
+        self._sock_path = sock_path
+        self._sock: Optional[socket.socket] = None
+        self._shm: Optional[shared_memory.SharedMemory] = None
+
+    def connect(self) -> None:
+        if self._sock is not None:
+            return
+        self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._sock.connect(self._sock_path)
+        self._sock.settimeout(120.0)
+
+    def close(self) -> None:
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except Exception:
+                pass
+            self._sock = None
+        if self._shm is not None:
+            try:
+                self._shm.close()
+            except Exception:
+                pass
+            self._shm = None
+
+    def _send(self, cmd: dict) -> dict:
+        self.connect()
+        msg = json.dumps(cmd).encode() + b"\n"
+        self._sock.sendall(msg)
+        # Read response line
+        buf = b""
+        while b"\n" not in buf:
+            data = self._sock.recv(4096)
+            if not data:
+                raise ConnectionError("Daemon closed connection")
+            buf += data
+        line = buf.split(b"\n", 1)[0]
+        return json.loads(line)
+
+    def ping(self) -> dict:
+        return self._send({"cmd": "ping"})
+
+    def get_sensor_info(self) -> dict:
+        return self._send({"cmd": "get_sensor_info"})
+
+    def get_metadata(self) -> dict:
+        return self._send({"cmd": "get_metadata"})
+
+    def set_controls(self, **kwargs) -> dict:
+        return self._send({"cmd": "set_controls", **kwargs})
+
+    def capture_still(self, exposure: float = None, gain: float = None,
+                      timeout: float = 120) -> dict:
+        cmd: dict[str, Any] = {"cmd": "capture_still", "timeout": timeout}
+        if exposure is not None:
+            cmd["exposure"] = exposure
+        if gain is not None:
+            cmd["gain"] = gain
+        return self._send(cmd)
+
+    def capture_dng(self, path: str, timeout: float = 120) -> dict:
+        return self._send({"cmd": "capture_dng", "path": path, "timeout": timeout})
+
+    def set_binning(self, level: int, width: int, height: int) -> dict:
+        return self._send({"cmd": "set_binning", "level": level,
+                           "width": width, "height": height})
+
+    def set_stream(self, width: int = None, height: int = None,
+                   quality: int = None) -> dict:
+        cmd: dict[str, Any] = {"cmd": "set_stream"}
+        if width is not None:
+            cmd["width"] = width
+        if height is not None:
+            cmd["height"] = height
+        if quality is not None:
+            cmd["quality"] = quality
+        return self._send(cmd)
+
+    # ------------------------------------------------------------------
+    # Shared memory frame reader
+    # ------------------------------------------------------------------
+
+    def _open_shm(self) -> None:
+        if self._shm is None:
+            self._shm = shared_memory.SharedMemory(name=SHM_NAME)
+
+    def get_stream_jpeg(self) -> Optional[tuple[bytes, int]]:
+        """Read the latest JPEG frame from shared memory.
+
+        Returns (jpeg_bytes, sequence_counter) or None.
+        """
+        try:
+            self._open_shm()
+        except FileNotFoundError:
+            return None
+
+        buf = self._shm.buf
+        seq, w, h, ch, jpeg_len = struct.unpack_from("<QIIiI", buf, 0)
+        if jpeg_len <= 0 or jpeg_len > SHM_JPEG_MAX:
+            return None
+        jpeg = bytes(buf[SHM_HEADER:SHM_HEADER + jpeg_len])
+        return jpeg, seq
+
+    def get_frame_path(self) -> Optional[str]:
+        """Read the latest full-res frame path from shared memory."""
+        try:
+            self._open_shm()
+        except FileNotFoundError:
+            return None
+
+        buf = self._shm.buf
+        raw = bytes(buf[SHM_PATH_OFFSET:SHM_PATH_OFFSET + SHM_PATH_SIZE])
+        path = raw.split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+        return path if path else None
+
+
+# ------------------------------------------------------------------
+# Standalone entry point
+# ------------------------------------------------------------------
+
+def main():
+    """Run the daemon as a standalone process."""
+    import sys
+    # Remove this script's directory from sys.path to prevent
+    # indi_allsky/camera/libcamera.py from shadowing the system libcamera package.
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    sys.path = [p for p in sys.path if os.path.abspath(p) != script_dir]
+
+    import argparse
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    parser = argparse.ArgumentParser(description="Picamera2 daemon for indi-allsky")
+    parser.add_argument("--camera", type=int, default=0, help="Camera number")
+    parser.add_argument("--backend", type=str, default="auto",
+                        choices=["auto", "picamera2", "libcamera", "libcamera-still"],
+                        help="Camera backend: auto (prefer picamera2), picamera2, libcamera (python3-libcamera bindings), libcamera-still (subprocess)")
+    parser.add_argument("--stream-width", type=int, default=640)
+    parser.add_argument("--stream-height", type=int, default=480)
+    parser.add_argument("--stream-quality", type=int, default=95)
+    parser.add_argument("--latitude", type=float, default=0.0)
+    parser.add_argument("--longitude", type=float, default=0.0)
+    parser.add_argument("--elevation", type=float, default=0.0)
+    parser.add_argument("--osd", type=bool, default=True)
+    args = parser.parse_args()
+
+    # Try to read location from indi-allsky config DB
+    lat, lon, elev = args.latitude, args.longitude, args.elevation
+    if lat == 0 and lon == 0:
+        try:
+            import sqlite3, json
+            conn = sqlite3.connect("/var/lib/indi-allsky/indi-allsky.sqlite")
+            row = conn.execute("SELECT data FROM config ORDER BY id DESC LIMIT 1").fetchone()
+            conn.close()
+            if row:
+                cfg = json.loads(row[0])
+                lat = cfg.get("LOCATION_LATITUDE", cfg.get("LATITUDE", 0))
+                lon = cfg.get("LOCATION_LONGITUDE", cfg.get("LONGITUDE", 0))
+                elev = cfg.get("LOCATION_ELEVATION", cfg.get("ELEVATION", 0))
+                if lat or lon:
+                    logging.info("Location from DB: lat=%.4f lon=%.4f elev=%.0f", lat, lon, elev)
+                # Restore stream settings if saved
+                if cfg.get("STREAM_WIDTH") and args.stream_width == 640:
+                    args.stream_width = cfg["STREAM_WIDTH"]
+                    args.stream_height = cfg.get("STREAM_HEIGHT", 480)
+                    args.stream_quality = cfg.get("STREAM_QUALITY", 95)
+                    logging.info("Stream settings from DB: %dx%d q%d",
+                                 args.stream_width, args.stream_height, args.stream_quality)
+                if "STREAM_OSD" in cfg:
+                    args.osd = cfg["STREAM_OSD"]
+                # Read backend from DB config if not specified on command line
+                db_backend = cfg.get("LIBCAMERA", {}).get("BACKEND", "auto")
+                if args.backend == "auto" and db_backend and db_backend != "auto":
+                    args.backend = db_backend
+                    logging.info("Camera backend from DB config: %s", args.backend)
+        except Exception as e:
+            logging.warning("Could not read location from DB: %s", e)
+
+    # Also honour ALLSKY_CAMERA_BACKEND env var (overrides DB and default)
+    import os as _os
+    env_backend = _os.environ.get("ALLSKY_CAMERA_BACKEND", "").strip()
+    if env_backend:
+        args.backend = env_backend
+        logging.info("Camera backend from env ALLSKY_CAMERA_BACKEND: %s", args.backend)
+
+    daemon = Picamera2Daemon(
+        camera_num=args.camera,
+        stream_width=args.stream_width,
+        stream_height=args.stream_height,
+        stream_quality=args.stream_quality,
+        latitude=lat,
+        longitude=lon,
+        elevation=elev,
+        backend_type=args.backend,
+    )
+    daemon._osd_enabled = args.osd
+    try:
+        daemon.run()
+    except KeyboardInterrupt:
+        daemon.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/indi_allsky/camera/stream_overlay.py
+++ b/indi_allsky/camera/stream_overlay.py
@@ -1,0 +1,531 @@
+"""Stream overlay using indi-allsky's actual overlay modules.
+
+Imports the real CardinalDirs, Orb, MoonOverlay classes and uses
+Pillow for text rendering (matching the original processing.py exactly).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import logging
+import os
+import re
+import sqlite3
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+
+try:
+    import cv2
+except ImportError:
+    cv2 = None
+
+try:
+    import ephem
+except ImportError:
+    ephem = None
+
+try:
+    from PIL import Image as PILImage, ImageFont, ImageDraw
+    _has_pillow = True
+except ImportError:
+    _has_pillow = False
+
+logger = logging.getLogger(__name__)
+
+DB_PATH = "/var/lib/indi-allsky/indi-allsky.sqlite"
+
+
+class _Constants:
+    POSITION_LATITUDE = 0
+    POSITION_LONGITUDE = 1
+    POSITION_ELEVATION = 2
+
+
+def _load_config() -> dict:
+    try:
+        conn = sqlite3.connect(DB_PATH)
+        row = conn.execute("SELECT data FROM config ORDER BY id DESC LIMIT 1").fetchone()
+        conn.close()
+        if row:
+            return json.loads(row[0])
+    except Exception as e:
+        logger.warning("Could not load config from DB: %s", e)
+    return {}
+
+
+def _try_import_overlay(module_name: str, class_name: str):
+    overlay_dir = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "..", "overlay"
+    )
+    module_path = os.path.join(overlay_dir, module_name + ".py")
+    if not os.path.isfile(module_path):
+        return None
+    import importlib.util
+    if "indi_allsky.constants" not in sys.modules:
+        sys.modules["indi_allsky"] = type(sys)("indi_allsky")
+        sys.modules["indi_allsky.constants"] = _Constants
+        sys.modules["indi_allsky"].constants = _Constants
+    spec = importlib.util.spec_from_file_location(
+        f"indi_allsky.overlay.{module_name}", module_path,
+        submodule_search_locations=[overlay_dir],
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"indi_allsky.overlay.{module_name}"] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as e:
+        logger.warning("Could not import overlay %s: %s", module_name, e)
+        return None
+    return getattr(mod, class_name, None)
+
+
+# Font search paths (same as original)
+FONT_PATHS = [
+    Path("/usr/share/fonts"),
+    Path("/usr/local/share/fonts"),
+]
+
+
+class StreamOverlay:
+    """Render OSD onto stream frames using indi-allsky's overlay modules + Pillow text."""
+
+    def __init__(
+        self,
+        latitude: float = 0.0,
+        longitude: float = 0.0,
+        elevation: float = 0.0,
+    ) -> None:
+        self._lat = latitude
+        self._lon = longitude
+        self._elev = elevation
+        self._config = _load_config()
+
+        # Text properties (from config, same as processing.py)
+        tp = self._config.get("TEXT_PROPERTIES", {})
+        self._text_color_rgb = list(tp.get("FONT_COLOR", [200, 200, 200]))
+        self._text_xy = [int(tp.get("FONT_X", 30)), int(tp.get("FONT_Y", 30))]
+        self._text_size_pillow = int(tp.get("PIL_FONT_SIZE", 30))
+        self._text_font_height = int(tp.get("FONT_HEIGHT", 30))
+        self._text_anchor = "la"
+        self._font_outline = tp.get("FONT_OUTLINE", True)
+
+        # Font file
+        font_file = tp.get("PIL_FONT_FILE", "fonts-freefont-ttf/FreeMonoBold.ttf")
+        self._font_path = self._find_font(font_file)
+
+        # Label template
+        self._label_template = self._config.get(
+            "IMAGE_LABEL_TEMPLATE",
+            "{timestamp:%Y%m%d %H:%M:%S}\nExposure {exposure:0.2f}s\nGain {gain_f:0.2f}",
+        )
+
+        # Ephem observer
+        self._observer: Any = None
+        if ephem is not None and (latitude != 0 or longitude != 0):
+            self._observer = ephem.Observer()
+            self._observer.lat = str(latitude)
+            self._observer.lon = str(longitude)
+            self._observer.elevation = elevation
+            self._observer.pressure = 0
+
+        self._astro_cache: dict = {}
+        self._astro_cache_time: float = 0
+
+        # Position (simple list, no multiprocessing needed for stream)
+        self._position_av = [latitude, longitude, elevation]
+
+        # Import overlay modules
+        self._cardinal_dirs = None
+        self._orb = None
+        self._moon_overlay = None
+
+        CardinalCls = _try_import_overlay("cardinalDirsLabel", "IndiAllskyCardinalDirsLabel")
+        if CardinalCls:
+            try:
+                self._cardinal_dirs = CardinalCls(self._config)
+            except Exception as e:
+                logger.warning("Cardinal dirs init failed: %s", e)
+
+        OrbCls = _try_import_overlay("orb", "IndiAllskyOrbGenerator")
+        if OrbCls:
+            try:
+                self._orb = OrbCls(self._config)
+                self._orb.sun_alt_deg = self._config.get('NIGHT_SUN_ALT_DEG', -6.0)
+                self._orb.azimuth_offset = self._config.get('ORB_PROPERTIES', {}).get('AZ_OFFSET', 0.0)
+                self._orb.retrograde = self._config.get('ORB_PROPERTIES', {}).get('RETROGRADE', False)
+                self._orb.sun_color_rgb = self._config.get('ORB_PROPERTIES', {}).get('SUN_COLOR', [200, 200, 0])
+                self._orb.moon_color_rgb = self._config.get('ORB_PROPERTIES', {}).get('MOON_COLOR', [128, 128, 128])
+            except Exception as e:
+                logger.warning("Orb init failed: %s", e)
+
+        MoonCls = _try_import_overlay("moonOverlay", "IndiAllSkyMoonOverlay")
+        if MoonCls:
+            try:
+                self._moon_overlay = MoonCls(self._config)
+            except Exception as e:
+                logger.warning("Moon overlay init failed: %s", e)
+
+        self._moon_scaled = False
+        self._logo = None
+        self._logo_alpha = None
+
+    def _find_font(self, font_file: str) -> Optional[Path]:
+        """Locate a font file in system font paths."""
+        for base in FONT_PATHS:
+            p = base / font_file
+            if p.is_file():
+                return p
+        # Try truetype subdirs
+        for base in FONT_PATHS:
+            for sub in base.rglob(Path(font_file).name):
+                if sub.is_file():
+                    return sub
+        return None
+
+    # ------------------------------------------------------------------
+    # Main apply
+    # ------------------------------------------------------------------
+
+    def apply(self, frame: np.ndarray, metadata: dict) -> np.ndarray:
+        if cv2 is None:
+            return frame
+
+        h, w = frame.shape[:2]
+        self._refresh_astro()
+        full_w = 4056
+        scale = max(0.15, w / full_w)
+
+        # 1. Orb — scale radius
+        if self._orb:
+            orig_radius = self._config.get("ORB_PROPERTIES", {}).get("RADIUS", 9)
+            self._orb.config["ORB_PROPERTIES"]["RADIUS"] = max(2, int(orig_radius * scale))
+            self._apply_orb(frame)
+            self._orb.config["ORB_PROPERTIES"]["RADIUS"] = orig_radius
+
+        # 2. Cardinal dirs — draw at image edges with padding
+        if self._config.get("CARDINAL_DIRS", {}).get("ENABLE"):
+            self._draw_cardinals_edge(frame, w, h, scale)
+
+        # 3. Moon overlay — scale position and size once
+        if self._moon_overlay and self._config.get("MOON_OVERLAY", {}).get("ENABLE", True):
+            try:
+                if not self._moon_scaled:
+                    self._moon_overlay.x = int(self._moon_overlay.x * scale)
+                    self._moon_overlay.y = int(self._moon_overlay.y * scale)
+                    self._moon_overlay.scale = self._moon_overlay.scale * scale
+                    self._moon_overlay.moon_orig = None
+                    self._moon_scaled = True
+                moon_cycle = self._astro_cache.get("moon_cycle", 0)
+                moon_phase = self._astro_cache.get("moon_phase", 0)
+                self._moon_overlay.apply(frame, moon_cycle, moon_phase)
+            except Exception as e:
+                logger.debug("Moon overlay error: %s", e)
+
+        # 4. Text label using Pillow (matches processing.py exactly)
+        self._draw_label_pillow(frame, w, h, metadata, scale)
+
+        return frame
+
+    # ------------------------------------------------------------------
+    # Pillow text rendering (extracted from processing.py)
+    # ------------------------------------------------------------------
+
+    def _draw_cardinals_edge(self, frame: np.ndarray, w: int, h: int, scale: float) -> None:
+        """Draw N/S/E/W labels at image edges with equal padding."""
+        if not _has_pillow:
+            return
+        cfg = self._config.get("CARDINAL_DIRS", {})
+        color_rgb = tuple(cfg.get("FONT_COLOR", [255, 0, 0]))
+        pad = max(5, int(15 * scale))
+        font_size = max(12, int(cfg.get("PIL_FONT_SIZE", 20) * scale))
+
+        try:
+            font = ImageFont.truetype(str(self._font_path), font_size) if self._font_path else ImageFont.load_default()
+        except Exception:
+            font = ImageFont.load_default()
+
+        chars = {
+            "N": cfg.get("CHAR_NORTH", "N"),
+            "S": cfg.get("CHAR_SOUTH", "S"),
+            "E": cfg.get("CHAR_EAST", "E"),
+            "W": cfg.get("CHAR_WEST", "W"),
+        }
+        if cfg.get("SWAP_NS"):
+            chars["N"], chars["S"] = chars["S"], chars["N"]
+        if cfg.get("SWAP_EW"):
+            chars["E"], chars["W"] = chars["W"], chars["E"]
+
+        # Frame is BGR; Pillow sees it as RGB, so swap R/B in colors
+        color_bgr = (color_rgb[2], color_rgb[1], color_rgb[0])
+        img = PILImage.fromarray(frame)
+        draw = ImageDraw.Draw(img)
+
+        stroke = max(1, int(4 * scale)) if self._font_outline else 0
+
+        # Respect IMAGE_FLIP_V/H
+        if self._config.get("IMAGE_FLIP_V"):
+            chars["N"], chars["S"] = chars["S"], chars["N"]
+        if self._config.get("IMAGE_FLIP_H"):
+            chars["E"], chars["W"] = chars["W"], chars["E"]
+
+        draw.text((w // 2, pad), chars["N"], fill=color_bgr, font=font,
+                  anchor="mt", stroke_width=stroke, stroke_fill=(0, 0, 0))
+        draw.text((w // 2, h - pad), chars["S"], fill=color_bgr, font=font,
+                  anchor="mb", stroke_width=stroke, stroke_fill=(0, 0, 0))
+        draw.text((w - pad, h // 2), chars["E"], fill=color_bgr, font=font,
+                  anchor="rm", stroke_width=stroke, stroke_fill=(0, 0, 0))
+        draw.text((pad, h // 2), chars["W"], fill=color_bgr, font=font,
+                  anchor="lm", stroke_width=stroke, stroke_fill=(0, 0, 0))
+
+        np.copyto(frame, np.array(img))
+
+    def _draw_label_pillow(self, frame: np.ndarray, w: int, h: int,
+                           metadata: dict, scale: float) -> None:
+        """Render IMAGE_LABEL_TEMPLATE using Pillow — same as processing.py."""
+        if not _has_pillow:
+            return
+
+        # Format the template
+        text = self._format_label(metadata)
+        if not text:
+            return
+
+        # Frame is BGR; Pillow sees it as RGB — swap R/B in color tuples
+        img = PILImage.fromarray(frame)
+        draw = ImageDraw.Draw(img)
+
+        # Scale font size for stream resolution
+        base_size = self._text_size_pillow
+        font_size = max(10, int(base_size * scale))
+        font_height = max(10, int(self._text_font_height * scale))
+
+        # Reset state — config colors are RGB, swap to BGR for Pillow-on-BGR-frame
+        default_rgb = self._text_color_rgb
+        color_bgr = (int(default_rgb[2]), int(default_rgb[1]), int(default_rgb[0]))
+        xy = [int(self._text_xy[0] * scale), int(self._text_xy[1] * scale)]
+        anchor = "la"
+
+        for line in text.split("\n"):
+            if line.startswith("#"):
+                # Process directive (same regex as processing.py)
+                m_color = re.search(r'color:(\d{1,3}),(\d{1,3}),(\d{1,3})', line, re.IGNORECASE)
+                if m_color:
+                    # Template colors are RGB, swap to BGR for Pillow-on-BGR-frame
+                    color_bgr = (int(m_color.group(3)), int(m_color.group(2)), int(m_color.group(1)))
+
+                m_xy = re.search(r'xy:(-?\d+),(-?\d+)', line, re.IGNORECASE)
+                if m_xy:
+                    nx, ny = int(m_xy.group(1)), int(m_xy.group(2))
+                    xy = [
+                        int(nx * scale) if nx >= 0 else w + int(nx * scale),
+                        int(ny * scale) if ny >= 0 else h + int(ny * scale),
+                    ]
+
+                m_anchor = re.search(r'anchor:([a-z]{2})', line, re.IGNORECASE)
+                if m_anchor:
+                    anchor = m_anchor.group(1).lower()
+
+                m_size = re.search(r'size:(\d+)', line, re.IGNORECASE)
+                if m_size:
+                    sz = int(m_size.group(1))
+                    font_size = max(8, int(sz * scale))
+                    font_height = max(8, int(sz * scale))
+                continue
+
+            # Render text line
+            try:
+                font = ImageFont.truetype(str(self._font_path), font_size) if self._font_path else ImageFont.load_default()
+            except Exception:
+                font = ImageFont.load_default()
+
+            stroke_width = max(1, int(4 * scale)) if self._font_outline else 0
+
+            draw.text(
+                tuple(xy),
+                line,
+                fill=color_bgr,
+                font=font,
+                stroke_width=stroke_width,
+                stroke_fill=(0, 0, 0),
+                anchor=anchor,
+            )
+
+            xy[1] += font_height
+
+        np.copyto(frame, np.array(img))
+
+    def _format_label(self, metadata: dict) -> str:
+        """Format the IMAGE_LABEL_TEMPLATE with current values."""
+        # Prefer requested values (what we asked the camera for) over
+        # ISP actual values (which may differ due to hardware limits)
+        req_exp = metadata.get("requested_exposure")
+        exp_us = req_exp if req_exp else metadata.get("ExposureTime", 0)
+        exposure = exp_us / 1e6 if exp_us else 0
+        req_gain = metadata.get("requested_gain")
+        gain = req_gain if req_gain else metadata.get("AnalogueGain", 0)
+        temp_c = metadata.get("SensorTemperature")
+        now = datetime.now(timezone.utc)
+
+        # Temperature in configured unit
+        temp_display = self._config.get("TEMP_DISPLAY", "c")
+        if temp_c is not None:
+            if temp_display == "f":
+                temp_val = temp_c * 9 / 5 + 32
+                temp_unit = "F"
+            elif temp_display == "k":
+                temp_val = temp_c + 273.15
+                temp_unit = "K"
+            else:
+                temp_val = temp_c
+                temp_unit = "C"
+        else:
+            temp_val = 0
+            temp_unit = "C"
+
+        # Rational exposure (e.g. "1/500" for short exposures)
+        if exposure > 0 and exposure < 1:
+            from fractions import Fraction
+            rational_exp = str(Fraction(exposure).limit_denominator(10000))
+        else:
+            rational_exp = "{:.1f}".format(exposure)
+
+        sun_alt = self._astro_cache.get("sun_alt", 0)
+        moon_alt = self._astro_cache.get("moon_alt", 0)
+
+        variables = {
+            "timestamp": now,
+            "ts": now, "ts_utc": now, "timestamp_utc": now,
+            "exposure": round(exposure, 2),
+            "rational_exp": rational_exp,
+            "gain": round(gain, 2), "gain_f": round(gain, 2),
+            "temp": temp_val, "temp_unit": temp_unit,
+            "temp_c": temp_c if temp_c is not None else 0,
+            "stars": 0, "detections": 0,
+            "latitude": self._lat, "longitude": self._lon,
+            "elevation": self._elev,
+            "sun_alt": sun_alt,
+            "sun_up": "Up" if sun_alt > 0 else "Down",
+            "moon_alt": moon_alt,
+            "moon_phase": self._astro_cache.get("moon_phase", 0),
+            "moon_cycle": self._astro_cache.get("moon_cycle", 0),
+            "moon_up": "Up" if moon_alt > 0 else "Down",
+            "lux": metadata.get("Lux", 0),
+            "stretch": "", "stack_method": "", "stack_count": 0,
+            "kpindex": 0, "ovation_max": 0, "smoke_rating": "Clear",
+            "sqm": 0, "camera_sqm_raw_mag": 0,
+            # Satellites (placeholders until live data available)
+            "iss_up": "--", "iss_alt": 0, "iss_next_h": 0, "iss_next_alt": 0,
+            "hst_up": "--", "hst_alt": 0, "hst_next_h": 0, "hst_next_alt": 0,
+            "tiangong_up": "--", "tiangong_alt": 0, "tiangong_next_h": 0, "tiangong_next_alt": 0,
+            # Planets
+            "mercury_alt": self._astro_cache.get("mercury_alt", 0),
+            "mercury_up": "Up" if self._astro_cache.get("mercury_alt", 0) > 0 else "Down",
+            "venus_alt": self._astro_cache.get("venus_alt", 0),
+            "venus_up": "Up" if self._astro_cache.get("venus_alt", 0) > 0 else "Down",
+            "venus_phase": 0,
+            "mars_alt": self._astro_cache.get("mars_alt", 0),
+            "mars_up": "Up" if self._astro_cache.get("mars_alt", 0) > 0 else "Down",
+            "jupiter_alt": self._astro_cache.get("jupiter_alt", 0),
+            "jupiter_up": "Up" if self._astro_cache.get("jupiter_alt", 0) > 0 else "Down",
+            "saturn_alt": self._astro_cache.get("saturn_alt", 0),
+            "saturn_up": "Up" if self._astro_cache.get("saturn_alt", 0) > 0 else "Down",
+            # Device status placeholders
+            "dew_heater_status": "", "fan_status": "",
+            "owner": "", "location": "",
+        }
+
+        # Process template: format text lines, pass directives through
+        result_lines = []
+        for raw_line in self._label_template.split("\n"):
+            line = raw_line.strip()
+            if not line:
+                continue
+            if line.startswith("#"):
+                result_lines.append(line)
+                continue
+            try:
+                result_lines.append(line.format(**variables))
+            except (KeyError, ValueError, IndexError, TypeError):
+                result_lines.append(line)
+
+        return "\n".join(result_lines)
+
+    # ------------------------------------------------------------------
+    # Orb
+    # ------------------------------------------------------------------
+
+    def _apply_orb(self, frame: np.ndarray) -> None:
+        if self._orb is None or self._observer is None:
+            return
+        orb_mode = self._config.get("ORB_PROPERTIES", {}).get("MODE", "ha")
+        if orb_mode == "off":
+            return
+        try:
+            utcnow = datetime.now(tz=timezone.utc)
+            obs = ephem.Observer()
+            obs.lon = math.radians(self._lon)
+            obs.lat = math.radians(self._lat)
+            obs.elevation = self._elev
+            obs.pressure = 0
+            obs.date = utcnow
+            sun = ephem.Sun()
+            sun.compute(obs)
+            moon = ephem.Moon()
+            moon.compute(obs)
+            self._orb.text_color_rgb = list(self._text_color_rgb)
+            if orb_mode == "ha":
+                self._orb.drawOrbsHourAngle_opencv(frame, utcnow, obs, sun, moon)
+            elif orb_mode == "az":
+                self._orb.drawOrbsAzimuth_opencv(frame, utcnow, obs, sun, moon)
+            elif orb_mode == "alt":
+                self._orb.drawOrbsAltitude_opencv(frame, utcnow, obs, sun, moon)
+        except Exception as e:
+            logger.debug("Orb error: %s", e)
+
+    # ------------------------------------------------------------------
+    # Celestial
+    # ------------------------------------------------------------------
+
+    def _refresh_astro(self) -> None:
+        now = time.monotonic()
+        if now - self._astro_cache_time < 10.0:
+            return
+        self._astro_cache_time = now
+        if self._observer is None or ephem is None:
+            return
+        try:
+            self._observer.date = ephem.now()
+            sun = ephem.Sun(self._observer)
+            moon = ephem.Moon(self._observer)
+            sun_lon = ephem.Ecliptic(sun).lon
+            moon_lon = ephem.Ecliptic(moon).lon
+            sm_angle = (moon_lon - sun_lon) % math.tau
+            moon_cycle_pct = (sm_angle / math.tau) * 100.0
+
+            self._astro_cache = {
+                "sun_alt": math.degrees(float(sun.alt)),
+                "sun_az": math.degrees(float(sun.az)),
+                "moon_alt": math.degrees(float(moon.alt)),
+                "moon_az": math.degrees(float(moon.az)),
+                "moon_phase": moon.phase,
+                "moon_cycle": moon_cycle_pct,
+            }
+            for name, body in [
+                ("mercury", ephem.Mercury), ("venus", ephem.Venus),
+                ("mars", ephem.Mars), ("jupiter", ephem.Jupiter),
+                ("saturn", ephem.Saturn),
+            ]:
+                try:
+                    p = body(self._observer)
+                    self._astro_cache[name + "_alt"] = math.degrees(float(p.alt))
+                    self._astro_cache[name + "_az"] = math.degrees(float(p.az))
+                except Exception:
+                    pass
+        except Exception:
+            pass

--- a/indi_allsky/capture.py
+++ b/indi_allsky/capture.py
@@ -625,10 +625,14 @@ class CaptureWorker(Process):
                         if frame_delta < -1:
 
                             if self.config['CAMERA_INTERFACE'].startswith('pycurl'):
-                                ### camera does not obey expsoure values
+                                ### camera does not obey exposure values
                                 pass
                             elif self.config['CAMERA_INTERFACE'] == 'indi_passive':
-                                ### camera does not obey expsoure values
+                                ### camera does not obey exposure values
+                                pass
+                            elif self.config.get('LIBCAMERA', {}).get('BACKEND', 'auto') == 'libcamera-still':
+                                ### subprocess backend: daemon manages exposure timing,
+                                ### capture_still may return a pre-buffered stream frame
                                 pass
                             else:
                                 logger.error('%0.4fs EXPOSURE RECEIVED IN %0.4fs.  POSSIBLE CAMERA PROBLEM.', self.exposure_av[constants.EXPOSURE_CURRENT], frame_elapsed)

--- a/indi_allsky/config.py
+++ b/indi_allsky/config.py
@@ -158,6 +158,7 @@ class IndiAllSkyConfigBase(object):
         "TARGET_ADU_DAY"     : 75,
         "TARGET_ADU_DEV"     : 10,
         "TARGET_ADU_DEV_DAY" : 20,
+        "TARGET_ADU_DISABLE" : False,
         "ADU_ROI" : [],
         "ADU_FOV_DIV" : 4,
         "DETECT_STARS" : True,
@@ -597,6 +598,7 @@ class IndiAllSkyConfigBase(object):
             "CCM_DISABLE"            : False,
             "CCM_DISABLE_DAY"        : False,
             "CAMERA_ID"              : 0,
+            "BACKEND"                : "auto",  # auto | picamera2 | libcamera | libcamera-still
             "EXTRA_OPTIONS"          : "",
             "EXTRA_OPTIONS_DAY"      : "",
             "MQTT_TRANSPORT"         : "tcp",  # tcp or websockets

--- a/indi_allsky/flask/__init__.py
+++ b/indi_allsky/flask/__init__.py
@@ -19,6 +19,7 @@ from .views import bp_allsky  # noqa: E402
 from .auth_views import bp_auth_allsky  # noqa: E402
 from .syncapi_views import bp_syncapi_allsky  # noqa: E402
 from .actionapi_views import bp_actionapi_allsky  # noqa: E402
+from .captureapi_views import bp_captureapi_allsky, register_websocket  # noqa: E402
 
 
 dictConfig({
@@ -100,9 +101,14 @@ def create_app():
     app.register_blueprint(bp_auth_allsky)
     app.register_blueprint(bp_syncapi_allsky)
     app.register_blueprint(bp_actionapi_allsky)
+    app.register_blueprint(bp_captureapi_allsky)
 
     csrf.exempt(bp_syncapi_allsky)  # disable CSRF for syncapi views
     csrf.exempt(bp_actionapi_allsky)  # disable CSRF for actionapi views
+    csrf.exempt(bp_captureapi_allsky)
+
+    # Register WebSocket endpoints (requires flask-sock)
+    register_websocket(app)
 
     db.init_app(app)
     migrate.init_app(app, db, directory=app.config['MIGRATION_FOLDER'])

--- a/indi_allsky/flask/captureapi_views.py
+++ b/indi_allsky/flask/captureapi_views.py
@@ -1,0 +1,929 @@
+import subprocess
+import struct
+import threading
+import time
+import os
+import json
+import io
+
+from flask import Blueprint, jsonify, request, Response, current_app as app
+from flask.views import View
+from flask_login import login_required
+
+try:
+    from flask_sock import Sock
+    _has_flask_sock = True
+except ImportError:
+    _has_flask_sock = False
+
+bp_captureapi_allsky = Blueprint(
+    "captureapi_indi_allsky",
+    __name__,
+    url_prefix="/indi-allsky",
+)
+
+CAPTURE_CMD = "rpicam-still"
+STREAM_CMD = "rpicam-vid"
+CAMERA_ID = 0
+HTDOCS = "/var/www/html/allsky/images"
+DB_PATH = "/var/lib/indi-allsky/indi-allsky.sqlite"
+
+
+# ---------------------------------------------------------------------------
+# Allsky service helpers
+# ---------------------------------------------------------------------------
+
+LOCK_FILE = "/tmp/allsky-stream.lock"
+
+
+def _systemctl(*args):
+    """Run systemctl command, trying sudo (system) first, then --user."""
+    cmd = ["sudo", "systemctl"] + list(args)
+    r = subprocess.run(cmd, capture_output=True, timeout=10)
+    if r.returncode != 0:
+        cmd = ["systemctl", "--user"] + list(args)
+        r = subprocess.run(cmd, capture_output=True, timeout=10)
+    return r
+
+
+def _stop_allsky():
+    """No-op: picamera2 daemon owns the camera; no service contention."""
+    pass
+
+
+def _start_allsky():
+    """No-op: picamera2 daemon owns the camera; no service contention."""
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Single-shot capture (Capture One button)
+# ---------------------------------------------------------------------------
+
+def _capture(output_path, quality=90, width=None, height=None,
+             shutter=None, gain=None, awb=None, brightness=None,
+             contrast=None, saturation=None, sharpness=None,
+             denoise=None, ev=None, awbgains=None):
+    """Capture a single frame via the picamera2 daemon."""
+    from ..camera.picamera2_client import Picamera2Client
+    try:
+        client = Picamera2Client()
+        exposure = shutter / 1e6 if shutter else None
+        result = client.capture_still(exposure=exposure, gain=gain, timeout=30)
+        client.close()
+        if not result.get('ok'):
+            return False, result.get('error', 'Capture failed')
+
+        # Load the numpy frame and save as JPEG
+        import numpy as np
+        try:
+            import cv2
+        except ImportError:
+            return False, "OpenCV not available"
+
+        frame = np.load(result['frame_path'])
+        bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+        cv2.imwrite(output_path, bgr, [cv2.IMWRITE_JPEG_QUALITY, quality])
+        return True, ""
+    except Exception as e:
+        return False, str(e)
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+def _get_config():
+    import sqlite3
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT data FROM config ORDER BY createDate DESC LIMIT 1")
+    row = cur.fetchone()
+    conn.close()
+    if row:
+        return json.loads(row[0]) if isinstance(row[0], str) else row[0]
+    return {}
+
+
+def _save_config(config_data, note="slider update"):
+    """Update the latest config row in-place, or insert if none exists."""
+    import sqlite3
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    data_json = json.dumps(config_data)
+    cur.execute(
+        "UPDATE config SET data=? WHERE id=(SELECT id FROM config ORDER BY id DESC LIMIT 1)",
+        (data_json,),
+    )
+    if cur.rowcount == 0:
+        now = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
+        cur.execute(
+            "INSERT INTO config (createDate, level, encrypted, note, data) VALUES (?, '0', 0, ?, ?)",
+            (now, note, data_json),
+        )
+    conn.commit()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# MJPEG Stream Manager - single rpicam-vid process, multiple clients
+# ---------------------------------------------------------------------------
+
+class MJPEGStreamManager:
+    """Reads JPEG frames from the picamera2 daemon's shared memory.
+
+    No subprocess — the daemon owns the camera and both capture and
+    streaming read from the same shared frame buffer.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._client = None
+        self._frame = None
+        self._frame_event = threading.Event()
+        self._client_count = 0
+        self._settings = {}
+        self._running = False
+        self._metadata = {}
+        self._frame_count = 0
+        self._start_time = 0
+        self._reader_thread = None
+        self._last_seq = -1
+
+    @property
+    def running(self):
+        return self._running
+
+    @property
+    def client_count(self):
+        return self._client_count
+
+    def start(self, settings=None):
+        """Connect to picamera2 daemon shared memory. Returns (ok, error_msg)."""
+        from ..camera.picamera2_client import Picamera2Client
+        with self._lock:
+            if settings is None:
+                settings = {}
+            self._settings = settings
+            self._running = True
+            self._frame_count = 0
+            self._start_time = time.monotonic()
+            self._client = Picamera2Client()
+            self._reader_thread = threading.Thread(
+                target=self._read_frames, daemon=True)
+            self._reader_thread.start()
+        # Wait for first frame (up to 5s)
+        for _ in range(50):
+            if self._frame is not None:
+                return True, ""
+            time.sleep(0.1)
+        if self._running:
+            return True, ""  # daemon running but slow
+        return False, "No frames from picamera2 daemon"
+
+    def stop(self):
+        with self._lock:
+            self._running = False
+            if self._client:
+                self._client.close()
+                self._client = None
+
+    def update_settings(self, settings):
+        """Send updated settings to the daemon. Returns (ok, error_msg)."""
+        self._settings.update(settings)
+        if self._client:
+            try:
+                s = settings
+                if s.get("shutter") or s.get("gain"):
+                    self._client.set_controls(
+                        exposure=float(s["shutter"]) / 1e6 if s.get("shutter") else None,
+                        gain=float(s["gain"]) if s.get("gain") else None,
+                    )
+                if s.get("width") or s.get("height") or s.get("quality"):
+                    self._client.set_stream(
+                        width=int(s["width"]) if s.get("width") else None,
+                        height=int(s["height"]) if s.get("height") else None,
+                        quality=int(s["quality"]) if s.get("quality") else None,
+                    )
+            except Exception:
+                pass
+        return True, ""
+
+    def _read_frames(self):
+        """Poll shared memory for new JPEG frames from the daemon.
+
+        Only updates when a genuinely new frame arrives (seq changes).
+        Metadata is fetched once per new frame, not continuously.
+        """
+        while self._running:
+            try:
+                result = self._client.get_stream_jpeg()
+                if result is not None:
+                    jpeg, seq = result
+                    if seq != self._last_seq:
+                        self._last_seq = seq
+                        self._frame = jpeg
+                        self._frame_count += 1
+                        self._frame_event.set()
+                        self._frame_event.clear()
+                        # Fetch metadata only when we have a new frame
+                        try:
+                            meta_resp = self._client.get_metadata()
+                            if meta_resp.get('ok'):
+                                self._metadata = meta_resp.get('metadata', {})
+                        except Exception:
+                            pass
+            except Exception:
+                pass
+            time.sleep(0.1)  # poll rate — no need to be faster than frame rate
+
+    def get_frame(self, timeout=5.0):
+        if self._frame is not None:
+            return self._frame
+        self._frame_event.wait(timeout=timeout)
+        return self._frame
+
+    def wait_new_frame(self, last_count, timeout=5.0):
+        deadline = time.monotonic() + timeout
+        while self._running and time.monotonic() < deadline:
+            if self._frame_count > last_count and self._frame is not None:
+                return self._frame, self._frame_count
+            time.sleep(0.02)
+        return None, last_count
+
+    def generate(self):
+        """Generator yielding MJPEG parts — always the latest frame, never queued.
+
+        Blocks until a new frame arrives, then sends it.  If multiple
+        frames arrived while the previous send was in flight, only the
+        latest is sent — intermediates are dropped.
+        """
+        self._client_count += 1
+        try:
+            while self._running:
+                # Always grab whatever is latest RIGHT NOW
+                frame = self._frame
+                seq = self._last_seq
+                if frame is not None:
+                    yield (b'--frame\r\n'
+                           b'Content-Type: image/jpeg\r\n'
+                           b'Content-Length: ' + str(len(frame)).encode() + b'\r\n'
+                           b'\r\n' + frame + b'\r\n')
+                # Wait for a NEW frame (seq must change)
+                wait_for = seq
+                while self._running and self._last_seq == wait_for:
+                    self._frame_event.wait(timeout=1)
+        finally:
+            self._client_count -= 1
+
+    def get_settings(self):
+        return dict(self._settings)
+
+    def get_metadata(self):
+        """Return latest ISP metadata + stream stats."""
+        meta = dict(self._metadata)
+        elapsed = time.monotonic() - self._start_time if self._start_time else 0
+        capture_time = meta.get("_capture_time", 0)
+        frame_age = round(time.time() - capture_time, 1) if capture_time else None
+        meta["_stream"] = {
+            "frames": self._frame_count,
+            "elapsed": round(elapsed, 1),
+            "fps": round(self._frame_count / elapsed, 1) if elapsed > 1 else 0,
+            "clients": self._client_count,
+        }
+        meta["frame_age"] = frame_age
+        # Normalize common ISP keys — prefer requested values over ISP actual
+        if "requested_exposure" in meta:
+            meta["exposure"] = round(meta["requested_exposure"] / 1_000_000, 2)
+        elif "ExposureTime" in meta:
+            meta["exposure"] = round(meta["ExposureTime"] / 1_000_000, 2)
+        if "requested_gain" in meta:
+            meta["gain"] = round(meta["requested_gain"], 2)
+        elif "AnalogueGain" in meta:
+            meta["gain"] = round(meta["AnalogueGain"], 2)
+        # Also include ISP actual values for OSD/debug
+        if "ExposureTime" in meta:
+            meta["actual_exposure"] = round(meta["ExposureTime"] / 1_000_000, 2)
+        if "AnalogueGain" in meta:
+            meta["actual_gain"] = round(meta["AnalogueGain"], 2)
+        if "SensorTemperature" in meta:
+            meta["sensor_temp"] = meta["SensorTemperature"]
+        if "Lux" in meta:
+            meta["lux"] = round(meta["Lux"], 1)
+        if "ColourTemperature" in meta:
+            meta["colour_temp"] = meta["ColourTemperature"]
+        return meta
+
+
+# Global stream manager instance
+_stream = MJPEGStreamManager()
+
+
+# ---------------------------------------------------------------------------
+# Views
+# ---------------------------------------------------------------------------
+
+class ConfigGetMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        try:
+            cfg = _get_config()
+            ccd = cfg.get("CCD_CONFIG", {})
+            result = {
+                "NIGHT_GAIN": ccd.get("NIGHT", {}).get("GAIN", 0),
+                "MOONMODE_GAIN": ccd.get("MOONMODE", {}).get("GAIN", 0),
+                "DAY_GAIN": ccd.get("DAY", {}).get("GAIN", 0),
+                "CCD_EXPOSURE_MAX": cfg.get("CCD_EXPOSURE_MAX", 30),
+                "CCD_EXPOSURE_DEF": cfg.get("CCD_EXPOSURE_DEF", 5),
+                "TARGET_ADU": cfg.get("TARGET_ADU", 75),
+                "TARGET_ADU_DAY": cfg.get("TARGET_ADU_DAY", 100),
+                "SATURATION_FACTOR": cfg.get("SATURATION_FACTOR", 1.0),
+                "SATURATION_FACTOR_DAY": cfg.get("SATURATION_FACTOR_DAY", 1.0),
+                "GAMMA_CORRECTION": cfg.get("GAMMA_CORRECTION", 1.0),
+                "GAMMA_CORRECTION_DAY": cfg.get("GAMMA_CORRECTION_DAY", 1.0),
+                "SHARPEN_AMOUNT": cfg.get("SHARPEN_AMOUNT", 0.0),
+                "SHARPEN_AMOUNT_DAY": cfg.get("SHARPEN_AMOUNT_DAY", 0.0),
+                "IMAGE_FLIP_V": cfg.get("IMAGE_FLIP_V", False),
+                "IMAGE_FLIP_H": cfg.get("IMAGE_FLIP_H", False),
+                "EXPOSURE_PERIOD": cfg.get("EXPOSURE_PERIOD", 35),
+                "EXPOSURE_PERIOD_DAY": cfg.get("EXPOSURE_PERIOD_DAY", 15),
+            }
+            return jsonify(result), 200
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+
+class ConfigSetMethodView(View):
+    decorators = [login_required]
+    methods = ["POST"]
+
+    def dispatch_request(self):
+        try:
+            updates = request.get_json(force=True)
+            if not updates:
+                return jsonify({"error": "No data"}), 400
+            cfg = _get_config()
+            ccd = cfg.setdefault("CCD_CONFIG", {})
+            key_map = {
+                "NIGHT_GAIN": lambda v: ccd.setdefault("NIGHT", {}).update({"GAIN": float(v)}),
+                "MOONMODE_GAIN": lambda v: ccd.setdefault("MOONMODE", {}).update({"GAIN": float(v)}),
+                "DAY_GAIN": lambda v: ccd.setdefault("DAY", {}).update({"GAIN": float(v)}),
+            }
+            flat_keys = [
+                "CCD_EXPOSURE_MAX", "CCD_EXPOSURE_DEF", "EXPOSURE_PERIOD", "EXPOSURE_PERIOD_DAY",
+                "SATURATION_FACTOR", "SATURATION_FACTOR_DAY",
+                "GAMMA_CORRECTION", "GAMMA_CORRECTION_DAY",
+                "SHARPEN_AMOUNT", "SHARPEN_AMOUNT_DAY",
+            ]
+            int_keys = ["TARGET_ADU", "TARGET_ADU_DAY"]
+            bool_keys = ["IMAGE_FLIP_V", "IMAGE_FLIP_H"]
+            changed = []
+            for k, v in updates.items():
+                if k in key_map:
+                    key_map[k](v)
+                    changed.append(k)
+                elif k in flat_keys:
+                    cfg[k] = float(v)
+                    changed.append(k)
+                elif k in int_keys:
+                    cfg[k] = int(v)
+                    changed.append(k)
+                elif k in bool_keys:
+                    cfg[k] = bool(v)
+                    changed.append(k)
+            if changed:
+                _save_config(cfg, note="live slider: " + ", ".join(changed))
+            return jsonify({"message": "Config updated", "changed": changed}), 200
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+
+class CaptureOneMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        try:
+            dest = os.path.join(HTDOCS, "capture_one.jpg")
+
+            # If stream is running, grab a frame from it (no rpicam-still needed)
+            if _stream.running:
+                frame = _stream.get_frame(timeout=5)
+                if frame is None:
+                    return jsonify({"error": "Stream active but no frame available"}), 500
+                with open(dest, "wb") as f:
+                    f.write(frame)
+                return jsonify({
+                    "url": "/indi-allsky/images/capture_one.jpg?t=" + str(int(time.time())),
+                    "message": "Captured from stream",
+                }), 200
+
+            # No stream running - stop allsky, do a still capture, restart
+            _stop_allsky()
+            ok, err = _capture(dest, quality=90,
+                               shutter=request.args.get("shutter", None, type=int),
+                               gain=request.args.get("gain", None, type=float),
+                               awb=request.args.get("awb", None),
+                               brightness=request.args.get("brightness", None, type=float),
+                               contrast=request.args.get("contrast", None, type=float),
+                               saturation=request.args.get("saturation", None, type=float),
+                               sharpness=request.args.get("sharpness", None, type=float),
+                               awbgains=request.args.get("awbgains", None))
+            _start_allsky()
+
+            if not ok:
+                return jsonify({"error": err}), 500
+            return jsonify({
+                "url": "/indi-allsky/images/capture_one.jpg?t=" + str(int(time.time())),
+                "message": "Captured",
+            }), 200
+        except subprocess.TimeoutExpired:
+            _start_allsky()
+            return jsonify({"error": "Capture timed out"}), 500
+        except Exception as e:
+            _start_allsky()
+            return jsonify({"error": str(e)}), 500
+
+
+class StreamStartMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        settings = {}
+        for key in ["shutter", "gain", "brightness", "contrast",
+                     "saturation", "sharpness", "awb", "awbgains",
+                     "denoise", "framerate"]:
+            val = request.args.get(key, None)
+            if val is not None:
+                settings[key] = val
+        ok, err = _stream.start(settings)
+        if not ok:
+            return jsonify({"error": err}), 500
+        return jsonify({"message": "Stream started",
+                        "clients": _stream.client_count}), 200
+
+
+class StreamStopMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        _stream.stop()
+        return jsonify({"message": "Stream stopped, allsky restarting"}), 200
+
+
+class StreamUpdateMethodView(View):
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        """Update camera settings live via the picamera2 daemon AND config DB."""
+        _ensure_stream()
+        from ..camera.picamera2_client import Picamera2Client
+        try:
+            client = Picamera2Client()
+            controls = {}
+            shutter = request.args.get("shutter")
+            if shutter and float(shutter) > 0:
+                controls["exposure"] = float(shutter) / 1e6
+            gain = request.args.get("gain")
+            if gain and float(gain) > 0:
+                controls["gain"] = float(gain)
+            awb = request.args.get("awb")
+            if awb:
+                controls["awb"] = awb != "off"
+            if controls:
+                client.set_controls(**controls)
+
+            # Stream settings → daemon
+            stream_kwargs = {}
+            quality = request.args.get("quality")
+            if quality:
+                stream_kwargs["quality"] = int(float(quality))
+            sw = request.args.get("stream_width")
+            sh = request.args.get("stream_height")
+            if sw and sh:
+                stream_kwargs["width"] = int(sw)
+                stream_kwargs["height"] = int(sh)
+            osd = request.args.get("osd")
+            if osd is not None:
+                stream_kwargs["osd"] = osd.lower() in ("1", "true", "on")
+            if stream_kwargs:
+                client.set_stream(**stream_kwargs)
+
+            client.close()
+
+            # Also update the indi-allsky config DB so capture worker uses these
+            try:
+                config = _get_config()
+                if gain and float(gain) > 0:
+                    gain_f = float(gain)
+                    # Update gain for current mode
+                    if config.get("CCD_CONFIG", {}).get("NIGHT", {}).get("GAIN") is not None:
+                        config["CCD_CONFIG"]["NIGHT"]["GAIN"] = gain_f
+                    if config.get("CCD_CONFIG", {}).get("MOONMODE", {}).get("GAIN") is not None:
+                        config["CCD_CONFIG"]["MOONMODE"]["GAIN"] = gain_f
+                    if config.get("CCD_CONFIG", {}).get("DAY", {}).get("GAIN") is not None:
+                        config["CCD_CONFIG"]["DAY"]["GAIN"] = gain_f
+                if shutter and float(shutter) > 0:
+                    exp_s = float(shutter) / 1e6
+                    config["CCD_EXPOSURE_MAX"] = exp_s
+                    config["CCD_EXPOSURE_DEF"] = exp_s
+                if "target_adu" in request.args:
+                    config["TARGET_ADU"] = int(float(request.args["target_adu"]))
+                if "autoexp" in request.args:
+                    config["TARGET_ADU_DISABLE"] = request.args["autoexp"].lower() not in ("1", "true", "on")
+                _save_config(config, note="live control update")
+            except Exception:
+                pass  # non-fatal: daemon controls still applied
+
+            # Queue indi-allsky reload so capture worker picks up changes
+            try:
+                from ..flask.models import IndiAllSkyDbTaskQueueTable
+                from ..flask import db
+                from .. import constants
+                task = IndiAllSkyDbTaskQueueTable(
+                    queue=constants.TaskQueueQueue.MAIN,
+                    state=constants.TaskQueueState.MANUAL,
+                    priority=100,
+                    data={'action': 'reload'},
+                )
+                db.session.add(task)
+                db.session.commit()
+            except Exception:
+                pass  # non-fatal
+
+            return jsonify({"message": "Settings applied"}), 200
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+
+def _ensure_stream():
+    """Auto-start the stream manager if not already running."""
+    if not _stream.running:
+        _stream.start()
+
+
+class StreamMJPEGMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        """MJPEG multipart stream - connect <img src> directly to this."""
+        _ensure_stream()
+        # Wait up to 5s for first frame
+        for _ in range(50):
+            if _stream.running and _stream._frame is not None:
+                break
+            time.sleep(0.1)
+        if not _stream.running:
+            return jsonify({"error": "Stream failed to start."}), 500
+        return Response(
+            _stream.generate(),
+            mimetype='multipart/x-mixed-replace; boundary=frame',
+        )
+
+
+class StreamFrameMethodView(View):
+    """Single-frame endpoint: reads latest JPEG directly from shared memory.
+
+    No login required — img.src fetches don't reliably send session cookies.
+    """
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        from ..camera.picamera2_client import Picamera2Client
+        try:
+            client = Picamera2Client()
+            result = client.get_stream_jpeg()
+            client.close()
+            if result is None:
+                return Response(b'', status=204)
+            jpeg, seq = result
+            return Response(jpeg, mimetype='image/jpeg',
+                            headers={'Cache-Control': 'no-cache, no-store, must-revalidate',
+                                     'Pragma': 'no-cache',
+                                     'Expires': '0',
+                                     'X-Frame-Seq': str(seq)})
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+
+class StreamStatusMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        elapsed = time.monotonic() - _stream._start_time if _stream._start_time else 0
+        return jsonify({
+            "running": _stream.running,
+            "clients": _stream.client_count,
+            "frames": _stream._frame_count,
+            "fps": round(_stream._frame_count / elapsed, 1) if elapsed > 1 else 0,
+            "settings": _stream.get_settings(),
+        }), 200
+
+
+# Keep old endpoints for backwards compat (they still work)
+class LiveStartMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        settings = {}
+        for key in ["shutter", "gain", "brightness", "contrast",
+                     "saturation", "sharpness", "awb", "awbgains", "denoise"]:
+            val = request.args.get(key, None)
+            if val is not None:
+                settings[key] = val
+        ok, err = _stream.start(settings)
+        if not ok:
+            return jsonify({"error": err}), 500
+        return jsonify({"message": "Live mode started (MJPEG stream)"}), 200
+
+
+class LiveStopMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        _stream.stop()
+        return jsonify({"message": "Live mode stopped"}), 200
+
+
+class LiveFrameMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        """Legacy: return latest frame as a single JPEG URL."""
+        if not _stream.running:
+            return jsonify({"error": "Stream not active"}), 400
+        frame = _stream.get_frame(timeout=5)
+        if frame is None:
+            return jsonify({"error": "No frame available"}), 500
+        # Write frame to htdocs for URL access
+        dest = os.path.join(HTDOCS, "live_frame.jpg")
+        with open(dest, "wb") as f:
+            f.write(frame)
+        return jsonify({
+            "url": "/indi-allsky/images/live_frame.jpg?t=" + str(int(time.time())),
+            "message": "Live",
+        }), 200
+
+
+class StreamMetadataMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        """Return live ISP metadata directly from the picamera2 daemon."""
+        from ..camera.picamera2_client import Picamera2Client
+        try:
+            client = Picamera2Client()
+            meta_resp = client.get_metadata()
+            client.close()
+            if not meta_resp.get('ok'):
+                return jsonify({"error": "No metadata"}), 503
+            raw = meta_resp.get('metadata', {})
+            # Normalize keys
+            meta = {}
+            req_exp = raw.get("requested_exposure")
+            exp_us = req_exp if req_exp else raw.get("ExposureTime", 0)
+            req_gain = raw.get("requested_gain")
+            gain_val = req_gain if req_gain else raw.get("AnalogueGain", 0)
+            meta["exposure"] = round(exp_us / 1_000_000, 2) if exp_us else 0
+            meta["gain"] = round(gain_val, 2) if gain_val else 0
+            meta["lux"] = round(raw.get("Lux", 0), 1)
+            meta["colour_temp"] = raw.get("ColourTemperature", 0)
+            meta["sensor_temp"] = raw.get("SensorTemperature")
+            ct = raw.get("_capture_time", 0)
+            meta["frame_age"] = round(time.time() - ct, 1) if ct > 1e9 else None
+            meta["frame"] = raw.get("frame_count", 0)
+            colour_gains = raw.get("ColourGains", (1.0, 1.0))
+            if isinstance(colour_gains, (list, tuple)) and len(colour_gains) >= 2:
+                meta["red_gain"] = round(float(colour_gains[0]), 3)
+                meta["blue_gain"] = round(float(colour_gains[1]), 3)
+            return jsonify(meta), 200
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+
+class SensorInfoMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        """Auto-detect camera sensor via picamera2 daemon."""
+        from ..camera.picamera2_client import Picamera2Client
+        try:
+            client = Picamera2Client()
+            info = client.get_sensor_info()
+            client.close()
+            if not info.get("ok"):
+                return jsonify({"error": "Daemon not available"}), 500
+            return jsonify({
+                "sensor": info.get("sensor_name", "unknown"),
+                "label": info.get("sensor_name", "unknown"),
+                "gain_min": info.get("min_gain", 0),
+                "gain_max": info.get("max_gain", 100),
+                "exposure_min": info.get("min_exposure", 0),
+                "exposure_max": info.get("max_exposure", 60),
+                "width": info.get("width", 0),
+                "height": info.get("height", 0),
+                "cfa": info.get("cfa", ""),
+            }), 200
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+
+class StreamModesMethodView(View):
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        """Return available sensor modes and current stream resolution."""
+        from ..camera.picamera2_client import Picamera2Client
+        try:
+            client = Picamera2Client()
+            result = client.get_modes()
+            client.close()
+            if not result.get("ok"):
+                return jsonify({"error": "Daemon not available"}), 500
+            return jsonify(result), 200
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+
+# ---------------------------------------------------------------------------
+# URL rules
+# ---------------------------------------------------------------------------
+
+bp_captureapi_allsky.add_url_rule("/api/capture_one", view_func=CaptureOneMethodView.as_view("captureapi_capture_one"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/live_start", view_func=LiveStartMethodView.as_view("captureapi_live_start"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/live_stop", view_func=LiveStopMethodView.as_view("captureapi_live_stop"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/live_frame", view_func=LiveFrameMethodView.as_view("captureapi_live_frame"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/stream/start", view_func=StreamStartMethodView.as_view("captureapi_stream_start"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/stream/stop", view_func=StreamStopMethodView.as_view("captureapi_stream_stop"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/stream/update", view_func=StreamUpdateMethodView.as_view("captureapi_stream_update"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/stream/feed.mjpeg", view_func=StreamMJPEGMethodView.as_view("captureapi_stream_feed"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/stream/status", view_func=StreamStatusMethodView.as_view("captureapi_stream_status"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/stream/metadata", view_func=StreamMetadataMethodView.as_view("captureapi_stream_metadata"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/config_get", view_func=ConfigGetMethodView.as_view("captureapi_config_get"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/config_set", view_func=ConfigSetMethodView.as_view("captureapi_config_set"), methods=["POST"])
+bp_captureapi_allsky.add_url_rule("/api/sensor_info", view_func=SensorInfoMethodView.as_view("captureapi_sensor_info"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/stream/modes", view_func=StreamModesMethodView.as_view("captureapi_stream_modes"), methods=["GET"])
+
+
+class StreamGetBackendMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        from ..camera.picamera2_client import Picamera2Client
+        try:
+            client = Picamera2Client()
+            resp = client.get_backend()
+            client.close()
+            return jsonify(resp), 200
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+
+class StreamSetBackendMethodView(View):
+    decorators = [login_required]
+    methods = ["GET"]
+
+    def dispatch_request(self):
+        backend = request.args.get("backend", "auto")
+        from ..camera.picamera2_client import Picamera2Client
+        try:
+            client = Picamera2Client()
+            resp = client._send({"cmd": "set_backend", "backend": backend})
+            client.close()
+            if resp.get("ok"):
+                # Persist to DB
+                try:
+                    config = _get_config()
+                    config.setdefault("LIBCAMERA", {})["BACKEND"] = backend
+                    _save_config(config, note="driver change from dashboard")
+                except Exception:
+                    pass
+            return jsonify(resp), 200 if resp.get("ok") else 500
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
+
+bp_captureapi_allsky.add_url_rule("/api/stream/frame.jpg", view_func=StreamFrameMethodView.as_view("captureapi_stream_frame"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/stream/get_backend", view_func=StreamGetBackendMethodView.as_view("captureapi_stream_get_backend"), methods=["GET"])
+bp_captureapi_allsky.add_url_rule("/api/stream/set_backend", view_func=StreamSetBackendMethodView.as_view("captureapi_stream_set_backend"), methods=["GET"])
+
+
+# ---------------------------------------------------------------------------
+# WebSocket stream (requires flask-sock)
+# ---------------------------------------------------------------------------
+
+def register_websocket(app):
+    """Register the WebSocket stream endpoint if flask-sock is available.
+
+    Call this from the Flask app factory after registering blueprints.
+    Wire format per frame (binary message):
+        [4 bytes]  uint32 big-endian — length of JSON header
+        [N bytes]  UTF-8 JSON metadata (ISP values, WB gains, mode, etc.)
+        [rest]     JPEG image data
+
+    This reads directly from the picamera2 daemon's shared memory,
+    so it works regardless of whether the MJPEG stream manager is running.
+    Both capture and streaming share the same camera — no contention.
+    """
+    if not _has_flask_sock:
+        return
+
+    sock = Sock(app)
+
+    @sock.route("/indi-allsky/api/stream/ws")
+    def stream_ws(ws):
+        """WebSocket endpoint: binary frames with per-frame metadata."""
+        from ..camera.picamera2_client import Picamera2Client
+
+        client = Picamera2Client()
+        last_seq = -1
+        frame_count = 0
+        start_time = time.monotonic()
+        last_meta_time = 0
+        cached_meta = {}
+        sent_initial = False
+
+        try:
+            while True:
+                # Always grab the most recent frame from shm
+                result = client.get_stream_jpeg()
+                if result is None:
+                    time.sleep(0.1)
+                    try:
+                        ws.send(b"")
+                    except Exception:
+                        break
+                    continue
+
+                jpeg, seq = result
+
+                # Always send the first frame immediately on connect,
+                # even if it's the same seq (stale from a long exposure)
+                if not sent_initial:
+                    sent_initial = True
+                    last_seq = seq
+                    frame_count += 1
+                elif seq == last_seq:
+                    time.sleep(0.1)
+                    continue
+                else:
+                    last_seq = seq
+                    frame_count += 1
+
+                # Refresh metadata ~1s
+                now = time.monotonic()
+                if now - last_meta_time > 1.0:
+                    try:
+                        meta_resp = client.get_metadata()
+                        if meta_resp.get("ok"):
+                            raw_meta = meta_resp.get("metadata", {})
+                            # Prefer requested values over ISP actual
+                            req_exp = raw_meta.get("requested_exposure")
+                            exp_us = req_exp if req_exp else raw_meta.get("ExposureTime", 0)
+                            req_gain = raw_meta.get("requested_gain")
+                            gain_val = req_gain if req_gain else raw_meta.get("AnalogueGain", 0)
+                            ct = raw_meta.get("_capture_time", 0)
+                            cached_meta = {
+                                "exposure": round(exp_us / 1_000_000, 2) if exp_us else 0,
+                                "gain": round(gain_val, 2),
+                                "lux": round(raw_meta.get("Lux", 0), 1),
+                                "colour_temp": raw_meta.get("ColourTemperature", 0),
+                                "sensor_temp": raw_meta.get("SensorTemperature"),
+                                "ae_state": raw_meta.get("AeState", -1),
+                                "frame_age": round(time.time() - ct, 1) if ct else None,
+                            }
+                            colour_gains = raw_meta.get("ColourGains", (1.0, 1.0))
+                            if isinstance(colour_gains, (list, tuple)) and len(colour_gains) >= 2:
+                                cached_meta["red_gain"] = round(float(colour_gains[0]), 3)
+                                cached_meta["blue_gain"] = round(float(colour_gains[1]), 3)
+                    except Exception:
+                        pass
+                    last_meta_time = now
+
+                meta = dict(cached_meta)
+                elapsed = now - start_time
+                meta["frame"] = frame_count
+                meta["fps"] = round(frame_count / elapsed, 1) if elapsed > 1 else 0
+
+                # Pack and send — if send blocks, we'll skip to the latest
+                # frame on the next iteration (shm always has the newest)
+                try:
+                    meta_bytes = json.dumps(meta, separators=(",", ":"), default=str).encode("utf-8")
+                    header = struct.pack(">I", len(meta_bytes))
+                    ws.send(header + meta_bytes + jpeg)
+                except Exception:
+                    break
+        finally:
+            client.close()

--- a/indi_allsky/flask/forms.py
+++ b/indi_allsky/flask/forms.py
@@ -3838,6 +3838,13 @@ class IndiAllskyConfigForm(FlaskForm):
         ('3', '3'),
     )
 
+    LIBCAMERA__BACKEND_choices = (
+        ('auto', 'Auto (prefer picamera2)'),
+        ('picamera2', 'Picamera2 (Python API)'),
+        ('libcamera', 'libcamera (Python bindings)'),
+        ('libcamera-still', 'libcamera-still (subprocess)'),
+    )
+
     PYCURL_CAMERA__IMAGE_FILE_TYPE_choices = (
         ('jpg', 'JPEG'),
         ('png', 'PNG'),
@@ -4791,6 +4798,7 @@ class IndiAllskyConfigForm(FlaskForm):
     LIBCAMERA__CCM_DISABLE           = BooleanField('Disable Color Correction Matrix (Night)')
     LIBCAMERA__CCM_DISABLE_DAY       = BooleanField('Disable Color Correction Matrix (Day)')
     LIBCAMERA__CAMERA_ID             = SelectField('Camera ID', choices=LIBCAMERA__CAMERA_ID_choices, validators=[LIBCAMERA__CAMERA_ID_validator])
+    LIBCAMERA__BACKEND               = SelectField('Camera Backend', choices=LIBCAMERA__BACKEND_choices, validators=[DataRequired()])
     LIBCAMERA__EXTRA_OPTIONS         = StringField('Night libcamera extra options', validators=[LIBCAMERA__EXTRA_OPTIONS_validator])
     LIBCAMERA__EXTRA_OPTIONS_DAY     = StringField('Day libcamera extra options', validators=[LIBCAMERA__EXTRA_OPTIONS_validator])
     LIBCAMERA__MQTT_TRANSPORT        = SelectField('MQTT Transport', choices=MQTTPUBLISH__TRANSPORT_choices, validators=[DataRequired(), MQTTPUBLISH__TRANSPORT_validator])

--- a/indi_allsky/flask/static/css/allsky_player.css
+++ b/indi_allsky/flask/static/css/allsky_player.css
@@ -1,0 +1,184 @@
+/* AllskyPlayer styles */
+
+.allsky-player {
+  position: relative;
+  width: 100%;
+}
+
+.allsky-player__inline {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border-radius: 6px;
+  background: #111;
+  min-height: 200px;
+}
+
+.allsky-player__img {
+  display: block;
+  width: 100%;
+  max-height: 85vh;
+  object-fit: contain;
+  background: #000;
+}
+
+/* Canvas for WebSocket mode */
+.allsky-player__canvas {
+  display: block;
+  width: 100%;
+  max-height: 85vh;
+  object-fit: contain;
+  background: #000;
+  cursor: pointer;
+}
+
+.allsky-player__offline {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 2;
+}
+
+.allsky-player__offline-title {
+  font-size: 1.1rem;
+  color: #999;
+  margin: 0;
+}
+
+.allsky-player__offline-sub {
+  font-size: 0.85rem;
+  color: #666;
+  margin: 4px 0 0;
+}
+
+/* Info bar */
+.allsky-player__info-bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 12px 6px;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent);
+  font-family: monospace;
+  font-size: 11px;
+  color: #ccc;
+  z-index: 3;
+  pointer-events: none;
+}
+
+.allsky-player__info-left,
+.allsky-player__info-right {
+  white-space: nowrap;
+}
+
+/* Hover buttons */
+.allsky-player__hover-btns {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: flex;
+  gap: 6px;
+  opacity: 0;
+  transition: opacity 0.2s;
+  z-index: 4;
+}
+
+.allsky-player__inline:hover .allsky-player__hover-btns {
+  opacity: 1;
+}
+
+.allsky-player__btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: rgba(30, 30, 30, 0.8);
+  color: #aaa;
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+  transition: background 0.15s, color 0.15s;
+}
+
+.allsky-player__btn:hover {
+  background: rgba(60, 60, 60, 0.9);
+  color: #fff;
+}
+
+/* Modal */
+.allsky-player__modal {
+  position: fixed;
+  inset: 0;
+  z-index: 9990;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.92);
+  padding: 16px;
+}
+
+.allsky-player__modal-inner {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 95vw;
+  max-height: 95vh;
+}
+
+.allsky-player__modal-controls {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.allsky-player__modal-info {
+  font-family: monospace;
+  font-size: 11px;
+  color: #ccc;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 4px 10px;
+  border-radius: 4px;
+  backdrop-filter: blur(4px);
+}
+
+.allsky-player__modal-img {
+  max-width: 95vw;
+  max-height: 92vh;
+  object-fit: contain;
+}
+
+/* Canvas in modal for WebSocket mode */
+.allsky-player__modal-canvas {
+  max-width: 95vw;
+  max-height: 92vh;
+  object-fit: contain;
+}
+
+/* Fullscreen overrides */
+.allsky-player__modal-inner:fullscreen {
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.allsky-player__modal-inner:fullscreen .allsky-player__modal-img,
+.allsky-player__modal-inner:fullscreen .allsky-player__modal-canvas {
+  max-width: 100vw;
+  max-height: 100vh;
+}

--- a/indi_allsky/flask/static/js/allsky_player.js
+++ b/indi_allsky/flask/static/js/allsky_player.js
@@ -1,0 +1,514 @@
+/**
+ * AllskyPlayer - Live stream player with WebSocket + MJPEG fallback.
+ *
+ * WebSocket mode: binary frames with metadata header, rendered to <canvas>.
+ * MJPEG fallback: <img src="feed.mjpeg"> when WebSocket not available.
+ *
+ * Usage:
+ *   var player = new AllskyPlayer({
+ *     container: document.getElementById('player-container'),
+ *     wsUrl: '/indi-allsky/api/stream/ws',
+ *     feedUrl: '/indi-allsky/api/stream/feed.mjpeg',
+ *     metadataUrl: '/indi-allsky/api/stream/metadata',
+ *   });
+ *   player.connect();
+ *   player.disconnect();
+ */
+
+(function (window) {
+  "use strict";
+
+  function AllskyPlayer(opts) {
+    this.container = opts.container;
+    this.wsUrl = opts.wsUrl || "/indi-allsky/api/stream/ws";
+    this.feedUrl = opts.feedUrl || "/indi-allsky/api/stream/feed.mjpeg";
+    this.metadataUrl = opts.metadataUrl || "/indi-allsky/api/stream/metadata";
+    this.preferWs = opts.preferWs !== false; // default: try WebSocket first
+    this.onstatuschange = opts.onstatuschange || function () {};
+    this.onmetadata = opts.onmetadata || function () {};
+
+    this._connected = false;
+    this._expanded = false;
+    this._useWs = false; // true when WebSocket is active
+    this._ws = null;
+    this._reconnectTimer = null;
+    this._metaPollTimer = null;
+    this._metadata = null;
+    this._naturalWidth = 0;
+    this._naturalHeight = 0;
+
+    this._build();
+    this._bindEvents();
+  }
+
+  AllskyPlayer.prototype._build = function () {
+    var c = this.container;
+    c.classList.add("allsky-player");
+    c.innerHTML = "";
+
+    // Inline view wrapper
+    var inline = document.createElement("div");
+    inline.className = "allsky-player__inline";
+    c.appendChild(inline);
+    this._inlineWrap = inline;
+
+    // Canvas for WebSocket mode
+    var canvas = document.createElement("canvas");
+    canvas.className = "allsky-player__canvas";
+    canvas.style.display = "none";
+    inline.appendChild(canvas);
+    this._canvas = canvas;
+
+    // Image element for MJPEG fallback
+    var img = document.createElement("img");
+    img.className = "allsky-player__img";
+    img.alt = "Live stream";
+    img.style.display = "none";
+    inline.appendChild(img);
+    this._img = img;
+
+    // Offline overlay
+    var offline = document.createElement("div");
+    offline.className = "allsky-player__offline";
+    offline.innerHTML =
+      '<p class="allsky-player__offline-title">Stream offline</p>' +
+      '<p class="allsky-player__offline-sub">Click Live View to start</p>';
+    inline.appendChild(offline);
+    this._offline = offline;
+
+    // Info bar (bottom)
+    var infoBar = document.createElement("div");
+    infoBar.className = "allsky-player__info-bar";
+    infoBar.innerHTML =
+      '<span class="allsky-player__info-left"></span>' +
+      '<span class="allsky-player__info-right"></span>';
+    inline.appendChild(infoBar);
+    this._infoBar = infoBar;
+    this._infoLeft = infoBar.querySelector(".allsky-player__info-left");
+    this._infoRight = infoBar.querySelector(".allsky-player__info-right");
+
+    // Hover buttons (expand + fullscreen)
+    var btns = document.createElement("div");
+    btns.className = "allsky-player__hover-btns";
+    btns.innerHTML =
+      '<button class="allsky-player__btn" data-action="expand" title="Expand (or double-click)">' +
+      '<svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 3h6m0 0v6m0-6l-7 7M9 21H3m0 0v-6m0 6l7-7"/></svg>' +
+      "</button>" +
+      '<button class="allsky-player__btn" data-action="fullscreen" title="Fullscreen">' +
+      '<svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5"/></svg>' +
+      "</button>";
+    inline.appendChild(btns);
+    this._hoverBtns = btns;
+
+    // Modal overlay (hidden by default)
+    var modal = document.createElement("div");
+    modal.className = "allsky-player__modal";
+    modal.style.display = "none";
+    modal.innerHTML =
+      '<div class="allsky-player__modal-inner">' +
+      '<div class="allsky-player__modal-controls">' +
+      '<span class="allsky-player__modal-info"></span>' +
+      '<button class="allsky-player__btn" data-action="modal-fullscreen" title="Fullscreen">' +
+      '<svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5"/></svg>' +
+      "</button>" +
+      '<button class="allsky-player__btn" data-action="close" title="Close (Esc)">' +
+      '<svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>' +
+      "</button>" +
+      "</div>" +
+      '<canvas class="allsky-player__modal-canvas" style="display:none"></canvas>' +
+      '<img class="allsky-player__modal-img" alt="Live stream expanded" style="display:none">' +
+      "</div>";
+    document.body.appendChild(modal);
+    this._modal = modal;
+    this._modalInner = modal.querySelector(".allsky-player__modal-inner");
+    this._modalCanvas = modal.querySelector(".allsky-player__modal-canvas");
+    this._modalImg = modal.querySelector(".allsky-player__modal-img");
+    this._modalInfo = modal.querySelector(".allsky-player__modal-info");
+  };
+
+  AllskyPlayer.prototype._bindEvents = function () {
+    var self = this;
+
+    // Double-click to expand
+    this._canvas.addEventListener("dblclick", function () {
+      self.expand();
+    });
+    this._img.addEventListener("dblclick", function () {
+      self.expand();
+    });
+
+    // Hover button actions
+    this._hoverBtns.addEventListener("click", function (e) {
+      var btn = e.target.closest("[data-action]");
+      if (!btn) return;
+      var action = btn.dataset.action;
+      if (action === "expand") self.expand();
+      else if (action === "fullscreen") {
+        self.expand();
+        setTimeout(function () {
+          self._goFullscreen(self._modalInner);
+        }, 100);
+      }
+    });
+
+    // Modal actions
+    this._modal.addEventListener("click", function (e) {
+      if (e.target === self._modal) self.collapse();
+      var btn = e.target.closest("[data-action]");
+      if (!btn) return;
+      var action = btn.dataset.action;
+      if (action === "close") self.collapse();
+      else if (action === "modal-fullscreen")
+        self._goFullscreen(self._modalInner);
+    });
+
+    // Escape to close
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && self._expanded) self.collapse();
+    });
+
+    // MJPEG img events
+    this._img.addEventListener("error", function () {
+      if (self._connected && !self._useWs) {
+        self._connected = false;
+        self._showOffline(true);
+        self.onstatuschange(false);
+      }
+    });
+    this._img.addEventListener("load", function () {
+      if (!self._connected && !self._useWs) {
+        self._connected = true;
+        self._showOffline(false);
+        self.onstatuschange(true);
+      }
+    });
+  };
+
+  // ---- Connection ----
+
+  AllskyPlayer.prototype.connect = function () {
+    if (this.preferWs) {
+      this._connectWs();
+    } else {
+      this._connectMjpeg();
+    }
+  };
+
+  AllskyPlayer.prototype.disconnect = function () {
+    this._disconnectWs();
+    this._disconnectMjpeg();
+    this._stopMetaPoll();
+    this._connected = false;
+    this._showOffline(true);
+    this.onstatuschange(false);
+    if (this._expanded) this.collapse();
+  };
+
+  AllskyPlayer.prototype.reconnect = function () {
+    this.disconnect();
+    this.connect();
+  };
+
+  // ---- WebSocket mode ----
+
+  AllskyPlayer.prototype._connectWs = function () {
+    var self = this;
+    if (this._ws && (this._ws.readyState === 0 || this._ws.readyState === 1))
+      return;
+
+    var proto = location.protocol === "https:" ? "wss:" : "ws:";
+    var url = proto + "//" + location.host + this.wsUrl;
+
+    var ws = new WebSocket(url);
+    ws.binaryType = "arraybuffer";
+    this._ws = ws;
+
+    ws.onopen = function () {
+      console.log("[AllskyPlayer] WS connected to", url);
+      self._useWs = true;
+      self._connected = true;
+      self._canvas.style.display = "";
+      self._img.style.display = "none";
+      self._showOffline(false);
+      self.onstatuschange(true);
+    };
+
+    ws.onclose = function (ev) {
+      console.log("[AllskyPlayer] WS closed:", ev.code, ev.reason);
+      self._connected = false;
+      self.onstatuschange(false);
+      self._scheduleReconnect();
+    };
+
+    ws.onerror = function (ev) {
+      console.error("[AllskyPlayer] WS error:", ev);
+      if (!self._connected) {
+        self._useWs = false;
+        self._connectMjpeg();
+        return;
+      }
+      self._connected = false;
+      self.onstatuschange(false);
+    };
+
+    ws.onmessage = function (event) {
+      if (!(event.data instanceof ArrayBuffer) || event.data.byteLength < 4) {
+        console.log("[AllskyPlayer] WS msg: not arraybuffer or too small, type=", typeof event.data, "len=", event.data ? event.data.byteLength || event.data.length : 0);
+        return;
+      }
+      self._frameCounter = (self._frameCounter || 0) + 1;
+      console.log("[AllskyPlayer] Frame", self._frameCounter, ":", event.data.byteLength, "bytes");
+
+      var view = new DataView(event.data);
+      var jsonLen = view.getUint32(0);
+
+      // Parse metadata
+      if (jsonLen > 0 && jsonLen < event.data.byteLength) {
+        try {
+          var jsonBytes = new Uint8Array(event.data, 4, jsonLen);
+          var meta = JSON.parse(new TextDecoder().decode(jsonBytes));
+          self._metadata = meta;
+          self._updateInfoBar(meta);
+          self.onmetadata(meta);
+        } catch (e) {}
+      }
+
+      // JPEG data
+      var jpegOffset = 4 + jsonLen;
+      var jpegData = new Uint8Array(event.data, jpegOffset);
+      if (jpegData.byteLength < 2) return;
+
+      var blob = new Blob([jpegData], { type: "image/jpeg" });
+      var url = URL.createObjectURL(blob);
+      var img = new Image();
+      img.onload = function () {
+        self._naturalWidth = img.naturalWidth;
+        self._naturalHeight = img.naturalHeight;
+
+        // Draw to inline canvas
+        if (self._canvas) {
+          self._canvas.width = img.naturalWidth;
+          self._canvas.height = img.naturalHeight;
+          var ctx = self._canvas.getContext("2d");
+          ctx.drawImage(img, 0, 0);
+        }
+
+        // Draw to modal canvas if expanded
+        if (self._expanded && self._modalCanvas) {
+          self._modalCanvas.width = img.naturalWidth;
+          self._modalCanvas.height = img.naturalHeight;
+          var ctx2 = self._modalCanvas.getContext("2d");
+          ctx2.drawImage(img, 0, 0);
+        }
+
+        URL.revokeObjectURL(url);
+      };
+      img.src = url;
+    };
+  };
+
+  AllskyPlayer.prototype._disconnectWs = function () {
+    if (this._ws) {
+      this._ws.onclose = null;
+      this._ws.onerror = null;
+      this._ws.close();
+      this._ws = null;
+    }
+    this._useWs = false;
+    this._canvas.style.display = "none";
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+  };
+
+  AllskyPlayer.prototype._scheduleReconnect = function () {
+    var self = this;
+    if (this._reconnectTimer) clearTimeout(this._reconnectTimer);
+    this._reconnectTimer = setTimeout(function () {
+      self._connectWs();
+    }, 3000);
+  };
+
+  // ---- MJPEG fallback mode ----
+
+  AllskyPlayer.prototype._connectMjpeg = function () {
+    // Poll single-frame endpoint instead of MJPEG stream to avoid
+    // TCP buffer queuing.  Each request gets the latest frame only.
+    this._useWs = false;
+    this._canvas.style.display = "none";
+    this._img.style.display = "";
+    this._showOffline(false);
+    this._startMetaPoll();
+    this._pollFrame();
+  };
+
+  AllskyPlayer.prototype._pollFrame = function () {
+    if (!this._connected && this._useWs) return;
+    if (this._pollInFlight) return;  // one request at a time
+    this._pollInFlight = true;
+    var self = this;
+    var frameUrl = this.feedUrl.replace("feed.mjpeg", "frame.jpg");
+    var img = new Image();
+    img.onload = function () {
+      // Set the display image and wait for it to paint before polling again
+      self._img.src = img.src;
+      self._connected = true;
+      self._showOffline(false);
+      self.onstatuschange(true);
+      self._pollInFlight = false;
+      // Wait for paint, then fetch next frame
+      requestAnimationFrame(function () {
+        if (!self._useWs) self._pollFrame();
+      });
+    };
+    img.onerror = function () {
+      self._pollInFlight = false;
+      setTimeout(function () { if (!self._useWs) self._pollFrame(); }, 2000);
+    };
+    img.src = frameUrl + "?t=" + Date.now();
+  };
+
+  AllskyPlayer.prototype._disconnectMjpeg = function () {
+    this._img.src = "";
+    this._img.style.display = "none";
+  };
+
+  // ---- Expand / Fullscreen ----
+
+  AllskyPlayer.prototype.expand = function () {
+    this._expanded = true;
+    this._modal.style.display = "";
+    if (this._useWs) {
+      this._modalCanvas.style.display = "";
+      this._modalImg.style.display = "none";
+    } else {
+      this._modalCanvas.style.display = "none";
+      this._modalImg.style.display = "";
+      this._modalImg.src = this.feedUrl + "?t=" + Date.now();
+    }
+  };
+
+  AllskyPlayer.prototype.collapse = function () {
+    this._expanded = false;
+    this._modal.style.display = "none";
+    this._modalImg.src = "";
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(function () {});
+    }
+  };
+
+  AllskyPlayer.prototype._goFullscreen = function (el) {
+    if (!el) return;
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(function () {});
+    } else {
+      el.requestFullscreen().catch(function () {});
+    }
+  };
+
+  AllskyPlayer.prototype._showOffline = function (show) {
+    this._offline.style.display = show ? "" : "none";
+    this._infoBar.style.display = show ? "none" : "";
+  };
+
+  // ---- Metadata polling (MJPEG mode only) ----
+
+  AllskyPlayer.prototype._startMetaPoll = function () {
+    var self = this;
+    this._stopMetaPoll();
+    this._pollMeta();
+    this._metaPollTimer = setInterval(function () {
+      self._pollMeta();
+    }, 1500);
+  };
+
+  AllskyPlayer.prototype._stopMetaPoll = function () {
+    if (this._metaPollTimer) {
+      clearInterval(this._metaPollTimer);
+      this._metaPollTimer = null;
+    }
+  };
+
+  AllskyPlayer.prototype._pollMeta = function () {
+    var self = this;
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", this.metadataUrl, true);
+    xhr.timeout = 3000;
+    xhr.onload = function () {
+      if (xhr.status === 200) {
+        try {
+          var data = JSON.parse(xhr.responseText);
+          self._metadata = data;
+          self._updateInfoBar(data);
+          self.onmetadata(data);
+        } catch (e) {}
+      }
+    };
+    xhr.send();
+  };
+
+  AllskyPlayer.prototype._updateInfoBar = function (meta) {
+    console.log("[AllskyPlayer] OSD meta:", JSON.stringify(meta));
+    var left = "";
+    var right = "";
+
+    // Left side: exposure, gain, lux
+    if (meta.exposure != null) {
+      left += _formatExp(meta.exposure);
+    }
+    if (meta.gain != null) {
+      left += (left ? " \u00b7 " : "") + "gain " + Number(meta.gain).toFixed(1);
+    }
+    if (meta.lux != null && meta.lux > 0) {
+      left += (left ? " \u00b7 " : "") + meta.lux.toFixed(0) + " lux";
+    }
+
+    // Right side: sensor temp, colour temp, fps, frames
+    if (meta.sensor_temp != null) {
+      right += parseFloat(meta.sensor_temp).toFixed(1) + "\u00b0C";
+    }
+    if (meta.colour_temp != null && meta.colour_temp > 0) {
+      right += (right ? " \u00b7 " : "") + meta.colour_temp + "K";
+    }
+    // Frame age warning
+    if (meta.frame_age != null && meta.frame_age > 10) {
+      right += (right ? " \u00b7 " : "") + '<span style="color:#f88">' + Math.round(meta.frame_age) + 's old</span>';
+    }
+    // Stream stats (from polling endpoint or WebSocket meta)
+    var s = meta._stream || meta;
+    if (s.fps != null) {
+      right += (right ? " \u00b7 " : "") + s.fps + " fps";
+    }
+    if (s.frame != null || s.frames != null) {
+      right += " \u00b7 #" + (s.frame || s.frames || 0);
+    }
+
+    this._infoLeft.textContent = left || "--";
+    this._infoRight.innerHTML = right || "--";
+
+    // Also update modal info
+    if (this._expanded && this._modalInfo) {
+      this._modalInfo.textContent =
+        left + (left && right ? "  |  " : "") + right;
+    }
+  };
+
+  // ---- Helpers ----
+
+  function _formatExp(v) {
+    if (v == null) return "--";
+    if (v < 0.001) return (v * 1000000).toFixed(0) + "\u00b5s";
+    if (v < 1) return (v * 1000).toFixed(1) + "ms";
+    return v.toFixed(2) + "s";
+  }
+
+  AllskyPlayer.prototype.destroy = function () {
+    this.disconnect();
+    if (this._modal && this._modal.parentNode) {
+      this._modal.parentNode.removeChild(this._modal);
+    }
+  };
+
+  window.AllskyPlayer = AllskyPlayer;
+})(window);

--- a/indi_allsky/flask/static/js/capture_buttons.js
+++ b/indi_allsky/flask/static/js/capture_buttons.js
@@ -1,0 +1,380 @@
+/* Camera controls for indi-allsky — unified live controls via picamera2 daemon.
+ * All changes apply immediately to the live stream and capture.
+ */
+
+// Toast notification helper
+function showToast(msg, type) {
+    type = type || "info";
+    var id = "toast-" + Date.now();
+    var bgClass = type === "success" ? "bg-success" : type === "danger" ? "bg-danger" : "bg-info";
+    var html = '<div id="' + id + '" class="toast ' + bgClass + ' text-white border-0" role="alert">'
+        + '<div class="d-flex"><div class="toast-body" style="white-space:pre-wrap;font-size:0.85rem">' + msg + '</div>'
+        + '<button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button></div></div>';
+    var container = document.getElementById("toast-container");
+    if (!container) {
+        container = document.createElement("div");
+        container.id = "toast-container";
+        container.className = "toast-container position-fixed top-0 end-0 p-3";
+        container.style.zIndex = "9999";
+        document.body.appendChild(container);
+    }
+    container.insertAdjacentHTML("beforeend", html);
+    var el = document.getElementById(id);
+    if (typeof bootstrap !== "undefined") new bootstrap.Toast(el, {delay: 3000}).show();
+}
+
+// ---- Slider definitions ----
+var sliderDefs = [
+    {id: "gain",       label: "Gain",          min: 0,    max: 100,      step: 0.5,   dec: 1},
+    {id: "exposure",   label: "Exposure (s)",   min: 0,    max: 60,       step: 0.1,   dec: 2},
+    {id: "brightness", label: "Brightness",     min: -1.0, max: 1.0,      step: 0.05,  dec: 2},
+    {id: "contrast",   label: "Contrast",       min: 0,    max: 4.0,      step: 0.1,   dec: 1},
+    {id: "target_adu", label: "Target ADU",     min: 10,   max: 224,      step: 5,     dec: 0},
+    {id: "quality",    label: "JPEG Quality",   min: 10,   max: 100,      step: 5,     dec: 0},
+];
+
+var debounceTimer = null;
+
+function buildControlsHTML() {
+    var html = '';
+    html += '<div class="mb-2"><strong class="text-info small">Camera Controls</strong>';
+    html += ' <span id="ctrl-status" class="text-light small ms-2" style="opacity:0;transition:opacity 0.3s">Applying...</span></div>';
+
+    sliderDefs.forEach(function(s) {
+        html += buildSlider(s);
+    });
+
+    // AWB mode
+    html += '<div class="row g-1 mb-1 align-items-center">';
+    html += '<div class="col-3 text-end"><label class="form-label text-light small mb-0">AWB</label></div>';
+    html += '<div class="col-6"><select id="ctrl-awb" class="form-select form-select-sm bg-dark text-light py-0" style="font-size:0.75rem" onchange="scheduleApply()">';
+    ["auto","incandescent","tungsten","fluorescent","indoor","daylight","cloudy"].forEach(function(m) {
+        html += '<option value="' + m + '"' + (m === "auto" ? " selected" : "") + '>' + m.charAt(0).toUpperCase() + m.slice(1) + '</option>';
+    });
+    html += '</select></div></div>';
+
+    // Stream resolution
+    html += '<div class="row g-1 mb-1 align-items-center">';
+    html += '<div class="col-3 text-end"><label class="form-label text-light small mb-0">Resolution</label></div>';
+    html += '<div class="col-6"><select id="ctrl-resolution" class="form-select form-select-sm bg-dark text-light py-0" style="font-size:0.75rem" onchange="changeResolution()">';
+    html += '<option value="640x480" selected>640x480</option>';
+    html += '<option value="1280x720">1280x720</option>';
+    html += '<option value="1920x1080">1920x1080</option>';
+    html += '</select></div></div>';
+
+    // Camera driver
+    html += '<div class="row g-1 mb-1 align-items-center">';
+    html += '<div class="col-3 text-end"><label class="form-label text-light small mb-0">Driver</label></div>';
+    html += '<div class="col-6"><select id="ctrl-driver" class="form-select form-select-sm bg-dark text-light py-0" style="font-size:0.75rem" onchange="changeDriver()">';
+    html += '<option value="auto">Auto</option>';
+    html += '<option value="picamera2">Picamera2 (best for Pi)</option>';
+    html += '<option value="libcamera">libcamera (Python bindings)</option>';
+    html += '<option value="libcamera-still">libcamera-still (subprocess)</option>';
+    html += '</select></div>';
+    html += '<div class="col-3"><span id="val-driver" class="text-white small">--</span></div>';
+    html += '</div>';
+
+    // Auto-exposure toggle
+    html += '<div class="row g-1 mb-1 align-items-center">';
+    html += '<div class="col-3 text-end"><label class="form-label text-light small mb-0">Auto Exp</label></div>';
+    html += '<div class="col-6"><div class="form-check form-switch">';
+    html += '<input class="form-check-input" type="checkbox" id="ctrl-autoexp" checked onchange="toggleAutoExposure()">';
+    html += '<label class="form-check-label text-light small" for="ctrl-autoexp">ADU-based auto-exposure</label>';
+    html += '</div></div></div>';
+
+    // OSD toggle
+    html += '<div class="row g-1 mb-1 align-items-center">';
+    html += '<div class="col-3 text-end"><label class="form-label text-light small mb-0">OSD</label></div>';
+    html += '<div class="col-6"><div class="form-check form-switch">';
+    html += '<input class="form-check-input" type="checkbox" id="ctrl-osd" checked onchange="toggleOSD()">';
+    html += '<label class="form-check-label text-light small" for="ctrl-osd">Show overlay</label>';
+    html += '</div></div></div>';
+
+    return html;
+}
+
+function changeDriver() {
+    var sel = document.getElementById("ctrl-driver");
+    if (!sel) return;
+    var backend = sel.value;
+    var status = document.getElementById("ctrl-status");
+    if (status) { status.textContent = "Switching driver..."; status.style.opacity = "1"; }
+    $.ajax({
+        type: "GET", url: "/indi-allsky/api/stream/set_backend?backend=" + backend, timeout: 30000,
+        success: function(data) {
+            var label = document.getElementById("val-driver");
+            if (label) label.textContent = data.backend || backend;
+            if (status) { status.textContent = "Driver switched"; setTimeout(function() { status.style.opacity = "0"; }, 2000); }
+        },
+        error: function() {
+            if (status) { status.textContent = "Switch failed"; }
+        },
+    });
+}
+
+function loadDriverInfo() {
+    $.ajax({
+        type: "GET", url: "/indi-allsky/api/stream/get_backend", timeout: 5000,
+        success: function(data) {
+            var sel = document.getElementById("ctrl-driver");
+            var label = document.getElementById("val-driver");
+            if (sel && data.backend_type) sel.value = data.backend_type;
+            if (label) label.textContent = data.backend || "unknown";
+        },
+    });
+}
+
+function toggleAutoExposure() {
+    var on = document.getElementById("ctrl-autoexp").checked;
+    $.ajax({
+        type: "GET",
+        url: "/indi-allsky/api/stream/update?autoexp=" + (on ? "1" : "0"),
+        timeout: 10000,
+        success: function() {
+            var status = document.getElementById("ctrl-status");
+            if (status) { status.textContent = on ? "Auto-exposure enabled" : "Auto-exposure disabled (manual)"; status.style.opacity = "1"; }
+            setTimeout(function() { if (status) status.style.opacity = "0"; }, 2000);
+        },
+    });
+}
+
+function toggleOSD() {
+    var on = document.getElementById("ctrl-osd").checked;
+    $.ajax({
+        type: "GET",
+        url: "/indi-allsky/api/stream/update?osd=" + (on ? "1" : "0"),
+        timeout: 10000,
+    });
+}
+
+function changeResolution() {
+    var sel = document.getElementById("ctrl-resolution");
+    if (!sel) return;
+    var parts = sel.value.split("x");
+    var w = parseInt(parts[0]), h = parseInt(parts[1]);
+    $.ajax({
+        type: "GET",
+        url: "/indi-allsky/api/stream/update?stream_width=" + w + "&stream_height=" + h,
+        timeout: 10000,
+        success: function() {
+            var status = document.getElementById("ctrl-status");
+            if (status) { status.textContent = "Resolution changed"; status.style.opacity = "1"; }
+            setTimeout(function() { if (status) status.style.opacity = "0"; }, 2000);
+        },
+    });
+}
+
+// Load modes from daemon and populate dropdown
+function loadModes() {
+    $.ajax({
+        type: "GET", url: "/indi-allsky/api/stream/modes", timeout: 10000,
+        success: function(data) {
+            var sel = document.getElementById("ctrl-resolution");
+            if (!sel || !data.modes) return;
+            // Add hardware modes
+            sel.innerHTML = "";
+            // Software downscale options
+            var sw = [
+                {w: 640, h: 480, label: "640x480 (fast)"},
+                {w: 1280, h: 720, label: "1280x720 (HD)"},
+                {w: 1920, h: 1080, label: "1920x1080 (FHD)"},
+            ];
+            // Add native sensor modes
+            data.modes.forEach(function(m) {
+                if (m.width && m.height) {
+                    sw.push({w: m.width, h: m.height,
+                        label: m.width + "x" + m.height + " (native" + (m.fps ? " " + Math.round(m.fps) + "fps" : "") + ")"});
+                }
+            });
+            // Deduplicate
+            var seen = {};
+            sw.forEach(function(r) {
+                var key = r.w + "x" + r.h;
+                if (seen[key]) return;
+                seen[key] = true;
+                var opt = document.createElement("option");
+                opt.value = r.w + "x" + r.h;
+                opt.textContent = r.label;
+                if (r.w === data.stream_width && r.h === data.stream_height) opt.selected = true;
+                sel.appendChild(opt);
+            });
+        },
+    });
+}
+
+function buildSlider(s) {
+    var sliderId = "ctrl-" + s.id;
+    var valId = "val-" + s.id;
+    var defVal = (s.id === "gain") ? 8 : (s.id === "exposure") ? 5 : (s.id === "target_adu") ? 75 : (s.id === "quality") ? 95 : (s.id === "brightness") ? 0 : 1;
+
+    var h = '<div class="row g-1 mb-1 align-items-center">';
+    h += '<div class="col-3 text-end"><label class="form-label text-light small mb-0" for="' + sliderId + '">' + s.label + '</label></div>';
+    h += '<div class="col-6"><input type="range" class="form-range" style="height:16px" id="' + sliderId + '" ';
+    h += 'min="' + s.min + '" max="' + s.max + '" step="' + s.step + '" value="' + defVal + '" ';
+    h += 'oninput="onSliderInput(\'' + s.id + '\')">';
+    h += '</div>';
+    h += '<div class="col-3"><span id="' + valId + '" class="text-white small">' + defVal.toFixed(s.dec) + '</span></div>';
+    h += '</div>';
+    return h;
+}
+
+function onSliderInput(id) {
+    var def = sliderDefs.find(function(s) { return s.id === id; });
+    if (!def) return;
+    var el = document.getElementById("ctrl-" + id);
+    var val = parseFloat(el.value);
+    document.getElementById("val-" + id).textContent = val.toFixed(def.dec);
+    scheduleApply();
+}
+
+function scheduleApply() {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    var status = document.getElementById("ctrl-status");
+    if (status) status.style.opacity = "1";
+    debounceTimer = setTimeout(function() {
+        applySettings();
+    }, 500);
+}
+
+function applySettings() {
+    var params = {};
+    sliderDefs.forEach(function(s) {
+        var el = document.getElementById("ctrl-" + s.id);
+        if (el) params[s.id] = parseFloat(el.value);
+    });
+    var awb = document.getElementById("ctrl-awb");
+    if (awb) params.awb = awb.value;
+
+    // Send to daemon via the stream update API
+    var qs = Object.keys(params).map(function(k) {
+        if (k === "exposure") return "shutter=" + Math.round(params[k] * 1000000);
+        return k + "=" + params[k];
+    }).join("&");
+
+    $.ajax({
+        type: "GET", url: "/indi-allsky/api/stream/update?" + qs, timeout: 10000,
+        success: function() {
+            var status = document.getElementById("ctrl-status");
+            if (status) {
+                status.textContent = "Applied";
+                setTimeout(function() { status.style.opacity = "0"; }, 1000);
+            }
+        },
+        error: function() {
+            var status = document.getElementById("ctrl-status");
+            if (status) { status.textContent = "Failed"; status.style.opacity = "1"; }
+        },
+    });
+}
+
+// Load sensor info to set gain range
+function loadSensorInfo() {
+    $.ajax({
+        type: "GET", url: "/indi-allsky/api/sensor_info", timeout: 10000,
+        success: function(data) {
+            if (data.gain_max) {
+                var el = document.getElementById("ctrl-gain");
+                if (el) el.max = data.gain_max;
+            }
+        },
+    });
+}
+
+// ---- Live View toggle ----
+var liveLoopActive = window.liveLoopActive || false;
+
+function toggleLiveLoop() {
+    if (!window.player) return;
+    if (liveLoopActive) {
+        window.player.disconnect();
+        liveLoopActive = false;
+        window.liveLoopActive = false;
+        var btn = document.getElementById("btn-live-loop");
+        if (btn) { btn.textContent = "Live View"; btn.className = "btn btn-outline-success btn-sm me-2"; }
+        $("#live-status").text("Stopped");
+    } else {
+        window.player.connect();
+        liveLoopActive = true;
+        window.liveLoopActive = true;
+        var btn = document.getElementById("btn-live-loop");
+        if (btn) { btn.textContent = "Stop Live"; btn.className = "btn btn-outline-danger btn-sm me-2"; }
+        $("#live-status").text("");
+    }
+}
+
+// ---- Capture One ----
+function captureOne() {
+    $("#live-status").text("Capturing...");
+    $.ajax({
+        type: "GET", url: "/indi-allsky/api/capture_one", timeout: 30000,
+        success: function() { $("#live-status").text("Captured!"); setTimeout(function() { $("#live-status").text(""); }, 3000); },
+        error: function() { $("#live-status").text("Capture failed"); },
+    });
+}
+
+// ---- Sync sliders from live metadata ----
+var _syncFromMeta = true;  // when true, sliders track live ISP values
+
+function syncControlsFromMetadata(meta) {
+    if (!_syncFromMeta) return;
+    // Only sync gain from live metadata — exposure is controlled by the
+    // config DB (CCD_EXPOSURE_MAX) and shouldn't snap back to the capture
+    // worker's calculated value.
+    if (meta.gain != null) {
+        setSliderValue("gain", meta.gain);
+    }
+}
+
+function setSliderValue(id, val) {
+    var el = document.getElementById("ctrl-" + id);
+    if (!el) return;
+    var def = sliderDefs.find(function(s) { return s.id === id; });
+    if (!def) return;
+    // Clamp to slider range
+    val = Math.max(parseFloat(el.min), Math.min(parseFloat(el.max), val));
+    el.value = val;
+    var valEl = document.getElementById("val-" + id);
+    if (valEl) valEl.textContent = val.toFixed(def.dec);
+}
+
+// When user touches a slider, stop syncing from metadata
+var _origOnSliderInput = onSliderInput;
+onSliderInput = function(id) {
+    _syncFromMeta = false;
+    _origOnSliderInput(id);
+};
+
+// Load initial values: exposure from config DB, gain from daemon metadata
+function loadInitialValues() {
+    // Exposure from config DB (the user's setting, not capture worker's value)
+    $.ajax({
+        type: "GET", url: "/indi-allsky/api/config_get", timeout: 5000,
+        success: function(data) {
+            if (data.CCD_EXPOSURE_MAX != null) setSliderValue("exposure", data.CCD_EXPOSURE_MAX);
+            var nightGain = data.CCD_CONFIG && data.CCD_CONFIG.NIGHT && data.CCD_CONFIG.NIGHT.GAIN;
+            if (nightGain != null) setSliderValue("gain", nightGain);
+            // Auto-exposure toggle
+            var autoexpEl = document.getElementById("ctrl-autoexp");
+            if (autoexpEl && data.TARGET_ADU_DISABLE != null) {
+                autoexpEl.checked = !data.TARGET_ADU_DISABLE;
+            }
+        },
+    });
+}
+
+// Init: inject controls into the page
+$(document).ready(function() {
+    var target = document.getElementById("slider-panel");
+    if (target) {
+        target.innerHTML = buildControlsHTML();
+        loadSensorInfo();
+        loadModes();
+        loadInitialValues();
+        loadDriverInfo();
+    }
+    // Update live button state if auto-connected
+    if (window.liveLoopActive) {
+        var btn = document.getElementById("btn-live-loop");
+        if (btn) { btn.textContent = "Stop Live"; btn.className = "btn btn-outline-danger btn-sm me-2"; }
+    }
+});

--- a/indi_allsky/flask/templates/config.html
+++ b/indi_allsky/flask/templates/config.html
@@ -656,6 +656,20 @@ var camera_id = {{ camera_id }};
 
     <div class="form-group row">
         <div class="col-sm-2">
+            {{ form_config.LIBCAMERA__BACKEND.label(class='col-form-label') }}
+        </div>
+        <div class="col-sm-2">
+            {{ form_config.LIBCAMERA__BACKEND(class='form-select bg-secondary') }}
+            <div id="LIBCAMERA__BACKEND-error" class="invalid-feedback text-danger" style="display: none;"></div>
+        </div>
+        <div class="col-sm-8">
+            <div>Camera driver: Auto detects the best available. Picamera2 is preferred on Raspberry Pi. libcamera uses python3-libcamera bindings. libcamera-still uses subprocess (slowest, no Python bindings needed).</div>
+            <div>Requires daemon restart to take effect.</div>
+        </div>
+    </div>
+
+    <div class="form-group row">
+        <div class="col-sm-2">
             {{ form_config.LIBCAMERA__IMAGE_FILE_TYPE.label(class='col-form-label') }}
         </div>
         <div class="col-sm-2">
@@ -10175,6 +10189,7 @@ const field_names = [
     'FITSHEADERS__4__VAL',
     'ADMIN_NETWORKS_FLASK',
     'LIBCAMERA__CAMERA_ID',
+    'LIBCAMERA__BACKEND',
     'LIBCAMERA__IMAGE_FILE_TYPE',
     'LIBCAMERA__IMAGE_FILE_TYPE_DAY',
     'LIBCAMERA__AWB',

--- a/indi_allsky/flask/templates/index_img.html
+++ b/indi_allsky/flask/templates/index_img.html
@@ -4,6 +4,7 @@
 
 {% block head %}
 <meta charset="UTF-8">
+<link rel="stylesheet" href="{{ url_for('indi_allsky.static', filename='css/allsky_player.css', v='1') }}">
 <style>
 .fit {
     max-width: 100%;
@@ -28,6 +29,7 @@ var camera_id = {{ camera_id }};
 var refreshInterval = {{ refreshInterval | int }};
 var night = {{ night }};
 var fullscreen = false;  //initial state
+var player = null;  // AllskyPlayer instance
 
 function init() {
     loadNextImage();
@@ -43,9 +45,12 @@ async function loop() {
 
     img = new Image();
     img.onload = function() {
-        $('#latest-image').attr({
-            'src': this.src,
-        });
+        // Only update the static image if player is not in live mode
+        if (!liveLoopActive) {
+            $('#latest-image').attr({
+                'src': this.src,
+            });
+        }
     };
 
 
@@ -56,14 +61,18 @@ async function loop() {
 
 
 function showImage(entry) {
-    console.log('Showing image ' + entry["url"]);
-    img.src = entry["url"];
+    if (!liveLoopActive) {
+        console.log('Showing image ' + entry["url"]);
+        img.src = entry["url"];
+    }
 }
 
 
 function loadNextImage() {
-    console.log('Loading next image');
-    loadJS("{{ url_for(latest_image_view) }}", {'camera_id' : camera_id, 'limit_s' : max_age, 'night' : night}, function() {});
+    if (!liveLoopActive) {
+        console.log('Loading next image');
+        loadJS("{{ url_for(latest_image_view) }}", {'camera_id' : camera_id, 'limit_s' : max_age, 'night' : night}, function() {});
+    }
     setTimeout(loadNextImage, refreshInterval);
 }
 
@@ -150,14 +159,44 @@ function closeFullscreen() {
 
 
 $( document ).ready(function() {
+    // Initialize AllskyPlayer on the player container
+    var playerContainer = document.getElementById('allsky-player-container');
+    if (playerContainer) {
+        player = new AllskyPlayer({
+            container: playerContainer,
+            wsUrl: '/indi-allsky/api/stream/ws',
+            feedUrl: '/indi-allsky/api/stream/feed.mjpeg',
+            metadataUrl: '/indi-allsky/api/stream/metadata',
+            preferWs: true,
+            onstatuschange: function(online) {
+                if (!online && liveLoopActive) {
+                    $('#live-status').text('Stream disconnected');
+                }
+            },
+            onmetadata: function(meta) {
+                if (typeof syncControlsFromMetadata === "function") {
+                    syncControlsFromMetadata(meta);
+                }
+            },
+        });
+        // Auto-connect the live stream on page load
+        player.connect();
+        liveLoopActive = true;
+    }
+
+    // Click on static image for fullscreen (when not in live mode)
     $('#latest-image').on("click", function() {
-        goFullscreen(this);
+        if (!liveLoopActive) {
+            goFullscreen(this);
+        }
     });
 
     init();
 });
 
 </script>
+<script src="{{ url_for('indi_allsky.static', filename='js/allsky_player.js', v='1') }}"></script>
+<script src="{{ url_for('indi_allsky.static', filename='js/capture_buttons.js', v='8') }}"></script>
 {% endblock %}
 
 {% block content %}
@@ -165,9 +204,25 @@ $( document ).ready(function() {
     <div class="row">
         <div class="text-muted text-center" id="message">Loading...</div>
     </div>
+    <div class="row mb-2">
+        <div class="col-12 text-center">
+            <button id="btn-capture-one" class="btn btn-outline-info btn-sm me-2" onclick="captureOne()">Capture One</button>
+            <button id="btn-live-loop" class="btn btn-outline-success btn-sm me-2" onclick="toggleLiveLoop()">Live View</button>
+            <button class="btn btn-outline-secondary btn-sm me-2" data-bs-toggle="collapse" data-bs-target="#slider-panel-wrap">Camera Settings</button>
+            <span id="live-status" class="text-muted small"></span>
+        </div>
+    </div>
+    <div class="collapse" id="slider-panel-wrap">
+        <div class="card card-body bg-dark border-success p-2 mb-2">
+            <div id="slider-panel"></div>
+        </div>
+    </div>
     <div class="row h-75 align-items-center">
         <div class="col-12 text-center">
-            <img id="latest-image" class="fit">
+            <!-- AllskyPlayer container (live stream) -->
+            <div id="allsky-player-container"></div>
+            <!-- Static latest image (hidden when live stream is active) -->
+            <img id="latest-image" class="fit" style="display:none">
         </div>
     </div>
 </div>

--- a/indi_allsky/flask/templates/loop_img.html
+++ b/indi_allsky/flask/templates/loop_img.html
@@ -244,6 +244,19 @@ $( document ).ready(function() {
 <div class="row">
     <div class="text-muted text-center" id="message"></div>
 </div>
+    <div class="row mb-2">
+        <div class="col-12 text-center">
+            <button id="btn-capture-one" class="btn btn-outline-info btn-sm me-2" onclick="captureOne()">Capture One</button>
+            <button id="btn-live-loop" class="btn btn-outline-success btn-sm me-2" onclick="toggleLiveLoop()">Live View</button>
+            <button class="btn btn-outline-secondary btn-sm me-2" data-bs-toggle="collapse" data-bs-target="#slider-panel-wrap">Camera Settings</button>
+            <span id="live-status" class="text-muted small"></span>
+        </div>
+    </div>
+    <div class="collapse" id="slider-panel-wrap">
+        <div class="card card-body bg-dark border-secondary p-2 mb-2">
+            <div id="slider-panel"></div>
+        </div>
+    </div>
 <div class="row h-75 align-items-center">
     <div class="col-12 text-center">
         <img id="loop-image" class="fit">
@@ -286,4 +299,5 @@ $("#ROCK_CHECKBOX").on("change", function() {
 
 </script>
 
+<script src="{{ url_for('indi_allsky.static', filename='js/capture_buttons.js', v='7') }}"></script>
 {% endblock %}

--- a/indi_allsky/flask/views.py
+++ b/indi_allsky/flask/views.py
@@ -2674,6 +2674,7 @@ class ConfigView(FormView):
             'LIBCAMERA__CCM_DISABLE'         : self.indi_allsky_config.get('LIBCAMERA', {}).get('CCM_DISABLE', False),
             'LIBCAMERA__CCM_DISABLE_DAY'     : self.indi_allsky_config.get('LIBCAMERA', {}).get('CCM_DISABLE_DAY', False),
             'LIBCAMERA__CAMERA_ID'           : str(self.indi_allsky_config.get('LIBCAMERA', {}).get('CAMERA_ID', 0)),  # string in form, int in config
+            'LIBCAMERA__BACKEND'             : self.indi_allsky_config.get('LIBCAMERA', {}).get('BACKEND', 'auto'),
             'LIBCAMERA__EXTRA_OPTIONS'       : self.indi_allsky_config.get('LIBCAMERA', {}).get('EXTRA_OPTIONS', ''),
             'LIBCAMERA__EXTRA_OPTIONS_DAY'   : self.indi_allsky_config.get('LIBCAMERA', {}).get('EXTRA_OPTIONS_DAY', ''),
             'LIBCAMERA__MQTT_TRANSPORT'      : self.indi_allsky_config.get('LIBCAMERA', {}).get('MQTT_TRANSPORT', 'tcp'),
@@ -3706,6 +3707,7 @@ class AjaxConfigView(BaseView):
         self.indi_allsky_config['LIBCAMERA']['CCM_DISABLE']             = bool(request.json['LIBCAMERA__CCM_DISABLE'])
         self.indi_allsky_config['LIBCAMERA']['CCM_DISABLE_DAY']         = bool(request.json['LIBCAMERA__CCM_DISABLE_DAY'])
         self.indi_allsky_config['LIBCAMERA']['CAMERA_ID']               = int(request.json['LIBCAMERA__CAMERA_ID'])
+        self.indi_allsky_config['LIBCAMERA']['BACKEND']                = str(request.json['LIBCAMERA__BACKEND'])
         self.indi_allsky_config['LIBCAMERA']['EXTRA_OPTIONS']           = str(request.json['LIBCAMERA__EXTRA_OPTIONS'])
         self.indi_allsky_config['LIBCAMERA']['EXTRA_OPTIONS_DAY']       = str(request.json['LIBCAMERA__EXTRA_OPTIONS_DAY'])
         self.indi_allsky_config['LIBCAMERA']['MQTT_TRANSPORT']          = str(request.json['LIBCAMERA__MQTT_TRANSPORT'])
@@ -4074,6 +4076,9 @@ class AjaxConfigView(BaseView):
             return jsonify(error_data), 400
 
 
+        # Pipeline config changes to picamera2 daemon via IPC
+        self._sync_daemon_controls(request.json)
+
         if reload_on_save:
             self._miscDb.setState('STATUS', constants.STATUS_RELOADING)
 
@@ -4097,6 +4102,93 @@ class AjaxConfigView(BaseView):
 
 
         return jsonify(message)
+
+
+    def _send_daemon_cmd(self, cmd_dict, timeout=10.0):
+        """Send a JSON command to the picamera2 daemon and return the response."""
+        import socket as _sock
+        try:
+            s = _sock.socket(_sock.AF_UNIX, _sock.SOCK_STREAM)
+            s.settimeout(timeout)
+            s.connect('/run/indi-allsky/picamera2.sock')
+            s.sendall(json.dumps(cmd_dict).encode() + b'\n')
+            buf = b''
+            while b'\n' not in buf:
+                chunk = s.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+            s.close()
+            return json.loads(buf.decode().strip())
+        except Exception as e:
+            app.logger.warning('Daemon IPC failed: %s', e)
+            return {'ok': False, 'error': str(e)}
+
+    def _sync_daemon_controls(self, form_data):
+        """Pipeline all camera-related config changes to the daemon via IPC.
+
+        Sends backend switch, exposure/gain, AWB, and stream settings
+        so the live stream reflects config page changes immediately.
+        """
+        # 1. Backend switch (if changed)
+        new_backend = form_data.get('LIBCAMERA__BACKEND', '')
+        if new_backend:
+            resp = self._send_daemon_cmd({'cmd': 'set_backend', 'backend': new_backend})
+            if resp.get('ok'):
+                app.logger.info('Camera backend switched to: %s', new_backend)
+            else:
+                app.logger.warning('Backend switch failed: %s', resp.get('error'))
+
+        # 2. Camera controls — determine current mode's gain + exposure
+        controls = {}
+
+        # Gain: pick from the active mode (night/moon/day)
+        night_gain = form_data.get('CCD_CONFIG__NIGHT__GAIN')
+        moon_gain = form_data.get('CCD_CONFIG__MOONMODE__GAIN')
+        day_gain = form_data.get('CCD_CONFIG__DAY__GAIN')
+        exposure_max = form_data.get('CCD_EXPOSURE_MAX')
+        exposure_def = form_data.get('CCD_EXPOSURE_DEF')
+
+        # Use night gain/exposure by default (the capture worker will
+        # override based on actual sun altitude, but this gives immediate
+        # feedback in the stream)
+        if night_gain is not None:
+            controls['gain'] = float(night_gain)
+        if exposure_max is not None:
+            controls['exposure'] = float(exposure_max)
+        elif exposure_def is not None:
+            controls['exposure'] = float(exposure_def)
+
+        # AWB
+        awb_night = form_data.get('LIBCAMERA__AWB_ENABLE')
+        if awb_night is not None:
+            controls['awb'] = bool(awb_night)
+
+        if controls:
+            resp = self._send_daemon_cmd({'cmd': 'set_controls', **controls})
+            if resp.get('ok'):
+                app.logger.info('Daemon controls applied: %s', controls)
+            else:
+                app.logger.warning('Daemon controls failed: %s', resp.get('error'))
+
+        # 3. Stream settings
+        stream_cmd = {}
+        stream_width = form_data.get('STREAM_WIDTH')
+        stream_height = form_data.get('STREAM_HEIGHT')
+        stream_quality = form_data.get('STREAM_QUALITY')
+        stream_osd = form_data.get('STREAM_OSD')
+        if stream_width is not None:
+            stream_cmd['width'] = int(stream_width)
+        if stream_height is not None:
+            stream_cmd['height'] = int(stream_height)
+        if stream_quality is not None:
+            stream_cmd['quality'] = int(stream_quality)
+        if stream_osd is not None:
+            stream_cmd['osd'] = bool(stream_osd)
+
+        if stream_cmd:
+            stream_cmd['cmd'] = 'set_stream'
+            self._send_daemon_cmd(stream_cmd)
 
 
 class AjaxSetTimeView(BaseView):

--- a/indi_allsky/image.py
+++ b/indi_allsky/image.py
@@ -2128,6 +2128,11 @@ class ImageWorker(Process):
 
 
     def calculate_exposure(self, adu, exposure, gain):
+        if self.config.get('TARGET_ADU_DISABLE', False):
+            # Manual exposure mode — skip auto-exposure recalculation
+            self.target_adu_found = True
+            return adu, 0.0
+
         if adu <= 0.0:
             # ensure we do not divide by zero
             logger.warning('Zero average, setting a default of 0.1')

--- a/indi_allsky/wsgi.py
+++ b/indi_allsky/wsgi.py
@@ -6,14 +6,26 @@
 # Version 20260401.0
 #
 import logging
+import logging.handlers
 
 from indi_allsky.flask import create_app
 application = create_app()
 
+
+class _RootRedirect:
+    """WSGI middleware: redirect / to /indi-allsky/ when no reverse proxy."""
+    def __init__(self, app):
+        self._app = app
+    def __call__(self, environ, start_response):
+        if environ.get("PATH_INFO", "/") == "/":
+            start_response("302 Found", [("Location", "/indi-allsky/")])
+            return [b""]
+        return self._app(environ, start_response)
+
+
 gunicorn_logger = logging.getLogger('gunicorn.error')
 application.logger.handlers = gunicorn_logger.handlers
 application.logger.setLevel(gunicorn_logger.level)
-
 
 # Attach a syslog handler so 'indi_allsky' logger messages appear in webapp log
 LOG_FORMATTER_SYSLOG = logging.Formatter('[%(levelname)s] %(processName)s-%(process)d %(module)s.%(funcName)s() [%(lineno)d]: %(message)s')
@@ -23,3 +35,5 @@ LOG_HANDLER_SYSLOG.setFormatter(LOG_FORMATTER_SYSLOG)
 indi_allsky_logger = logging.getLogger('indi_allsky')
 indi_allsky_logger.setLevel(logging.INFO)
 indi_allsky_logger.addHandler(LOG_HANDLER_SYSLOG)
+
+application = _RootRedirect(application)

--- a/requirements/requirements_latest.txt
+++ b/requirements/requirements_latest.txt
@@ -43,6 +43,7 @@ Flask-SQLAlchemy >= 3.1.1
 Flask-Migrate >= 4.0.5
 Flask-WTF >= 1.2.1
 Flask-Login >= 0.6.3
+flask-sock >= 0.7.0
 werkzeug >= 3.1.6
 is-safe-url
 certifi >= 2024.7.4

--- a/requirements/requirements_latest_web.txt
+++ b/requirements/requirements_latest_web.txt
@@ -27,6 +27,7 @@ Flask-SQLAlchemy >= 3.1.1
 Flask-Migrate >= 4.0.5
 Flask-WTF >= 1.2.1
 Flask-Login >= 0.6.2
+flask-sock >= 0.7.0
 werkzeug >= 3.1.6
 is-safe-url
 certifi >= 2023.7.22

--- a/service/picamera2-daemon.service
+++ b/service/picamera2-daemon.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Picamera2 Daemon for indi-allsky
+Before=indi-allsky.service
+After=network.target
+
+[Service]
+Type=simple
+User=root
+Group=video
+RuntimeDirectory=indi-allsky
+WorkingDirectory=/home/pi/indi-allsky
+ExecStart=${VENV}/bin/python3 ${INDI_DIR}/indi_allsky/camera/picamera2_daemon.py --camera 0
+Restart=on-failure
+RestartSec=3
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Replace rpicam-still/rpicam-vid with picamera2 daemon + WebSocket live stream

### Problem
The current libcamera backend spawns separate processes (rpicam-still for capture, rpicam-vid for streaming) that fight over exclusive camera access. The live stream must stop/restart the entire indi-allsky service to acquire the camera, and vice versa.

### Solution
A single-process picamera2 daemon that owns the camera and serves both capture and streaming simultaneously via IPC (shared memory + Unix socket).

### Changes

**Camera daemon** (`picamera2_daemon.py`):
- Standalone process owning the Picamera2 instance
- Continuous grab loop in daemon thread
- Shared memory for JPEG stream (dynamically sized from stream resolution)
- Unix socket IPC for controls, capture, metadata, sensor info
- Server-side OSD overlay using the original indi-allsky overlay modules (orb, cardinals, moon texture, Pillow text with `# color/xy/anchor/size` directives)
- Stream resolution, quality, and OSD state persisted to config DB

**Client** (`picamera2_client.py`):
- Zero-dependency client for capture worker and Flask
- Shared memory reader with resource tracker fix (prevents shm deletion on client exit)

**libcamera.py refactor**:
- `setCcdExposure` uses daemon client instead of rpicam-still subprocess
- Async capture via background thread
- Metadata from daemon instead of JSON file parsing
- No colorspace conversions (BGR throughout)

**WebSocket live stream**:
- Flask WebSocket endpoint reads directly from daemon shared memory
- Binary frame protocol: `[4B JSON len][metadata JSON][JPEG data]`
- Metadata: exposure, gain, lux, colour_temp, sensor_temp, WB gains
- Sends latest frame immediately on connect (no stall during long exposures)
- AllskyPlayer JS: canvas-based WS player with MJPEG fallback

**Camera controls**:
- Unified sliders (gain, exposure, brightness, contrast, target ADU, JPEG quality)
- Resolution selector with hardware/software mode labels
- OSD toggle (persisted)
- All changes apply live via daemon socket

**Infrastructure**:
- `picamera2-daemon.service`: systemd unit (starts before indi-allsky)
- `wsgi.py`: root redirect for direct SSL without reverse proxy
- `_stop_allsky/_start_allsky` removed (no camera contention)
- Runs on HTTPS/443 via gunicorn SSL — no Apache/nginx needed
- `flask-sock` added to requirements

### Testing
- Tested on Raspberry Pi 5 with IMX415 sensor
- Concurrent capture + streaming verified (no contention)
- Day/night mode transitions, long exposures (25s+), binning changes
- WebSocket stream delivers first frame in <500ms even during long exposures
