### PR TITLE
White Balance Early in Processing Pipeline

### DIFF
--- a/indi_allsky/image.py
+++ b/indi_allsky/image.py
@@ -577,6 +577,12 @@ class ImageWorker(Process):
         # adu value may be updated below
 
 
+        # white balance
+        self.image_processor.white_balance_mtf()
+        self.image_processor.white_balance_manual_bgr()
+        self.image_processor.white_balance_auto_bgr()
+
+
         self.image_processor.denoise()
 
         self.image_processor.stretch()
@@ -647,12 +653,6 @@ class ImageWorker(Process):
 
         # green removal
         self.image_processor.scnr()
-
-
-        # white balance
-        self.image_processor.white_balance_mtf()
-        self.image_processor.white_balance_manual_bgr()
-        self.image_processor.white_balance_auto_bgr()
 
 
         # saturation


### PR DESCRIPTION
White balance currently happens after stretching, but should be done while the image is linear to keep accurate colors.

Used ColorCalibration in PixInsight to find WB factors with a FITS image using the window trim as white reference and got a pleasing result. Applying them in indi-allsky gives me an image with a pink sky.
<img width="521" height="480" alt="ccd1_20260429_145138-480" src="https://github.com/user-attachments/assets/6aa29938-d611-46bd-8d05-c18f8c61cd9a" />

It never looks quite right, even if I try manually balancing the above image. Some part always has a strange tint.<br>

Moving WB earlier in the processing pipeline gives me the expected result straight from indi-allsky:
<img width="521" height="480" alt="ccd1_20260429_144648-480" src="https://github.com/user-attachments/assets/fd1d7424-fec6-472a-ac83-c0782f7e7c44" />

This is with the same settings as the first image.

Anyone who adjusted their WB factors would see their image change after updating. Whether that needs to be addressed could be worth discussing, but overall I think this improves white balancing.