### PR TITLE
Fix: Normalize cardinal direction angles

### DIFF
--- a/indi_allsky/overlay/cardinalDirsLabel.py
+++ b/indi_allsky/overlay/cardinalDirsLabel.py
@@ -122,12 +122,7 @@ class IndiAllskyCardinalDirsLabel(object):
     def findDirectionCoordinate(self, image, dir_az):
         height, width = image.shape[:2]
 
-        if dir_az >= 360:
-            angle = dir_az - 360
-        elif dir_az < 0:
-            angle = dir_az + 360
-        else:
-            angle = dir_az
+        angle = dir_az % 360
 
         #logger.info('Finding direction angle for: %0.1f', angle)
 

--- a/indi_allsky/overlay/cardinalDirsLabel.py
+++ b/indi_allsky/overlay/cardinalDirsLabel.py
@@ -437,13 +437,7 @@ class IndiAllskyCardinalDirsLabel(object):
         height, width = image.shape[:2]
 
         dir_az -= self.panorama_rotate_angle
-
-        if dir_az >= 360:
-            angle = dir_az - 360
-        elif dir_az < 0:
-            angle = dir_az + 360
-        else:
-            angle = dir_az
+        angle = dir_az % 360
 
 
         x = int(angle / 360 * width)


### PR DESCRIPTION
## Problem

My `LENS_AZIMUTH` was saved as `360` after solving the image in Virtual Sky and saving the derived values; I did not enter this value manually.

When placing the south label, the existing normalization subtracts `360` only once, leaving an angle of exactly `360`. The coordinate branches only cover angles from `0` up to—but not including—`360`, so `d_x` and `d_y` remain undefined and the image worker crashes with:

```text
UnboundLocalError: cannot access local variable 'd_x' where it is not associated with a value
```

That cost me a full night of imaging.

## Fix

Replace the conditional angle wrapping with:

```python
angle = dir_az % 360
```

This treats `360°` as `0°` and also handles other out-of-range angles consistently.

## Testing

- Confirmed that azimuths `0` and `360` produce identical coordinates for all four cardinal labels.