### PR TITLE
Auto purge legacy Bootstrap caches and unregister stale ServiceWorkers

### DIFF
--- a/indi_allsky/flask/static/js/sw.js
+++ b/indi_allsky/flask/static/js/sw.js
@@ -45,6 +45,12 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  // Block legacy Bootstrap stylesheet requests to prevent CSS interference
+  if (event.request.url.includes('bootstrap') && !event.request.url.includes('datatables')) {
+    event.respondWith(new Response('', { status: 404, statusText: 'Bootstrap Removed' }));
+    return;
+  }
+
   const url = new URL(event.request.url);
 
   // Only handle static assets under /static/

--- a/indi_allsky/flask/templates/base.html
+++ b/indi_allsky/flask/templates/base.html
@@ -28,6 +28,22 @@
             
             var savedFontSize = localStorage.getItem('allsky-font-size') || '100%';
             document.documentElement.style.fontSize = savedFontSize;
+
+            // One-time automatic purge of legacy Bootstrap caches & ServiceWorker storage
+            var PURGE_KEY = 'indi_allsky_bootstrap_purged_v4';
+            if (!localStorage.getItem(PURGE_KEY)) {
+                localStorage.setItem(PURGE_KEY, 'true');
+                if ('caches' in window) {
+                    caches.keys().then(function(names) {
+                        names.forEach(function(n) { caches.delete(n); });
+                    });
+                }
+                if ('serviceWorker' in navigator) {
+                    navigator.serviceWorker.getRegistrations().then(function(regs) {
+                        regs.forEach(function(r) { r.unregister(); });
+                    });
+                }
+            }
         })();
 
         if ('serviceWorker' in navigator) {
@@ -43,7 +59,7 @@
         }
     </script>
 
-    <link href="{{ url_for('indi_allsky.static', filename='css/dist.css') }}" rel="stylesheet">
+    <link href="{{ url_for('indi_allsky.static', filename='css/dist.css') }}?v={{ release if release else 'v2026.08.1' }}" rel="stylesheet">
     <script src="{{ url_for('indi_allsky.static', filename='js/jquery-3.7.1.min.js') }}"></script>
 
     <style>


### PR DESCRIPTION
This should purge caches automatically, avoiding further user reports. 

@aaronwmorris 