### PR TITLE
Enable boto3 retries for object storage uploads

### DIFF
--- a/indi_allsky/filetransfer/boto3_generic.py
+++ b/indi_allsky/filetransfer/boto3_generic.py
@@ -47,7 +47,12 @@ class boto3_generic(GenericFileTransfer):
         boto_config = Config(
             connect_timeout=self.connect_timeout,
             read_timeout=self.timeout,
-            retries={'max_attempts': 0},
+            # Retry transient errors instead of dropping the asset. With
+            # max_attempts=0 a single transient error -- e.g. a Backblaze B2
+            # InternalError (HTTP 500) or a dropped connection -- fails the
+            # PutObject permanently, and the failed upload task is not re-queued,
+            # so the asset silently stays only on local disk.
+            retries={'max_attempts': 5, 'mode': 'adaptive'},
         )
 
         self.client = boto3.client(

--- a/indi_allsky/filetransfer/boto3_minio.py
+++ b/indi_allsky/filetransfer/boto3_minio.py
@@ -66,7 +66,12 @@ class boto3_minio(GenericFileTransfer):
         boto_config = Config(
             connect_timeout=self.connect_timeout,
             read_timeout=self.timeout,
-            retries={'max_attempts': 0},
+            # Retry transient errors instead of dropping the asset. With
+            # max_attempts=0 a single transient error -- e.g. a Backblaze B2
+            # InternalError (HTTP 500) or a dropped connection -- fails the
+            # PutObject permanently, and the failed upload task is not re-queued,
+            # so the asset silently stays only on local disk.
+            retries={'max_attempts': 5, 'mode': 'adaptive'},
         )
 
         self.client = boto3.client(

--- a/indi_allsky/filetransfer/boto3_s3.py
+++ b/indi_allsky/filetransfer/boto3_s3.py
@@ -47,7 +47,12 @@ class boto3_s3(GenericFileTransfer):
         boto_config = Config(
             connect_timeout=self.connect_timeout,
             read_timeout=self.timeout,
-            retries={'max_attempts': 0},
+            # Retry transient errors instead of dropping the asset. With
+            # max_attempts=0 a single transient error -- e.g. a Backblaze B2
+            # InternalError (HTTP 500) or a dropped connection -- fails the
+            # PutObject permanently, and the failed upload task is not re-queued,
+            # so the asset silently stays only on local disk.
+            retries={'max_attempts': 5, 'mode': 'adaptive'},
         )
 
         self.client = boto3.client(


### PR DESCRIPTION
## Problem

All three boto3 upload backends (`boto3_generic`, `boto3_s3`, `boto3_minio`) build the client with retries disabled:

```python
boto_config = Config(
    connect_timeout=self.connect_timeout,
    read_timeout=self.timeout,
    retries={'max_attempts': 0},
)
```

With `max_attempts=0`, the first transient error on a `PutObject` is fatal. Since a failed upload task isn't re-queued, every transient blip silently leaves the asset only on local disk — and once retention prunes the local copy, it's gone from the bucket permanently.

## Evidence (Backblaze B2, `boto3_generic`)

Over one day, ~0.9% of uploads failed (63 of ~6,870), all transient and all in boto3's standard retryable set:

- `An error occurred (InternalError) when calling the PutObject operation (reached max retries: 0): internal incident` — B2 **server-side HTTP 500s**
- `Connection was closed before we received a valid response from endpoint URL` — transient connection resets

Re-uploading the exact same files with `max_attempts: 5` succeeded with **zero failures** — same endpoint, same objects, only retries toggled.

## Fix

Enable bounded **adaptive** retries (5 attempts) in all three backends, so transient errors are retried with exponential backoff instead of dropping data. Adaptive mode additionally applies client-side rate limiting if the object store starts throttling under load.

Tradeoff: with a small `UPLOAD_WORKERS` pool, a retrying upload occupies a worker slightly longer under transient errors — a reasonable cost versus permanently losing the asset.

`python -m py_compile` passes on all three files. No behavior change on the success path; retries only engage on the errors boto3 already classifies as retryable.