### PR TITLE
MqttBrokerSensor:  grab chart/overlay labels from configured topic names

### DIFF
--- a/indi_allsky/capture.py
+++ b/indi_allsky/capture.py
@@ -2310,31 +2310,37 @@ class CaptureWorker(Process):
         temp_sensor__a_label = self.config.get('TEMP_SENSOR', {}).get('A_LABEL', 'Sensor A')
         temp_sensor__a_user_var_slot = self.config.get('TEMP_SENSOR', {}).get('A_USER_VAR_SLOT', 'sensor_user_10')
         temp_sensor__a_title_template = self.config.get('TEMP_SENSOR', {}).get('A_TITLE_TEMPLATE', '{name:s} - {label:s} - {probe:s}')
+        temp_sensor__a_pin_1_name = self.config.get('TEMP_SENSOR', {}).get('A_PIN_1', '')
 
         temp_sensor__b_classname = self.config.get('TEMP_SENSOR', {}).get('B_CLASSNAME', '')
         temp_sensor__b_label = self.config.get('TEMP_SENSOR', {}).get('B_LABEL', 'Sensor B')
         temp_sensor__b_user_var_slot = self.config.get('TEMP_SENSOR', {}).get('B_USER_VAR_SLOT', 'sensor_user_20')
         temp_sensor__b_title_template = self.config.get('TEMP_SENSOR', {}).get('B_TITLE_TEMPLATE', '{name:s} - {label:s} - {probe:s}')
+        temp_sensor__b_pin_1_name = self.config.get('TEMP_SENSOR', {}).get('B_PIN_1', '')
 
         temp_sensor__c_classname = self.config.get('TEMP_SENSOR', {}).get('C_CLASSNAME', '')
         temp_sensor__c_label = self.config.get('TEMP_SENSOR', {}).get('C_LABEL', 'Sensor C')
         temp_sensor__c_user_var_slot = self.config.get('TEMP_SENSOR', {}).get('C_USER_VAR_SLOT', 'sensor_user_30')
         temp_sensor__c_title_template = self.config.get('TEMP_SENSOR', {}).get('C_TITLE_TEMPLATE', '{name:s} - {label:s} - {probe:s}')
+        temp_sensor__c_pin_1_name = self.config.get('TEMP_SENSOR', {}).get('C_PIN_1', '')
 
         temp_sensor__d_classname = self.config.get('TEMP_SENSOR', {}).get('D_CLASSNAME', '')
         temp_sensor__d_label = self.config.get('TEMP_SENSOR', {}).get('D_LABEL', 'Sensor D')
         temp_sensor__d_user_var_slot = self.config.get('TEMP_SENSOR', {}).get('D_USER_VAR_SLOT', 'sensor_user_40')
         temp_sensor__d_title_template = self.config.get('TEMP_SENSOR', {}).get('D_TITLE_TEMPLATE', '{name:s} - {label:s} - {probe:s}')
+        temp_sensor__d_pin_1_name = self.config.get('TEMP_SENSOR', {}).get('D_PIN_1', '')
 
         temp_sensor__e_classname = self.config.get('TEMP_SENSOR', {}).get('E_CLASSNAME', '')
         temp_sensor__e_label = self.config.get('TEMP_SENSOR', {}).get('E_LABEL', 'Sensor E')
         temp_sensor__e_user_var_slot = self.config.get('TEMP_SENSOR', {}).get('E_USER_VAR_SLOT', 'sensor_user_50')
         temp_sensor__e_title_template = self.config.get('TEMP_SENSOR', {}).get('E_TITLE_TEMPLATE', '{name:s} - {label:s} - {probe:s}')
+        temp_sensor__e_pin_1_name = self.config.get('TEMP_SENSOR', {}).get('E_PIN_1', '')
 
         temp_sensor__f_classname = self.config.get('TEMP_SENSOR', {}).get('F_CLASSNAME', '')
         temp_sensor__f_label = self.config.get('TEMP_SENSOR', {}).get('F_LABEL', 'Sensor F')
         temp_sensor__f_user_var_slot = self.config.get('TEMP_SENSOR', {}).get('F_USER_VAR_SLOT', 'sensor_user_55')
         temp_sensor__f_title_template = self.config.get('TEMP_SENSOR', {}).get('F_TITLE_TEMPLATE', '{name:s} - {label:s} - {probe:s}')
+        temp_sensor__f_pin_1_name = self.config.get('TEMP_SENSOR', {}).get('F_PIN_1', '')
 
 
         ### Sensor A
@@ -2343,12 +2349,16 @@ class CaptureWorker(Process):
                 temp_sensor__a_class = getattr(indi_allsky_sensors, temp_sensor__a_classname)
                 sensor_a_index = constants.SENSOR_INDEX_MAP[str(temp_sensor__a_user_var_slot)]
 
+                temp_sensor__a_labels = temp_sensor__a_class.METADATA['labels']
+                if hasattr(temp_sensor__a_class, 'get_dynamic_labels'):
+                    temp_sensor__a_labels = temp_sensor__a_class.get_dynamic_labels(temp_sensor__a_pin_1_name)
+
                 for x in range(temp_sensor__a_class.METADATA['count']):
                     try:
                         sensor_label_data = {
                             'name'  : temp_sensor__a_class.METADATA['name'],
                             'label' : temp_sensor__a_label,
-                            'probe' : temp_sensor__a_class.METADATA['labels'][x],
+                            'probe' : temp_sensor__a_labels[x],
                         }
 
                         self.SENSOR_SLOTS[sensor_a_index + x][1] = temp_sensor__a_title_template.format(**sensor_label_data)
@@ -2365,12 +2375,16 @@ class CaptureWorker(Process):
                 temp_sensor__b_class = getattr(indi_allsky_sensors, temp_sensor__b_classname)
                 sensor_b_index = constants.SENSOR_INDEX_MAP[str(temp_sensor__b_user_var_slot)]
 
+                temp_sensor__b_labels = temp_sensor__b_class.METADATA['labels']
+                if hasattr(temp_sensor__b_class, 'get_dynamic_labels'):
+                    temp_sensor__b_labels = temp_sensor__b_class.get_dynamic_labels(temp_sensor__b_pin_1_name)
+
                 for x in range(temp_sensor__b_class.METADATA['count']):
                     try:
                         sensor_label_data = {
                             'name'  : temp_sensor__b_class.METADATA['name'],
                             'label' : temp_sensor__b_label,
-                            'probe' : temp_sensor__b_class.METADATA['labels'][x],
+                            'probe' : temp_sensor__b_labels[x],
                         }
 
                         self.SENSOR_SLOTS[sensor_b_index + x][1] = temp_sensor__b_title_template.format(**sensor_label_data)
@@ -2387,12 +2401,16 @@ class CaptureWorker(Process):
                 temp_sensor__c_class = getattr(indi_allsky_sensors, temp_sensor__c_classname)
                 sensor_c_index = constants.SENSOR_INDEX_MAP[str(temp_sensor__c_user_var_slot)]
 
+                temp_sensor__c_labels = temp_sensor__c_class.METADATA['labels']
+                if hasattr(temp_sensor__c_class, 'get_dynamic_labels'):
+                    temp_sensor__c_labels = temp_sensor__c_class.get_dynamic_labels(temp_sensor__c_pin_1_name)
+
                 for x in range(temp_sensor__c_class.METADATA['count']):
                     try:
                         sensor_label_data = {
                             'name'  : temp_sensor__c_class.METADATA['name'],
                             'label' : temp_sensor__c_label,
-                            'probe' : temp_sensor__c_class.METADATA['labels'][x],
+                            'probe' : temp_sensor__c_labels[x],
                         }
 
                         self.SENSOR_SLOTS[sensor_c_index + x][1] = temp_sensor__c_title_template.format(**sensor_label_data)
@@ -2409,12 +2427,16 @@ class CaptureWorker(Process):
                 temp_sensor__d_class = getattr(indi_allsky_sensors, temp_sensor__d_classname)
                 sensor_d_index = constants.SENSOR_INDEX_MAP[str(temp_sensor__d_user_var_slot)]
 
+                temp_sensor__d_labels = temp_sensor__d_class.METADATA['labels']
+                if hasattr(temp_sensor__d_class, 'get_dynamic_labels'):
+                    temp_sensor__d_labels = temp_sensor__d_class.get_dynamic_labels(temp_sensor__d_pin_1_name)
+
                 for x in range(temp_sensor__d_class.METADATA['count']):
                     try:
                         sensor_label_data = {
                             'name'  : temp_sensor__d_class.METADATA['name'],
                             'label' : temp_sensor__d_label,
-                            'probe' : temp_sensor__d_class.METADATA['labels'][x],
+                            'probe' : temp_sensor__d_labels[x],
                         }
 
                         self.SENSOR_SLOTS[sensor_d_index + x][1] = temp_sensor__d_title_template.format(**sensor_label_data)
@@ -2431,12 +2453,16 @@ class CaptureWorker(Process):
                 temp_sensor__e_class = getattr(indi_allsky_sensors, temp_sensor__e_classname)
                 sensor_e_index = constants.SENSOR_INDEX_MAP[str(temp_sensor__e_user_var_slot)]
 
+                temp_sensor__e_labels = temp_sensor__e_class.METADATA['labels']
+                if hasattr(temp_sensor__e_class, 'get_dynamic_labels'):
+                    temp_sensor__e_labels = temp_sensor__e_class.get_dynamic_labels(temp_sensor__e_pin_1_name)
+
                 for x in range(temp_sensor__e_class.METADATA['count']):
                     try:
                         sensor_label_data = {
                             'name'  : temp_sensor__e_class.METADATA['name'],
                             'label' : temp_sensor__e_label,
-                            'probe' : temp_sensor__e_class.METADATA['labels'][x],
+                            'probe' : temp_sensor__e_labels[x],
                         }
 
                         self.SENSOR_SLOTS[sensor_e_index + x][1] = temp_sensor__e_title_template.format(**sensor_label_data)
@@ -2453,12 +2479,16 @@ class CaptureWorker(Process):
                 temp_sensor__f_class = getattr(indi_allsky_sensors, temp_sensor__f_classname)
                 sensor_f_index = constants.SENSOR_INDEX_MAP[str(temp_sensor__f_user_var_slot)]
 
+                temp_sensor__f_labels = temp_sensor__f_class.METADATA['labels']
+                if hasattr(temp_sensor__f_class, 'get_dynamic_labels'):
+                    temp_sensor__f_labels = temp_sensor__f_class.get_dynamic_labels(temp_sensor__f_pin_1_name)
+
                 for x in range(temp_sensor__f_class.METADATA['count']):
                     try:
                         sensor_label_data = {
                             'name'  : temp_sensor__f_class.METADATA['name'],
                             'label' : temp_sensor__f_label,
-                            'probe' : temp_sensor__f_class.METADATA['labels'][x],
+                            'probe' : temp_sensor__f_labels[x],
                         }
 
                         self.SENSOR_SLOTS[sensor_f_index + x][1] = temp_sensor__f_title_template.format(**sensor_label_data)

--- a/indi_allsky/devices/sensors/mqttBrokerSensor.py
+++ b/indi_allsky/devices/sensors/mqttBrokerSensor.py
@@ -43,6 +43,34 @@ class MqttBrokerSensor(SensorBase):
     }
 
 
+    @classmethod
+    def get_dynamic_labels(cls, pin_1_name):
+        """Derive per-slot labels from the configured topic list.
+
+        Used by capture.py:update_sensor_slot_labels() so chart and overlay
+        titles read the actual topic name instead of the static "Topic N"
+        placeholders in METADATA['labels'].
+
+        Pure function over config; safe to call from any process.
+        Always returns METADATA['count'] entries, padding with "Topic N"
+        for unfilled slots.
+        """
+        topics = (pin_1_name or '').split(',')
+        labels = []
+        for t in topics[:cls.METADATA['count']]:
+            parts = t.strip().rstrip('/').split('/')
+            # ESPHome / Home Assistant convention: <prefix>/sensor/<name>/state
+            if len(parts) >= 2 and parts[-1] == 'state':
+                slug = parts[-2]
+            else:
+                slug = parts[-1] if parts else ''
+            slug = slug.replace('_', ' ').replace('-', ' ').strip()
+            labels.append(slug.title() if slug else 'Topic {0}'.format(len(labels) + 1))
+        while len(labels) < cls.METADATA['count']:
+            labels.append('Topic {0}'.format(len(labels) + 1))
+        return tuple(labels)
+
+
     def __init__(self, *args, **kwargs):
         super(MqttBrokerSensor, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
Replaces the static `Topic 1..10` labels with names derived from the user's configured topics.

 ## Changes                                                                    

  - `mqttBrokerSensor.py`: new optional classmethod `get_dynamic_labels(pin_1_name)` — formats the comma-separated topic list,  drops trailing `/state`, pads to 10 with `Topic N`.                           

  - `capture.py`: `update_sensor_slot_labels()` reads `*_PIN_1` for slots A–F and uses `get_dynamic_labels` when the driver class implements it. Falls back  to `METADATA['labels']` otherwise.                                            
                                                  

### Backward compatatibility                                                            

  No new config keys, no schema changes. Every other driver lacks `get_dynamic_labels` → existing path unchanged (verified against BME280, INA228, MPU6050, simulator).

Solves: #2905 