### PR TITLE
fix: don't crash charts endpoint when detection mask size doesn't match image

### DIFF
--- a/indi_allsky/flask/views.py
+++ b/indi_allsky/flask/views.py
@@ -1842,6 +1842,14 @@ class JsonChartView(JsonView):
 
         _sqm_mask = self._load_detection_mask(latest_image.binmode)
 
+        if not isinstance(_sqm_mask, type(None)) and _sqm_mask.shape != image_data.shape[:2]:
+            app.logger.error(
+                'Detection mask shape %s does not match image shape %s, ignoring mask',
+                _sqm_mask.shape,
+                image_data.shape[:2],
+            )
+            _sqm_mask = None
+
 
         if isinstance(_sqm_mask, type(None)):
             sqm_roi = self.indi_allsky_config.get('SQM_ROI', [])

--- a/testing/mask_shape_test.py
+++ b/testing/mask_shape_test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+# Reproduces https://github.com/aaronwmorris/indi-allsky/issues/2965
+#
+# getChartData() in indi_allsky/flask/views.py replaces the correctly-shaped
+# default mask with the loaded detection mask via `numpy_mask = _sqm_mask == 0`
+# without checking that the detection mask's dimensions actually match the
+# current image. If a user's saved detection mask has different dimensions
+# than the current capture (different resolution/binning), numpy.ma.masked_array
+# raises numpy.ma.core.MaskError and the chart endpoint returns HTTP 500 for
+# every request.
+#
+# This isolates just the masking logic (no Flask app, DB, or camera needed)
+# and checks it against both the old (buggy) and new (fixed) behavior.
+
+import sys
+import numpy
+
+
+def apply_mask_old(image_data, sqm_mask):
+    if sqm_mask is None:
+        numpy_mask = numpy.full(image_data.shape[:2], True, numpy.bool_)
+    else:
+        numpy_mask = sqm_mask == 0
+
+    return numpy.ma.masked_array(image_data[:, :, 0], mask=numpy_mask)
+
+
+def apply_mask_fixed(image_data, sqm_mask):
+    if sqm_mask is not None and sqm_mask.shape != image_data.shape[:2]:
+        sqm_mask = None
+
+    if sqm_mask is None:
+        numpy_mask = numpy.full(image_data.shape[:2], True, numpy.bool_)
+    else:
+        numpy_mask = sqm_mask == 0
+
+    return numpy.ma.masked_array(image_data[:, :, 0], mask=numpy_mask)
+
+
+def main():
+    # image is 1000x600 (matches a real capture)
+    image_data = numpy.zeros((600, 1000, 3), numpy.uint8)
+
+    # detection mask was saved at a different resolution (800x500) -- the
+    # exact class of mismatch reported in #2965 (data size 5649400 vs mask
+    # size 6528000, i.e. two arrays of different pixel counts)
+    mismatched_mask = numpy.zeros((500, 800), numpy.uint8)
+
+    old_crashed = False
+    try:
+        apply_mask_old(image_data, mismatched_mask)
+    except numpy.ma.core.MaskError:
+        old_crashed = True
+
+    if not old_crashed:
+        print('FAIL: expected old behavior to raise MaskError on shape mismatch')
+        sys.exit(1)
+
+    print('OK: confirmed the bug reproduces on the old code path (MaskError)')
+
+    try:
+        result = apply_mask_fixed(image_data, mismatched_mask)
+    except numpy.ma.core.MaskError:
+        print('FAIL: fixed code path still raises MaskError on shape mismatch')
+        sys.exit(1)
+
+    assert result.shape == image_data.shape[:2], 'result should fall back to full image shape'
+    print('OK: fixed code path falls back gracefully instead of crashing')
+
+    # sanity check: matching shapes still mask correctly (unaffected by the fix)
+    matching_mask = numpy.zeros((600, 1000), numpy.uint8)
+    matching_mask[0:100, 0:100] = 255
+    result = apply_mask_fixed(image_data, matching_mask)
+    assert result.mask[50, 50] == False and result.mask[500, 500] == True, \
+        'matching-shape mask should still be applied normally'
+    print('OK: matching-shape mask still applies normally (no regression)')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What

Fixes the `/indi-allsky/js/charts` endpoint crashing with `numpy.ma.core.MaskError` whenever the configured detection mask's dimensions don't match the current image.

Fixes #2965

## Why it matters

`getChartData()` (in `indi_allsky/flask/views.py`) builds a correctly-shaped default mask, then unconditionally overwrites it with the loaded detection mask (`numpy_mask = _sqm_mask == 0`) whenever `DETECT_MASK` is configured — with no check that the mask's dimensions actually match the current image. `_load_detection_mask()` rotates/flips/crops/scales the mask to track the *configured* image pipeline, but none of that corrects a mask file that was saved at a different base resolution to begin with (e.g. saved before a binning/resolution change, or exported at a slightly different size). When that happens, `numpy.ma.masked_array()` raises `MaskError: Mask and data not compatible`, and the charts page returns HTTP 500 on every single request until the mask is regenerated at the exact right size — with no indication in the UI of why.

## How

In `getChartData()`, after loading the detection mask, compare its shape to `image_data.shape[:2]`. If they don't match, log an error and fall back to the same default mask used when no detection mask is configured, instead of crashing. Behavior is unchanged when the shapes match (the normal case).

## Testing

This repo doesn't have a pytest suite for the Flask view layer, so I added `testing/mask_shape_test.py` following the existing convention in `testing/` (standalone scripts like `autogain_test.py`). It isolates just the masking logic — no Flask/DB/camera needed — and:
- confirms the old code path reproduces the exact `MaskError` from the issue on a shape mismatch
- confirms the new code path falls back gracefully instead of crashing
- confirms a *matching*-shape mask still applies normally (no regression)

```
$ python3 testing/mask_shape_test.py
OK: confirmed the bug reproduces on the old code path (MaskError)
OK: fixed code path falls back gracefully instead of crashing
OK: matching-shape mask still applies normally (no regression)
```

I don't have a live indi-allsky install with a mismatched mask file to test end-to-end, but the isolated logic is exactly what the traceback in #2965 goes through.
