### PR TITLE
Fix gamma LUT refresh across day/night changes

### DIFF
--- a/indi_allsky/processing.py
+++ b/indi_allsky/processing.py
@@ -140,6 +140,7 @@ class ImageProcessor(object):
         self._alpha_mask_dict = dict()  # index for every bin mode
 
         self._gamma_lut = None
+        self._gamma_lut_gamma = None
 
         self.focus_mode = self.config.get('FOCUS_MODE', False)
 
@@ -2544,9 +2545,10 @@ class ImageProcessor(object):
 
 
     def _apply_gamma_correction(self, gamma):
-        if isinstance(self._gamma_lut, type(None)):
+        if self._gamma_lut is None or self._gamma_lut_gamma != gamma:
             range_array = numpy.arange(0, 256, dtype=numpy.float32)
             self._gamma_lut = (((range_array / 255) ** (1.0 / gamma)) * 255).astype(numpy.uint8)
+            self._gamma_lut_gamma = gamma
 
 
         self.image = self._gamma_lut.take(self.image, mode='raise')


### PR DESCRIPTION
## Problem

Indi-allsky supports separate gamma settings for daytime and nighttime processing. However, the image processor generated the gamma lookup table only once and reused it indefinitely.

After a day/night transition, the configuration selected the correct gamma value, but processing could continue using the lookup table generated for the previous mode. The resulting behaviour depended on when the image worker was started or reloaded:

- A worker started at night could apply nighttime gamma to daytime images.
- A worker started during the day could apply daytime gamma to nighttime images.
- Images could therefore appear unexpectedly dark, bright, or overly contrasty after a mode transition.

## Fix

Store the gamma value associated with the cached lookup table. Rebuild the table whenever the selected gamma differs from the cached value.

The lookup table remains cached while gamma is unchanged, preserving the existing performance benefit.

## Validation

- Verified transitions from night gamma to day gamma and from day gamma to night gamma.
- Confirmed that each transition produces output using the newly selected gamma.
- Existing image-processing tests passed during development.

This is limited to gamma-cache invalidation and does not change configuration semantics or default values.