### PR TITLE
ASI676MC calibration: replace marginal database groups with reserves

### DIFF
--- a/docs/asi676mc-frame-repair.md
+++ b/docs/asi676mc-frame-repair.md
@@ -293,12 +293,21 @@ camera identity remains authoritative and is rejected. Missing, corrupt,
 repaired, or incompatible files are skipped and summarized rather than
 silently shortening the search horizon.
 
-The 200-FITS and 2-GiB limits apply to the final purple/reference evidence set,
-not to catalog discovery. Only selected evidence enters the private session. A
-hard link keeps it stable without a second copy; where hard links are
-unavailable, the tool makes a private copy. It never uses a symbolic link whose
-target could change after selection. If a selected source disappears during
-staging, that file is skipped and the remaining evidence is still evaluated.
+The 200-FITS and 2.5-GiB limits apply to the final purple/reference evidence
+set, not to catalog discovery. Only selected evidence enters the private
+session. The saved-FITS path stages up to three groups beyond the requested
+count as validation reserves. If a group passes the main repair checks, but the
+complete repair is less than ten percent better than a simple colour-only
+correction, that inconclusive group is set aside, a reserve is promoted, and the
+fit is repeated. The complete repair must still outperform colour-only
+correction; otherwise calibration fails. The group count is reduced only when
+no reserve remains, and never below the seven-group minimum.
+
+A hard link keeps staged evidence stable without a second copy; where hard
+links are unavailable, the tool makes a private copy. It never uses a symbolic
+link whose target could change after selection. If a selected source disappears
+during staging, that file is skipped and the remaining evidence is still
+evaluated.
 
 Cancellation removes only private links, copies, or partial copies. Source
 FITS pixels and headers are never changed. The only durable discovery update
@@ -396,8 +405,8 @@ normal reference. The complete evidence must also provide:
 - sufficient unsaturated samples for each Bayer parity;
 - sufficient clipped-highlight evidence for both blend boundaries;
 - plausible gains with low between-pair median absolute deviation; and
-- a repair materially closer to adjacent normal evidence than both the
-  original and a gain-only, no-row-shift counterfactual.
+- a repair materially closer to nearby normal evidence than both the original
+  frame and a colour-only correction.
 
 Normal references that change too much across a two-sided triplet are rejected
 at the affected sample locations, limiting the influence of cloud, aircraft,

--- a/indi_allsky/asi676mc_calibration.py
+++ b/indi_allsky/asi676mc_calibration.py
@@ -61,9 +61,12 @@ QUEUED_STALE_SECONDS = 30 * 60
 RUNNING_STALE_SECONDS = 2 * 60 * 60
 DATABASE_GROUP_MIN = 7
 DATABASE_GROUP_MAX = 30
+DATABASE_RESERVE_GROUPS = 3
 DATABASE_CAPTURE_TIME_TOLERANCE = 1.0
 DATABASE_MAX_FILES = 200
-DATABASE_MAX_BYTES = MAX_SESSION_BYTES
+# Database staging can include the requested 30 three-file groups plus three
+# reserve groups. Browser uploads retain their existing 2-GiB limit.
+DATABASE_MAX_BYTES = 5 * 1024 * 1024 * 1024 // 2
 PROGRESS_MANIFEST_INTERVAL_FILES = 50
 POPULATION_PREVIEW_COUNT_PER_GROUP = 2
 POPULATION_PREVIEW_MAX_DIMENSION = 320
@@ -1275,7 +1278,7 @@ def discover_full_retention_database_evidence(
     selected_ids = set()
     selected_pairs = []
     selected_bytes = 0
-    selected_group_count = 0
+    staged_group_count = 0
     two_sided_group_count = 0
     selection_limit_blocked = False
 
@@ -1316,7 +1319,7 @@ def discover_full_retention_database_evidence(
             used_two_sided = False
         if not added:
             continue
-        selected_group_count += 1
+        staged_group_count += 1
         selected_pairs.append(engine.MatchedPair(
             bad=pair.bad,
             references=(
@@ -1334,18 +1337,18 @@ def discover_full_retention_database_evidence(
         ))
         if used_two_sided:
             two_sided_group_count += 1
-        if selected_group_count >= target_groups:
+        if staged_group_count >= target_groups + DATABASE_RESERVE_GROUPS:
             break
 
-    if selected_group_count < minimum:
+    if staged_group_count < minimum:
         limit_detail = ''
         if pairs and selection_limit_blocked:
-            limit_detail = ' within the 200-file/2-GiB evidence staging limit'
+            limit_detail = ' within the 200-file/2.5-GiB evidence staging limit'
         raise engine.CalibrationError(
             'the complete retained database archive was exhausted: {0} '
             'purple frames had compatible adjacent normal evidence{1}; at '
             'least {2} are required'.format(
-                selected_group_count,
+                staged_group_count,
                 limit_detail,
                 minimum,
             )
@@ -1390,7 +1393,13 @@ def discover_full_retention_database_evidence(
         'metadata_signature_count': metadata_signature_count,
         'legacy_fits_inspected_count': legacy_inspected_count,
         'detected_bad_count': detected_bad_count,
-        'selected_group_count': selected_group_count,
+        # selected_group_count remains the requested working-set count for
+        # retained result/report compatibility. The additional staged groups
+        # are reserves and are not fitted unless validation promotes them.
+        'selected_group_count': min(staged_group_count, target_groups),
+        'staged_group_count': staged_group_count,
+        'reserve_group_count': max(0, staged_group_count - target_groups),
+        'validation_exclusion_limit': DATABASE_RESERVE_GROUPS,
         'selected_marked_group_count': sum(
             _database_record_has_role(record, 'bad')
             for record in selected_records
@@ -1398,7 +1407,10 @@ def discover_full_retention_database_evidence(
         'two_sided_group_count': two_sided_group_count,
         'selection_limit_reached': (
             selection_limit_blocked
-            or selected_group_count < min(target_groups, len(pairs))
+            or staged_group_count < min(
+                target_groups + DATABASE_RESERVE_GROUPS,
+                len(pairs),
+            )
         ),
         'selection_limit_file_count': DATABASE_MAX_FILES,
         'selection_limit_bytes': DATABASE_MAX_BYTES,
@@ -1511,7 +1523,7 @@ def _stage_database_files_unlocked(
             if file_size <= 0 or file_size > MAX_FILE_BYTES:
                 staging_rejections['selected FITS size changed'] += 1
                 continue
-            if manifest['total_bytes'] + file_size > MAX_SESSION_BYTES:
+            if manifest['total_bytes'] + file_size > DATABASE_MAX_BYTES:
                 staging_rejections['selected FITS no longer fits staging limit'] += 1
                 continue
             destination = upload_dir.joinpath(
@@ -1933,6 +1945,17 @@ def _result_summary(payload):
             0,
         ),
     }
+    if 'requested_group_count' in quality:
+        quality_summary.update({
+            'requested_group_count': quality['requested_group_count'],
+            'used_group_count': quality['used_group_count'],
+            'examined_group_count': quality['examined_group_count'],
+            'excluded_marginal_group_count': quality[
+                'excluded_marginal_group_count'
+            ],
+            'replacement_group_count': quality['replacement_group_count'],
+            'marginal_exclusions': quality['marginal_exclusions'],
+        })
 
     return {
         'outcome': 'calibration',
@@ -2150,6 +2173,46 @@ def _result_warnings(
     the download points to its own detail section.
     """
     warnings = []
+    marginal_exclusions = list(quality.get('marginal_exclusions') or ())
+    if marginal_exclusions:
+        details = '; '.join(
+            '{0}: full repair was {1:.1%} better than colour-only correction; '
+            'at least {2:.1%} was required'.format(
+                item.get('name', 'Unknown FITS'),
+                float(item.get('improvement_vs_gain_only', 0.0)),
+                float(item.get('required_improvement', 0.0)),
+            )
+            for item in marginal_exclusions
+        )
+        replacement_count = int(quality.get('replacement_group_count', 0))
+        requested_count = quality.get('requested_group_count')
+        used_count = int(
+            quality.get('used_group_count', quality.get('matched_bad_count', 0))
+        )
+        if replacement_count:
+            outcome = '{0} reserve {1} replaced {2}.'.format(
+                replacement_count,
+                'group' if replacement_count == 1 else 'groups',
+                'it' if len(marginal_exclusions) == 1 else 'them',
+            )
+        elif requested_count is not None and used_count < int(requested_count):
+            outcome = (
+                'No additional suitable reserve was available, so calibration '
+                'used {0} of the requested {1} groups.'.format(
+                    used_count,
+                    int(requested_count),
+                )
+            )
+        else:
+            outcome = 'The remaining evidence was sufficient.'
+        warnings.append(
+            'Calibration set aside {0} because the result was inconclusive '
+            '({1}). {2}'.format(
+                _counted_item(len(marginal_exclusions), 'frame group'),
+                details,
+                outcome,
+            )
+        )
     bound_identity_count = int(
         quality.get('bound_session_camera_count', 0)
     )
@@ -2687,7 +2750,10 @@ def _friendly_threshold_analysis_failure(message_text):
 
 def _friendly_failure_message(message):
     """Translate calibration-engine failures into safe, actionable UI copy."""
-    message_text = str(message or '')
+    message_text = str(message or '').split(
+        '; private calibration input cleanup also failed:',
+        1,
+    )[0]
     lowered = message_text.lower()
     # Accept the current wording and older persisted task failures so an
     # interrupted session still receives the same useful explanation after an
@@ -2855,20 +2921,82 @@ def _friendly_failure_message(message):
         'too few stable samples to compare' in lowered
         or 'too few samples for the gain-only phase countercheck' in lowered
         or 'invalid gain-only phase countercheck' in lowered
+        or 'too few stable pixels to compare full repair' in lowered
+        or 'colour-only comparison could not be calculated' in lowered
     ):
         return (
             'Too few stable scene pixels remained for the final comparison. '
             'Use clearer daylight sequences with less cloud or movement.'
         )
-    if (
-        'repaired frame remains too different' in lowered
-        or 'repair does not materially improve agreement' in lowered
-        or 'evidence does not confirm the asi676mc one-row phase shift' in lowered
-    ):
+    if lowered.startswith('validation_group_count_after_exclusion:'):
+        detail = message_text.split(':', 1)[1].strip()
         return (
-            'The selected high-ratio frames do not behave like the ASI676MC '
-            'one-row purple-frame fault after repair. Check the evidence and '
-            'use untouched purple frames with close normal references.'
+            'Calibration could not continue: {0}. Collect more complete '
+            'normal/purple/normal groups.'
+        ).format(detail)
+    if lowered.startswith('validation_refit_signature_separation:'):
+        detail = message_text.split(':', 1)[1].strip()
+        return (
+            'Calibration could not safely use the remaining groups: {0}. '
+            'Collect clearer normal/purple/normal groups with steadier '
+            'lighting.'
+        ).format(detail)
+    validation_match = re.match(
+        r'validation_([a-z_]+): ([^:]+): (.+)',
+        message_text,
+        flags=re.IGNORECASE,
+    )
+    if validation_match:
+        failure_code, filename, measurement = validation_match.groups()
+        if failure_code == 'repaired_reference_error':
+            return (
+                'Could not verify {0}: {1}. The scene probably changed too '
+                'much within this frame group. Try another group with steadier '
+                'clouds, lighting, and exposure.'
+            ).format(filename, measurement)
+        if failure_code == 'original_improvement':
+            return (
+                'Could not verify {0}: {1}. The change is too small to prove '
+                'that repair worked for this group. Try another group with a '
+                'clear purple frame and stable nearby frames.'
+            ).format(filename, measurement)
+        if failure_code == 'phase_improvement':
+            return (
+                'Could not verify {0}: {1}. This group is inconclusive, so it '
+                'cannot safely be used to calculate repair values.'
+            ).format(filename, measurement)
+        if failure_code == 'runtime_repair':
+            return (
+                'Could not verify {0}: {1}. Try a larger collection with clear '
+                'purple frames and stable nearby normal frames.'
+            ).format(filename, measurement)
+        if failure_code == 'normal_rejected':
+            return (
+                'Could not verify {0}: {1}. The normal and purple examples are '
+                'not separated clearly enough to use safely.'
+            ).format(filename, measurement)
+        if failure_code == 'normal_modified':
+            return (
+                'Could not verify {0}: {1}. Repair must leave every normal '
+                'frame unchanged, so no values were produced.'
+            ).format(filename, measurement)
+    if 'repaired frame remains too different' in lowered:
+        return (
+            'A repaired purple frame was still too different from its nearby '
+            'normal frame. The scene probably changed too much within that '
+            'group; use closer, more stable captures.'
+        )
+    if 'repair does not materially improve agreement' in lowered:
+        return (
+            'Repair did not make one purple frame enough closer to its nearby '
+            'normal frame. Check that group for cloud, lighting, or exposure '
+            'changes.'
+        )
+    if 'evidence does not confirm the asi676mc one-row phase shift' in lowered:
+        return (
+            'The complete repair was not enough better than a simple '
+            'colour-only correction for one frame group. That group is '
+            'inconclusive; use another clear purple-frame group.'
         )
     if 'astropy could not be imported' in lowered:
         return (
@@ -2911,6 +3039,20 @@ def task_failure_message(message, limit=255):
     friendly = _friendly_failure_message(message)
     if len(friendly) <= limit:
         return friendly
+    validation_match = re.match(
+        r'validation_[a-z_]+: ([^:]+): (.+)',
+        str(message or ''),
+        flags=re.IGNORECASE,
+    )
+    if validation_match:
+        filename, measurement = validation_match.groups()
+        specific = 'Could not verify {0}: {1}.'.format(
+            filename,
+            measurement,
+        )
+        if len(specific) <= limit:
+            return specific
+        return specific[:limit - 1].rstrip() + '…'
     fallback = (
         'Calibration could not use the selected evidence. Open Tools > '
         'Fix ASI676MC purple frames for the complete reasons and next steps.'
@@ -3367,6 +3509,85 @@ def format_threshold_suggestion_report(payload, manifest):
     return '\n'.join(lines).rstrip() + '\n'
 
 
+def format_failure_report(message, manifest):
+    """Build a browser-safe downloadable record for a failed calibration."""
+    source_details = manifest.get('source') or {}
+    cleanup_complete = bool(manifest.get('sources_deleted_utc'))
+    lines = [
+        'indi-allsky ASI676MC purple-frame calibration report',
+        '=' * 54,
+        'Status: Failed',
+        'Generated: {0}'.format(_format_report_timestamp(
+            manifest.get('completed_utc') or _utc_now_text()
+        )),
+    ]
+    _append_report_section(lines, 'Why calibration stopped')
+    _append_report_paragraph(lines, _friendly_failure_message(message))
+    _append_report_paragraph(
+        lines,
+        'No calibration values were produced and no indi-allsky settings were '
+        'changed.',
+    )
+
+    _append_report_section(lines, 'Evidence source')
+    if source_details.get('kind') == 'database':
+        lines.extend((
+            'Method: Saved FITS search in Tools > Fix ASI676MC purple frames',
+            'Camera: {0}'.format(source_details.get('camera_name', 'Unknown')),
+            'Purple-frame groups requested: {0}'.format(
+                source_details.get('requested_group_count', 0)
+            ),
+            'Purple-frame groups staged: {0}'.format(
+                source_details.get(
+                    'staged_group_count',
+                    source_details.get('selected_group_count', 0),
+                )
+            ),
+            'Reserve groups staged: {0}'.format(
+                source_details.get('reserve_group_count', 0)
+            ),
+            'FITS staged: {0}'.format(len(manifest.get('files', ()))),
+        ))
+        if cleanup_complete:
+            cleanup_text = (
+                'Only temporary staging links or copies were removed. The '
+                'database-owned saved FITS were not changed.'
+            )
+        else:
+            cleanup_text = (
+                'Some temporary staging links or copies could not be removed '
+                'immediately. They will be removed automatically later. The '
+                'database-owned saved FITS were not changed.'
+            )
+        _append_report_paragraph(lines, cleanup_text)
+    elif source_details.get('kind') == 'upload':
+        lines.append('Method: Manual FITS upload')
+        lines.append('FITS uploaded: {0}'.format(len(manifest.get('files', ()))))
+        if cleanup_complete:
+            cleanup_text = (
+                'The private uploaded copies were removed. The original files '
+                'on the user\'s computer were not changed.'
+            )
+        else:
+            cleanup_text = (
+                'Some private uploaded copies could not be removed '
+                'immediately. They will be removed automatically later. The '
+                'original files on the user\'s computer were not changed.'
+            )
+        _append_report_paragraph(lines, cleanup_text)
+    else:
+        lines.append('Method: Tools > Fix ASI676MC purple frames')
+
+    _append_report_section(lines, 'About this report')
+    _append_report_paragraph(
+        lines,
+        'This report records the same reason shown on the calibration page and '
+        'in the background task result. It is not a configuration file and '
+        'cannot be imported.',
+    )
+    return '\n'.join(lines).rstrip() + '\n'
+
+
 def format_integrated_report(payload, manifest):
     """Build the report downloaded from the authenticated calibration page.
 
@@ -3516,6 +3737,18 @@ def format_integrated_report(payload, manifest):
             'Target purple-frame groups: {0}'.format(
                 source_details.get('requested_group_count', 0)
             ),
+            *(
+                (
+                    'Purple-frame groups staged: {0}'.format(
+                        source_details['staged_group_count']
+                    ),
+                    'Reserve groups staged: {0}'.format(
+                        source_details.get('reserve_group_count', 0)
+                    ),
+                )
+                if 'staged_group_count' in source_details
+                else ()
+            ),
             'Selection path: {0}'.format(
                 _database_selection_text(
                     source_details.get('selection_mode')
@@ -3624,7 +3857,16 @@ def format_integrated_report(payload, manifest):
         )
 
     _append_report_section(lines, 'Evidence used')
-    evidence_lines = (
+    evidence_lines = []
+    if source_kind == 'database' and 'requested_group_count' in quality:
+        evidence_lines.extend((
+            ('Purple-frame groups requested', quality['requested_group_count']),
+            ('Purple-frame groups used', quality['used_group_count']),
+            ('Reserve groups promoted', quality['replacement_group_count']),
+            ('Inconclusive groups set aside',
+             quality['excluded_marginal_group_count']),
+        ))
+    evidence_lines.extend((
         ('Purple frames with a normal reference', quality['pair_count']),
         ('Purple frames skipped without a reference',
          quality.get('unmatched_bad_count', 0)),
@@ -3641,7 +3883,7 @@ def format_integrated_report(payload, manifest):
          quality.get('validated_normal_frames', 0)),
         ('FITS files unreadable or unusable',
          quality.get('rejected_file_count', 0)),
-    )
+    ))
     evidence_width = max(len(label) for label, _value in evidence_lines)
     lines.extend(
         '{0:<{1}}  {2}'.format(label + ':', evidence_width + 1, value)
@@ -3679,6 +3921,33 @@ def format_integrated_report(payload, manifest):
     lines.append('Maximum matching separation: {0:g} seconds'.format(
         float(manifest.get('max_pair_seconds', 0))
     ))
+
+    marginal_exclusions = quality.get('marginal_exclusions') or ()
+    if marginal_exclusions:
+        _append_report_section(lines, 'Frame groups set aside')
+        _append_report_paragraph(
+            lines,
+            'Each group below was repaired successfully and became much closer '
+            'to its nearby normal frame. However, the tool could not prove '
+            'that the complete repair was enough better than correcting the '
+            'colour alone. The group was therefore set aside. For the three '
+            'difference values, lower is better.',
+        )
+        for item in marginal_exclusions:
+            _append_report_paragraph(
+                lines,
+                '{0}: before repair {1:.3%}; colour-only correction {2:.3%}; '
+                'full repair {3:.3%}; extra improvement from full repair '
+                '{4:.3%}; minimum required {5:.3%}.'.format(
+                    item.get('name', 'Unknown FITS'),
+                    float(item.get('original_error', 0.0)),
+                    float(item.get('gain_only_error', 0.0)),
+                    float(item.get('repaired_error', 0.0)),
+                    float(item.get('improvement_vs_gain_only', 0.0)),
+                    float(item.get('required_improvement', 0.0)),
+                ),
+                prefix='- ',
+            )
 
     _append_report_section(lines, 'Result notes')
     report_notes = _result_warnings(
@@ -4007,6 +4276,15 @@ def run_calibration_session(
                     14,
                 ),
                 trusted_camera_name=trusted_camera_name,
+                target_group_count=(
+                    source_details.get('requested_group_count')
+                    if source_details.get('validation_exclusion_limit')
+                    else None
+                ),
+                marginal_exclusion_limit=source_details.get(
+                    'validation_exclusion_limit',
+                    0,
+                ),
             )
 
         with _file_lock(_session_lock_path(session_dir)):
@@ -4157,6 +4435,21 @@ def run_calibration_session(
                 manifest['error'] = (
                     '{0}; private calibration input cleanup also failed: {1}'
                 ).format(error, cleanup_error)
+            if not cancelled:
+                try:
+                    session_dir.joinpath(
+                        'asi676mc_calibration_report.txt'
+                    ).write_text(
+                        format_failure_report(manifest['error'], manifest),
+                        encoding='utf-8',
+                    )
+                except OSError:
+                    # The primary failure and cleanup state remain available
+                    # through status/task output even if the optional text
+                    # report cannot be persisted.
+                    logger.exception(
+                        'Unable to write ASI676MC calibration failure report'
+                    )
             manifest.pop('worker_token', None)
             _write_manifest(session_dir, manifest)
         raise
@@ -4254,7 +4547,7 @@ def get_completed_result(session_id, owner, storage_root=None):
 def _get_report_details(session_id, owner, storage_root=None):
     """Resolve an owned completed report and its retained session metadata."""
     session_dir, manifest = get_session(session_id, owner, storage_root)
-    if manifest.get('status') != 'success':
+    if manifest.get('status') not in ('success', 'failed'):
         raise CalibrationSessionError('the calibration report is not ready')
     report_path = session_dir.joinpath('asi676mc_calibration_report.txt')
     if not report_path.is_file():

--- a/indi_allsky/asi676mc_calibration_engine.py
+++ b/indi_allsky/asi676mc_calibration_engine.py
@@ -343,6 +343,7 @@ class FrameRecord:
     x_bayer_offset: int = 0
     y_bayer_offset: int = 0
     camera_identity_source: str = 'fits_header'
+    source_name: str = None
 
     @property
     def is_bad(self):
@@ -467,6 +468,7 @@ def inspect_fits(path, settings, trusted_camera_name=None):
         camera_name=camera_name,
         signature=signature,
         camera_identity_source=camera_identity_source,
+        source_name=path.name,
     )
 
 
@@ -531,6 +533,7 @@ def inspect_fits_metadata(path, metadata, settings, verify_header=False):
         camera_name=camera_name,
         signature=signature,
         camera_identity_source='database_metadata',
+        source_name=str(metadata.get('original_name') or path.name),
     )
 
 
@@ -608,6 +611,12 @@ def scan_folder(
                             record,
                             camera_identity_source='bound_database',
                         )
+                    record = replace(
+                        record,
+                        source_name=str(
+                            metadata.get('original_name') or path.name
+                        ),
+                    )
             else:
                 record = inspect_fits(
                     path,
@@ -1736,11 +1745,14 @@ def _best_gain_only_planes(observed_planes, reference_planes, stable_masks):
         )
         if not numpy.any(mask):
             raise CalibrationError(
-                'too few samples for the gain-only phase countercheck'
+                'too few stable pixels to compare full repair with '
+                'colour-only correction'
             )
         ratio = float(numpy.median(observed_float[mask] / reference[mask]))
         if not numpy.isfinite(ratio) or ratio <= 0.0:
-            raise CalibrationError('invalid gain-only phase countercheck')
+            raise CalibrationError(
+                'the colour-only comparison could not be calculated'
+            )
         corrected.append(observed_float / ratio)
     return tuple(corrected)
 
@@ -1749,11 +1761,13 @@ def validate_calibrated_frames(
     pairs,
     settings,
     checkpoint_callback=None,
+    collect_phase_failures=False,
 ):
     """Apply final rounded settings to every pair without writing outputs."""
     repaired_count = 0
     normal_count = 0
     similarity_checks = []
+    phase_failures = []
     unique_normal = {
         reference.path: reference
         for pair in pairs
@@ -1784,7 +1798,10 @@ def validate_calibrated_frames(
         result = asi676mc.repair_if_needed(data, settings)
         if not result['repaired'] or result['validation_failed']:
             raise CalibrationError(
-                f'calibrated repair validation failed for {pair.bad.path}'
+                'validation_runtime_repair: {0}: the calculated repair values '
+                'did not produce a valid repaired frame'.format(
+                    pair.bad.source_name or pair.bad.path.name
+                )
             )
         repaired_planes = _sample_array_planes(
             data,
@@ -1812,27 +1829,66 @@ def validate_calibrated_frames(
             stable_masks,
         )
         improvement = CALIBRATION_OPTIONS['MIN_REFERENCE_ERROR_IMPROVEMENT']
-        if repaired_error > CALIBRATION_OPTIONS['MAX_REPAIRED_REFERENCE_ERROR']:
-            raise CalibrationError(
-                'repaired frame remains too different from its normal '
-                'reference: {0}'.format(pair.bad.path)
-            )
-        if repaired_error > original_error * (1.0 - improvement):
-            raise CalibrationError(
-                'repair does not materially improve agreement with the normal '
-                'reference: {0}'.format(pair.bad.path)
-            )
-        if repaired_error > unshifted_error * (1.0 - improvement):
-            raise CalibrationError(
-                'evidence does not confirm the ASI676MC one-row phase shift: '
-                '{0}'.format(pair.bad.path)
-            )
-        similarity_checks.append({
-            'name': pair.bad.path.name,
+        original_improvement = (
+            1.0 - repaired_error / max(original_error, 1.0e-12)
+        )
+        phase_improvement = (
+            1.0 - repaired_error / max(unshifted_error, 1.0e-12)
+        )
+        check = {
+            'name': pair.bad.source_name or pair.bad.path.name,
             'original_error': original_error,
             'gain_only_error': unshifted_error,
             'repaired_error': repaired_error,
-        })
+            'improvement_vs_original': original_improvement,
+            'improvement_vs_gain_only': phase_improvement,
+            'required_improvement': improvement,
+        }
+        if repaired_error > CALIBRATION_OPTIONS['MAX_REPAIRED_REFERENCE_ERROR']:
+            raise CalibrationError(
+                'validation_repaired_reference_error: {0}: the repaired frame '
+                'differs from its nearby normal frame by {1:.1%}; the maximum '
+                'allowed is {2:.1%}'.format(
+                    check['name'],
+                    repaired_error,
+                    CALIBRATION_OPTIONS['MAX_REPAIRED_REFERENCE_ERROR'],
+                )
+            )
+        if repaired_error > original_error * (1.0 - improvement):
+            raise CalibrationError(
+                'validation_original_improvement: {0}: full repair made the '
+                'purple frame {1:.1%} closer to its nearby normal frame; at '
+                'least {2:.1%} is required'.format(
+                    check['name'],
+                    original_improvement,
+                    improvement,
+                )
+            )
+        if repaired_error > unshifted_error * (1.0 - improvement):
+            check['failure_code'] = 'phase_improvement'
+            check['reason'] = (
+                'full repair matched the nearby normal frame {0:.1%} better '
+                'than colour-only correction; at least {1:.1%} is required'.format(
+                    phase_improvement,
+                    improvement,
+                )
+            )
+            # A marginal miss still shows positive evidence for row shifting.
+            # If row shifting is no better than gain-only correction, preserve
+            # the hard failure used to reject ordinary colour populations.
+            if collect_phase_failures and phase_improvement > 0.0:
+                phase_failures.append({
+                    'pair': pair,
+                    'check': check,
+                })
+                continue
+            raise CalibrationError(
+                'validation_phase_improvement: {0}: {1}'.format(
+                    check['name'],
+                    check['reason'],
+                )
+            )
+        similarity_checks.append(check)
         repaired_count += 1
 
     # A normal frame must take the fast no-op path.  The array comparison also
@@ -1845,14 +1901,20 @@ def validate_calibrated_frames(
         result = asi676mc.repair_if_needed(data, settings)
         if result['repaired'] or result['signature_before']['is_bad']:
             raise CalibrationError(
-                f'calibrated detector rejects normal frame {record.path}'
+                'validation_normal_rejected: {0}: the calculated detection '
+                'settings mistook a normal frame for a purple frame'.format(
+                    record.source_name or record.path.name
+                )
             )
         if not numpy.array_equal(data, original):
             raise CalibrationError(
-                f'normal-frame validation mutated {record.path}'
+                'validation_normal_modified: {0}: the repair changed pixels '
+                'in a normal frame'.format(
+                    record.source_name or record.path.name
+                )
             )
         normal_count += 1
-    return repaired_count, normal_count, similarity_checks
+    return repaired_count, normal_count, similarity_checks, phase_failures
 
 
 def calibration_payload(
@@ -1971,6 +2033,8 @@ def calibrate_folder(
     progressive=False,
     initial_scan_count=14,
     trusted_camera_name=None,
+    target_group_count=None,
+    marginal_exclusion_limit=0,
 ):
     """Run complete calibration for one staged evidence directory.
 
@@ -2075,117 +2139,222 @@ def calibrate_folder(
     )
 
     pairs, unmatched = match_pairs(records, max_pair_seconds)
-    evidence = validate_evidence(
-        records,
-        pairs,
-        unmatched,
-        allow_unmatched=allow_unmatched,
-    )
-    ranges = signature_ranges(records)
-    try:
-        validate_signature_separation(ranges, config)
-    except CalibrationError as separation_error:
-        # The detector can find enough frames through its three-way AND rule
-        # even when one individual threshold lies outside that metric's safe
-        # gap. Present the same review-and-rerun result used for an outright
-        # detector miss instead of fitting repair constants against a weak
-        # detector configuration.
+    database_reserve_mode = target_group_count is not None
+    marginal_exclusion_limit = max(0, int(marginal_exclusion_limit or 0))
+    if not database_reserve_mode:
+        requested_group_count = len(pairs)
+    else:
+        requested_group_count = max(0, int(target_group_count))
+    working_group_count = min(requested_group_count, len(pairs))
+    active_pairs = list(pairs[:working_group_count])
+    reserve_pairs = list(pairs[working_group_count:])
+    excluded_checks = []
+    replacement_count = 0
+
+    def records_for_pairs(candidate_pairs):
+        """Return the unique bad/reference records in staged pair order."""
+        selected = []
+        selected_paths = set()
+        for candidate_pair in candidate_pairs:
+            for record in (candidate_pair.bad,) + candidate_pair.references:
+                if record.path in selected_paths:
+                    continue
+                selected.append(record)
+                selected_paths.add(record.path)
+        return selected
+
+    while True:
+        # Preserve the original upload and progressive-search behavior: their
+        # evidence and detector ranges include the complete inspected
+        # collection, including unmatched frames. Only the saved-FITS reserve
+        # path intentionally fits a requested subset of the staged groups.
+        active_records = (
+            records_for_pairs(active_pairs)
+            if database_reserve_mode
+            else records
+        )
+        evidence = validate_evidence(
+            active_records,
+            active_pairs,
+            [] if database_reserve_mode else unmatched,
+            allow_unmatched=allow_unmatched,
+        )
+        ranges = signature_ranges(active_records)
         try:
-            suggestions = build_detection_threshold_suggestions(
+            validate_signature_separation(ranges, config)
+        except CalibrationError as separation_error:
+            # The detector can find enough frames through its three-way AND
+            # rule even when one threshold lies outside that metric's safe
+            # gap. This preliminary result is only valid before any final
+            # validation exclusion has changed the working evidence set.
+            if excluded_checks:
+                raise CalibrationError(
+                    'validation_refit_signature_separation: after setting '
+                    'aside an inconclusive group, the remaining groups no '
+                    'longer clearly separate normal and purple frames'
+                ) from separation_error
+            try:
+                suggestions = build_detection_threshold_suggestions(
+                    ranges,
+                    config,
+                )
+            except CalibrationError:
+                raise separation_error
+            payload = threshold_suggestion_payload(
+                active_records,
+                evidence,
                 ranges,
-                config,
+                suggestions,
+                detected_bad_count=bad_count,
             )
-        except CalibrationError:
-            raise separation_error
-        payload = threshold_suggestion_payload(
-            records,
+            payload['quality']['rejected_file_count'] = len(rejected)
+            payload['rejected_files'] = [
+                {
+                    'name': Path(path).name,
+                    'reason': str(reason),
+                }
+                for path, reason in rejected
+            ]
+            print(
+                'Detector populations are clear, but one or more configured '
+                'thresholds lie outside their safe gaps; returning threshold '
+                'suggestions only.'
+            )
+            return finish_scan_payload(payload)
+        threshold_assessment = assess_detection_threshold_margins(
+            ranges,
+            config,
+        )
+        print(
+            'Matched {0} purple frames to {1} distinct normal frames '
+            '({2:.2f}:1)'.format(
+                evidence['pair_count'],
+                evidence['unique_good_count'],
+                evidence['good_bad_ratio'],
+            )
+        )
+
+        if progress_callback:
+            progress_callback({
+                'phase': 'fitting',
+                'processed_files': scanned_file_count,
+                'total_files': available_file_count,
+                'detected_bad_count': bad_count,
+            })
+        samples = collect_pair_samples(
+            active_pairs,
+            checkpoint_callback=checkpoint_callback,
+        )
+        gains_detail = estimate_gains(samples)
+        gain_values = {
+            name: result['value']
+            for name, result in gains_detail.items()
+        }
+        saturation_threshold, plateau = estimate_saturation_threshold(samples)
+        print('Fitting clipped-highlight boundaries...')
+        highlight = estimate_highlight_ratios(
+            samples,
+            gain_values,
+            saturation_threshold,
+            checkpoint_callback=checkpoint_callback,
+        )
+        payload = calibration_payload(
+            config,
             evidence,
             ranges,
-            suggestions,
-            detected_bad_count=bad_count,
+            gains_detail,
+            saturation_threshold,
+            plateau,
+            highlight,
+            rejected,
         )
-        payload['quality']['rejected_file_count'] = len(rejected)
-        payload['rejected_files'] = [
-            {
-                'name': Path(path).name,
-                'reason': str(reason),
-            }
-            for path, reason in rejected
-        ]
-        print(
-            'Detector populations are clear, but one or more configured '
-            'thresholds lie outside their safe gaps; returning threshold '
-            'suggestions only.'
+        payload['threshold_assessment'] = threshold_assessment
+        print('Validating calibrated settings against every matched frame...')
+        if progress_callback:
+            progress_callback({
+                'phase': 'validating',
+                'processed_files': scanned_file_count,
+                'total_files': available_file_count,
+                'detected_bad_count': bad_count,
+            })
+        validation_settings = dict(config)
+        validation_settings.update(payload['derived_settings'])
+        (
+            repaired_count,
+            normal_validation_count,
+            similarity_checks,
+            phase_failures,
+        ) = validate_calibrated_frames(
+            active_pairs,
+            validation_settings,
+            checkpoint_callback=checkpoint_callback,
+            collect_phase_failures=bool(marginal_exclusion_limit),
         )
-        return finish_scan_payload(payload)
-    threshold_assessment = assess_detection_threshold_margins(ranges, config)
-    print(
-        'Matched {0} purple frames to {1} distinct normal frames '
-        '({2:.2f}:1)'.format(
-            evidence['pair_count'],
-            evidence['unique_good_count'],
-            evidence['good_bad_ratio'],
-        )
-    )
+        if not phase_failures:
+            break
 
-    if progress_callback:
-        progress_callback({
-            'phase': 'fitting',
-            'processed_files': scanned_file_count,
-            'total_files': available_file_count,
-            'detected_bad_count': bad_count,
-        })
-    samples = collect_pair_samples(
-        pairs,
-        checkpoint_callback=checkpoint_callback,
-    )
-    gains_detail = estimate_gains(samples)
-    gain_values = {
-        name: result['value']
-        for name, result in gains_detail.items()
-    }
-    saturation_threshold, plateau = estimate_saturation_threshold(samples)
-    print('Fitting clipped-highlight boundaries...')
-    highlight = estimate_highlight_ratios(
-        samples,
-        gain_values,
-        saturation_threshold,
-        checkpoint_callback=checkpoint_callback,
-    )
-    payload = calibration_payload(
-        config,
-        evidence,
-        ranges,
-        gains_detail,
-        saturation_threshold,
-        plateau,
-        highlight,
-        rejected,
-    )
-    payload['threshold_assessment'] = threshold_assessment
-    print('Validating calibrated settings against every matched frame...')
-    if progress_callback:
-        progress_callback({
-            'phase': 'validating',
-            'processed_files': scanned_file_count,
-            'total_files': available_file_count,
-            'detected_bad_count': bad_count,
-        })
-    validation_settings = dict(config)
-    validation_settings.update(payload['derived_settings'])
-    (
-        repaired_count,
-        normal_validation_count,
-        similarity_checks,
-    ) = validate_calibrated_frames(
-        pairs,
-        validation_settings,
-        checkpoint_callback=checkpoint_callback,
-    )
+        if (
+            len(excluded_checks) + len(phase_failures)
+            > marginal_exclusion_limit
+        ):
+            first_check = phase_failures[0]['check']
+            raise CalibrationError(
+                'validation_phase_improvement: {0}: {1}; more than {2} '
+                'inconclusive groups would need to be set aside'.format(
+                    first_check['name'],
+                    first_check['reason'],
+                    marginal_exclusion_limit,
+                )
+            )
+
+        failed_pair_ids = {
+            id(item['pair']) for item in phase_failures
+        }
+        active_pairs = [
+            pair for pair in active_pairs
+            if id(pair) not in failed_pair_ids
+        ]
+        for failure in phase_failures:
+            excluded_checks.append(dict(failure['check']))
+        promoted_count = min(len(phase_failures), len(reserve_pairs))
+        if promoted_count:
+            active_pairs.extend(reserve_pairs[:promoted_count])
+            del reserve_pairs[:promoted_count]
+            replacement_count += promoted_count
+        if len(active_pairs) < minimum:
+            raise CalibrationError(
+                'validation_group_count_after_exclusion: only {0} groups '
+                'remain after setting aside {1} inconclusive {2}; at least {3} '
+                'are required'.format(
+                    len(active_pairs),
+                    len(excluded_checks),
+                    'group' if len(excluded_checks) == 1 else 'groups',
+                    minimum,
+                )
+            )
+        print(
+            'Set aside {0} inconclusive {1}; promoted {2} reserve {3} and '
+            'refitting.'.format(
+                len(phase_failures),
+                'group' if len(phase_failures) == 1 else 'groups',
+                promoted_count,
+                'group' if promoted_count == 1 else 'groups',
+            )
+        )
+
     payload['quality']['validated_bad_repairs'] = repaired_count
     payload['quality']['validated_normal_frames'] = normal_validation_count
     payload['quality']['reference_similarity_checks'] = similarity_checks
     payload['quality']['worst_repaired_reference_error'] = max(
         check['repaired_error'] for check in similarity_checks
     )
+    if database_reserve_mode:
+        payload['quality'].update({
+            'requested_group_count': requested_group_count,
+            'used_group_count': len(active_pairs),
+            'examined_group_count': working_group_count + replacement_count,
+            'excluded_marginal_group_count': len(excluded_checks),
+            'replacement_group_count': replacement_count,
+            'marginal_exclusions': excluded_checks,
+        })
     return finish_scan_payload(payload)

--- a/indi_allsky/flask/templates/asi676mc_calibration.html
+++ b/indi_allsky/flask/templates/asi676mc_calibration.html
@@ -479,6 +479,14 @@
             <button id="calibration-failure-reset" type="button" class="tw:btn tw:btn-neutral" style="display: none;">
                 Try again
             </button>
+            <a
+                id="calibration-failure-report-download"
+                class="tw:btn tw:btn-info tw:no-underline"
+                href="#"
+                style="display: none;"
+            >
+                Download details
+            </a>
         </div>
     </div>
 </div>
@@ -822,7 +830,7 @@ function showCalibrationProgressView() {
     }
 }
 
-function showCalibrationFailure(sessionId, message) {
+function showCalibrationFailure(sessionId, message, reportAvailable) {
     // A worker failure is a completed, discardable session. Keep its message
     // beside the final progress state so a long setup form cannot hide the
     // reason below the fold, and offer the same deliberate reset as results.
@@ -843,6 +851,9 @@ function showCalibrationFailure(sessionId, message) {
         .removeClass('progress-bar-animated')
         .addClass('calibration-progress-error');
     $('#calibration-progress-error').text(message).show();
+    $('#calibration-failure-report-download')
+        .attr('href', calibrationUrl(calibrationReportUrlTemplate, sessionId))
+        .toggle(Boolean(reportAvailable));
     $('#cancel-calibration').hide().prop('disabled', false).text('Cancel calibration');
     $('#calibration-failure-reset').show().prop('disabled', false);
 }
@@ -884,6 +895,7 @@ function resetCalibrationInterface() {
     $('#start-database-calibration').prop('disabled', false);
     $('#cancel-calibration').hide().prop('disabled', false).text('Cancel calibration');
     $('#calibration-failure-reset').hide().prop('disabled', false);
+    $('#calibration-failure-report-download').hide().attr('href', '#');
     $('#calibration-progress-error').hide().empty();
     $('#calibration-files').val('');
     $('#calibration-values, #calibration-threshold-values, #calibration-threshold-advisory-values, #calibration-population-evidence, #calibration-population-previews, #calibration-quality, #calibration-warning-list').empty();
@@ -1700,7 +1712,8 @@ async function pollCalibration(sessionId) {
                 sessionId,
                 'Calibration failed. '
                 + failureReason
-                + settingsUnchangedMessage + ' ' + cleanupMessage
+                + settingsUnchangedMessage + ' ' + cleanupMessage,
+                status.report_available
             );
             return;
         }

--- a/testing/image/test_asi676mc_calibration_engine.py
+++ b/testing/image/test_asi676mc_calibration_engine.py
@@ -329,6 +329,64 @@ class TestAsi676mcCalibrationEngine(unittest.TestCase):
             1.26,
         )
 
+    def test_upload_analysis_keeps_unmatched_frames_in_detector_evidence(self):
+        records = self._threshold_population_records()
+        for record in records:
+            record.signature['is_bad'] = record.path.name.startswith(
+                'likely_purple_'
+            )
+        unmatched_bad = self._threshold_record(
+            'unmatched_bad.fit',
+            100000,
+            0.001,
+            (2.20, 1.70, 2.20),
+        )
+        unmatched_bad.signature['is_bad'] = True
+        records.append(unmatched_bad)
+        preliminary = {
+            'outcome': 'threshold_suggestion',
+            'quality': {},
+            'threshold_suggestions': [],
+            'signature_ranges': {},
+        }
+
+        with mock.patch.object(
+            calibration_engine,
+            'scan_folder',
+            return_value=(records, []),
+        ), mock.patch.object(
+            calibration_engine,
+            'validate_evidence',
+            wraps=calibration_engine.validate_evidence,
+        ) as validate_evidence, mock.patch.object(
+            calibration_engine,
+            'signature_ranges',
+            wraps=calibration_engine.signature_ranges,
+        ) as signature_ranges, mock.patch.object(
+            calibration_engine,
+            'validate_signature_separation',
+            side_effect=calibration_engine.CalibrationError('test stop'),
+        ), mock.patch.object(
+            calibration_engine,
+            'build_detection_threshold_suggestions',
+            return_value=[],
+        ), mock.patch.object(
+            calibration_engine,
+            'threshold_suggestion_payload',
+            return_value=preliminary,
+        ):
+            calibration_engine.calibrate_folder(
+                Path('unused'),
+                allow_unmatched=True,
+            )
+
+        self.assertEqual(validate_evidence.call_args.args[0], records)
+        self.assertEqual(signature_ranges.call_args.args[0], records)
+        self.assertIn(
+            unmatched_bad,
+            validate_evidence.call_args.args[2],
+        )
+
     def test_all_rejected_failure_preserves_grouped_reasons_without_paths(self):
         rejected = [
             (Path('private_one.fit'), 'missing explicit BAYERPAT=RGGB metadata'),
@@ -814,6 +872,221 @@ class TestAsi676mcCalibrationEngine(unittest.TestCase):
                 delta=0.02,
             )
 
+    def test_database_validation_promotes_reserve_then_reduces_without_one(self):
+        def evidence_records(group_count):
+            records = []
+            for index in range(group_count):
+                exposure = 0.001 if index < 4 else 0.002
+                base_time = 1000 + index * 300
+                for role, offset, ratios, is_bad in (
+                    ('before', 0, (0.90, 0.70, 1.10), False),
+                    ('bad', 20, (2.20, 1.70, 2.20), True),
+                    ('after', 40, (0.92, 0.72, 1.12), False),
+                ):
+                    record = self._threshold_record(
+                        '{0:02d}_{1}.fit'.format(index, role),
+                        base_time + offset,
+                        exposure,
+                        ratios,
+                    )
+                    record.signature['is_bad'] = is_bad
+                    records.append(record)
+            return records
+
+        gains = {
+            name: {'value': 1.0, 'mad': 0.0, 'sample_count': 1000}
+            for name in ('GAIN_R', 'GAIN_G1', 'GAIN_G2', 'GAIN_B')
+        }
+        highlight = {
+            'start_ratio': 0.55,
+            'end_ratio': 0.75,
+            'pair_count': 8,
+            'sample_count': 1000,
+            'score': 0.01,
+            'default_score': 0.01,
+            'raw_best_score': 0.01,
+            'raw_best_start_ratio': 0.55,
+            'raw_best_end_ratio': 0.75,
+            'preferred_default': True,
+            'runner_up_score': 0.011,
+        }
+
+        for available_groups, expected_replacements, expected_used in (
+            (10, 1, 8),
+            (8, 0, 7),
+        ):
+            with self.subTest(available_groups=available_groups):
+                records = evidence_records(available_groups)
+                validation_calls = []
+
+                def validate(candidate_pairs, _settings, **_kwargs):
+                    validation_calls.append(list(candidate_pairs))
+                    checks = [{
+                        'name': pair.bad.path.name,
+                        'original_error': 0.49,
+                        'gain_only_error': 0.086,
+                        'repaired_error': 0.070,
+                        'improvement_vs_original': 0.85,
+                        'improvement_vs_gain_only': 0.18,
+                        'required_improvement': 0.10,
+                    } for pair in candidate_pairs]
+                    if len(validation_calls) == 1:
+                        failed_pair = candidate_pairs[-1]
+                        failure_check = {
+                            **checks[-1],
+                            'name': failed_pair.bad.path.name,
+                            'gain_only_error': 0.086,
+                            'repaired_error': 0.0814,
+                            'improvement_vs_gain_only': 0.053,
+                            'failure_code': 'phase_improvement',
+                            'reason': (
+                                'full repair matched the nearby normal frame '
+                                '5.3% better than colour-only correction; at '
+                                'least 10.0% is required'
+                            ),
+                        }
+                        return (
+                            len(candidate_pairs) - 1,
+                            len(candidate_pairs) * 2,
+                            checks[:-1],
+                            [{'pair': failed_pair, 'check': failure_check}],
+                        )
+                    return (
+                        len(candidate_pairs),
+                        len(candidate_pairs) * 2,
+                        checks,
+                        [],
+                    )
+
+                with mock.patch.object(
+                    calibration_engine,
+                    'scan_folder',
+                    return_value=(records, []),
+                ), mock.patch.object(
+                    calibration_engine,
+                    'collect_pair_samples',
+                    return_value=[],
+                ), mock.patch.object(
+                    calibration_engine,
+                    'estimate_gains',
+                    return_value=gains,
+                ), mock.patch.object(
+                    calibration_engine,
+                    'estimate_saturation_threshold',
+                    return_value=(65000, 65534),
+                ), mock.patch.object(
+                    calibration_engine,
+                    'estimate_highlight_ratios',
+                    return_value=highlight,
+                ), mock.patch.object(
+                    calibration_engine,
+                    'validate_calibrated_frames',
+                    side_effect=validate,
+                ):
+                    payload = calibration_engine.calibrate_folder(
+                        Path('unused'),
+                        target_group_count=8,
+                        marginal_exclusion_limit=3,
+                    )
+
+                quality = payload['quality']
+                self.assertEqual(len(validation_calls), 2)
+                self.assertEqual(quality['requested_group_count'], 8)
+                self.assertEqual(quality['used_group_count'], expected_used)
+                self.assertEqual(
+                    quality['replacement_group_count'],
+                    expected_replacements,
+                )
+                self.assertEqual(quality['excluded_marginal_group_count'], 1)
+                self.assertEqual(
+                    quality['marginal_exclusions'][0][
+                        'improvement_vs_gain_only'
+                    ],
+                    0.053,
+                )
+                self.assertNotIn(
+                    validation_calls[0][-1],
+                    validation_calls[1],
+                )
+                if expected_replacements:
+                    self.assertIn(
+                        '08_bad.fit',
+                        [pair.bad.path.name for pair in validation_calls[1]],
+                    )
+
+    def test_only_phase_improvement_failure_is_collectable(self):
+        bad = self._threshold_record(
+            'marginal_bad.fit',
+            1000,
+            0.001,
+            (2.2, 1.7, 2.2),
+        )
+        bad.signature['is_bad'] = True
+        pair = calibration_engine.MatchedPair(bad=bad, references=())
+        placeholder_planes = tuple(numpy.ones((8, 8)) for _index in range(4))
+        placeholder_masks = tuple(
+            numpy.ones((8, 8), dtype=bool) for _index in range(4)
+        )
+
+        def validate(reference_errors):
+            with mock.patch.object(
+                calibration_engine,
+                '_read_fits',
+                return_value=(
+                    numpy.zeros((16, 16), dtype=numpy.uint16),
+                    {},
+                    0,
+                ),
+            ), mock.patch.object(
+                calibration_engine,
+                '_reference_planes',
+                return_value=(placeholder_planes, placeholder_masks),
+            ), mock.patch.object(
+                calibration_engine,
+                '_sample_array_planes',
+                return_value=placeholder_planes,
+            ), mock.patch.object(
+                calibration_engine,
+                '_best_gain_only_planes',
+                return_value=placeholder_planes,
+            ), mock.patch.object(
+                calibration_engine,
+                '_reference_error',
+                side_effect=reference_errors,
+            ), mock.patch.object(
+                calibration_engine.asi676mc,
+                'repair_if_needed',
+                return_value={'repaired': True, 'validation_failed': False},
+            ):
+                return calibration_engine.validate_calibrated_frames(
+                    [pair],
+                    calibration_engine.DEFAULT_SETTINGS,
+                    collect_phase_failures=True,
+                )
+
+        repaired, normal, checks, failures = validate(
+            (0.493104, 0.081437, 0.085976)
+        )
+
+        self.assertEqual((repaired, normal, checks), (0, 0, []))
+        self.assertEqual(len(failures), 1)
+        self.assertAlmostEqual(
+            failures[0]['check']['improvement_vs_gain_only'],
+            1.0 - 0.081437 / 0.085976,
+        )
+
+        with self.assertRaisesRegex(
+            calibration_engine.CalibrationError,
+            'validation_original_improvement',
+        ):
+            validate((0.100, 0.095, 0.200))
+
+        with self.assertRaisesRegex(
+            calibration_engine.CalibrationError,
+            'validation_phase_improvement',
+        ):
+            validate((0.490, 0.090, 0.086))
+
     def test_two_normal_colour_regimes_do_not_pass_as_phase_shift_failure(self):
         normal = self._normal_frame()
         higher_ratio = normal.copy()
@@ -867,7 +1140,7 @@ class TestAsi676mcCalibrationEngine(unittest.TestCase):
             ):
                 with self.assertRaisesRegex(
                     calibration_engine.CalibrationError,
-                    'one-row phase shift',
+                    'validation_phase_improvement',
                 ):
                     calibration_engine.calibrate_folder(folder)
 

--- a/testing/image/test_asi676mc_web_calibration.py
+++ b/testing/image/test_asi676mc_web_calibration.py
@@ -317,6 +317,37 @@ class TestAsi676mcWebCalibration(unittest.TestCase):
                 settings=calibration_engine.DEFAULT_SETTINGS,
             )
 
+    def test_full_retention_discovery_stages_three_reserve_groups(self):
+        records = []
+        bad_ids = set(range(2, 30, 3))
+        for record_id in range(1, 31):
+            record = self._database_record(record_id, record_id * 20)
+            if record_id >= 28:
+                record['exposure'] = 0.002
+            ratio = 3.0 if record_id in bad_ids else 1.0
+            record['signature'] = {
+                'purple_ratio': ratio,
+                'red_side_ratio': ratio,
+                'blue_side_ratio': ratio,
+            }
+            records.append(record)
+
+        selected, summary = (
+            asi676mc_calibration.discover_full_retention_database_evidence(
+                records,
+                bad_frames=[],
+                target_groups=7,
+                max_pair_seconds=30.0,
+                settings=calibration_engine.DEFAULT_SETTINGS,
+            )
+        )
+
+        self.assertEqual(summary['selected_group_count'], 7)
+        self.assertEqual(summary['staged_group_count'], 10)
+        self.assertEqual(summary['reserve_group_count'], 3)
+        self.assertEqual(summary['validation_exclusion_limit'], 3)
+        self.assertEqual(len(selected), 30)
+
     def test_full_retention_discovery_finds_unmarked_bad_frames_5000_files_back(self):
         records = []
         bad_ids = {50, 150, 250, 350, 450, 550, 650}
@@ -609,7 +640,7 @@ class TestAsi676mcWebCalibration(unittest.TestCase):
         ):
             with self.assertRaisesRegex(
                 calibration_engine.CalibrationError,
-                'within the 200-file/2-GiB evidence staging limit',
+                'within the 200-file/2.5-GiB evidence staging limit',
             ):
                 asi676mc_calibration.discover_full_retention_database_evidence(
                     records,
@@ -1009,6 +1040,14 @@ class TestAsi676mcWebCalibration(unittest.TestCase):
                 'full_retention_detector_groups',
             )
             self.assertTrue(calibrate_folder.call_args.kwargs['metadata_by_name'])
+            self.assertEqual(
+                calibrate_folder.call_args.kwargs['target_group_count'],
+                7,
+            )
+            self.assertEqual(
+                calibrate_folder.call_args.kwargs['marginal_exclusion_limit'],
+                3,
+            )
             completed = asi676mc_calibration._read_manifest(
                 root.joinpath(manifest['session_id'])
             )
@@ -1124,6 +1163,70 @@ class TestAsi676mcWebCalibration(unittest.TestCase):
         self.assertNotIn('operator', report.lower())
         self.assertNotIn('They repaired', report)
 
+    def test_success_report_records_marginal_exclusion_and_replacement(self):
+        payload = self._successful_payload()
+        payload['quality'].update({
+            'requested_group_count': 20,
+            'used_group_count': 20,
+            'examined_group_count': 21,
+            'excluded_marginal_group_count': 1,
+            'replacement_group_count': 1,
+            'marginal_exclusions': [{
+                'name': 'marginal_bad.fit',
+                'original_error': 0.493104,
+                'gain_only_error': 0.085976,
+                'repaired_error': 0.081437,
+                'improvement_vs_original': 0.83485,
+                'improvement_vs_gain_only': 0.05279,
+                'required_improvement': 0.10,
+                'reason': (
+                    'full repair matched the nearby normal frame 5.3% better '
+                    'than colour-only correction; at least 10.0% is required'
+                ),
+            }],
+        })
+        manifest = {
+            'settings': dict(calibration_engine.DEFAULT_SETTINGS),
+            'max_pair_seconds': 90.0,
+            'files': [],
+            'source': {
+                'kind': 'database',
+                'camera_name': 'ASI676MC',
+                'requested_group_count': 20,
+                'selected_group_count': 20,
+                'staged_group_count': 23,
+                'reserve_group_count': 3,
+                'selection_mode': 'full_retention_detector_groups',
+            },
+        }
+
+        report = asi676mc_calibration.format_integrated_report(
+            payload,
+            manifest,
+        )
+        result = asi676mc_calibration._result_summary(payload)
+        warning = ' '.join(result['warnings'])
+        flat_report = ' '.join(report.split())
+
+        self.assertIn('Purple-frame groups staged: 23', report)
+        self.assertIn('Reserve groups staged: 3', report)
+        self.assertIn('Reserve groups promoted:', report)
+        self.assertIn('Frame groups set aside', report)
+        self.assertIn('marginal_bad.fit', report)
+        self.assertIn('extra improvement from full repair 5.279%', flat_report)
+        self.assertIn('minimum required 10.000%', flat_report)
+        self.assertIn('marginal_bad.fit', warning)
+        self.assertIn('5.3%', warning)
+        self.assertIn('1 reserve group replaced it', warning)
+        for technical_term in (
+            'gain-only',
+            'row-shift',
+            'repaired-reference',
+            'adjacent-reference',
+        ):
+            self.assertNotIn(technical_term, report.lower())
+            self.assertNotIn(technical_term, warning.lower())
+
     def test_report_timestamp_uses_explicit_local_timezone(self):
         local_timezone = timezone(timedelta(hours=2), name='CEST')
         with mock.patch.object(
@@ -1210,6 +1313,89 @@ class TestAsi676mcWebCalibration(unittest.TestCase):
             download_name,
             '2026-08-02_14-34-56_asi676mc_calibration_report.txt',
         )
+
+    def test_failed_validation_has_same_specific_downloadable_report(self):
+        engine_message = (
+            'validation_phase_improvement: marginal_bad.fit: full repair '
+            'matched the nearby normal frame 5.3% better than colour-only '
+            'correction; at least 10.0% is required'
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            session_id = asi676mc_calibration.create_session(
+                'alice', root
+            )['session_id']
+            for index in range(14):
+                asi676mc_calibration.store_upload(
+                    session_id,
+                    'alice',
+                    self._fits_upload('failure_{0:02d}.fit'.format(index)),
+                    root,
+                )
+            asi676mc_calibration.mark_queued(
+                session_id,
+                'alice',
+                task_id=55,
+                max_pair_seconds=90.0,
+                settings=calibration_engine.DEFAULT_SETTINGS,
+                source_details={'kind': 'upload', 'selected_file_count': 14},
+                storage_root=root,
+            )
+            with mock.patch.object(
+                calibration_engine,
+                'calibrate_folder',
+                side_effect=calibration_engine.CalibrationError(engine_message),
+            ):
+                with self.assertRaises(calibration_engine.CalibrationError):
+                    asi676mc_calibration.run_calibration_session(
+                        session_id,
+                        root,
+                    )
+
+            status = asi676mc_calibration.get_status(
+                session_id,
+                'alice',
+                root,
+            )
+            self.assertEqual(status['status'], 'failed')
+            self.assertTrue(status['report_available'])
+            self.assertIn('marginal_bad.fit', status['error'])
+            self.assertIn('5.3%', status['error'])
+            self.assertIn('10.0%', status['error'])
+            self.assertIn('colour-only correction', status['error'])
+            self.assertIn('inconclusive', status['error'])
+            report_path = asi676mc_calibration.get_report_path(
+                session_id,
+                'alice',
+                root,
+            )
+            report = report_path.read_text(encoding='utf-8')
+            self.assertIn('Status: Failed', report)
+            self.assertIn('marginal_bad.fit', report)
+            self.assertIn('5.3%', report)
+            self.assertIn('10.0%', report)
+            self.assertIn('colour-only correction', report)
+            self.assertIn('inconclusive', report)
+            self.assertIn('No calibration values were produced', report)
+            self.assertIn('private uploaded copies were removed', report)
+
+            cleanup_pending = asi676mc_calibration.format_failure_report(
+                engine_message,
+                {
+                    'source': {'kind': 'upload'},
+                    'files': [{}] * 14,
+                    'sources_deleted_utc': None,
+                },
+            )
+            cleanup_pending = ' '.join(cleanup_pending.split())
+            self.assertIn(
+                'could not be removed immediately',
+                cleanup_pending,
+            )
+            self.assertIn(
+                'will be removed automatically later',
+                cleanup_pending,
+            )
 
     def test_population_preview_candidates_are_bounded_and_representative(self):
         evidence = []
@@ -1369,6 +1555,8 @@ class TestAsi676mcWebCalibration(unittest.TestCase):
         self.assertIn('Current value is already safe', report)
         self.assertIn('Post-repair standard FITS excluded: 2', report)
         self.assertNotIn('Recommended calibration values', report)
+        self.assertNotIn('Purple-frame groups staged', report)
+        self.assertNotIn('Reserve groups staged', report)
         self.assertNotIn('operator', report.lower())
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -1449,6 +1637,9 @@ class TestAsi676mcWebCalibration(unittest.TestCase):
         self.assertIn('Method: Manual FITS upload', report)
         self.assertIn('FITS selected: 21', report)
         self.assertIn('private uploaded copies were removed', report)
+        self.assertNotIn('Purple-frame groups requested', report)
+        self.assertNotIn('Reserve groups promoted', report)
+        self.assertNotIn('Inconclusive groups set aside', report)
         self.assertIn(
             '21 uploaded FITS files did not name the camera model',
             report,
@@ -1556,9 +1747,20 @@ class TestAsi676mcWebCalibration(unittest.TestCase):
             call_kwargs = calibrate_folder.call_args.kwargs
             self.assertTrue(call_kwargs['allow_unmatched'])
             self.assertFalse(call_kwargs['recursive'])
+            self.assertIsNone(call_kwargs['target_group_count'])
+            self.assertEqual(call_kwargs['marginal_exclusion_limit'], 0)
             self.assertNotIn('report_title', call_kwargs)
             self.assertEqual(result['quality']['matched_bad_count'], 7)
             self.assertEqual(len(result['values']), 7)
+            for reserve_key in (
+                'requested_group_count',
+                'staged_group_count',
+                'used_group_count',
+                'replacement_group_count',
+                'excluded_marginal_group_count',
+                'marginal_exclusions',
+            ):
+                self.assertNotIn(reserve_key, result['quality'])
             self.assertFalse(root.joinpath(session_id, 'uploads').exists())
             self.assertEqual(success_saw_deleted_sources, [True])
 
@@ -1788,8 +1990,46 @@ class TestAsi676mcWebCalibration(unittest.TestCase):
             'evidence does not confirm the ASI676MC one-row phase shift: '
             'C:\\private\\purple.fit'
         )
-        self.assertIn('do not behave like', wrong_failure_type)
+        self.assertIn('complete repair was not enough better', wrong_failure_type)
         self.assertNotIn('purple.fit', wrong_failure_type)
+
+        specific_failures = (
+            (
+                'validation_repaired_reference_error: bad.fit: '
+                'the repaired frame differs from its nearby normal frame by '
+                '36.0%; the maximum allowed is 35.0%',
+                ('bad.fit', '36.0%', '35.0%', 'scene probably changed'),
+            ),
+            (
+                'validation_original_improvement: bad.fit: full repair made '
+                'the purple frame 7.0% closer to its nearby normal frame; at '
+                'least 10.0% is required',
+                ('bad.fit', '7.0%', '10.0%', 'too small to prove'),
+            ),
+            (
+                'validation_phase_improvement: bad.fit: full repair matched '
+                'the nearby normal frame 5.3% better than colour-only '
+                'correction; at least 10.0% is required',
+                ('bad.fit', '5.3%', '10.0%', 'inconclusive'),
+            ),
+        )
+        for raw_message, expected_parts in specific_failures:
+            with self.subTest(raw_message=raw_message):
+                friendly = asi676mc_calibration._friendly_failure_message(
+                    raw_message
+                )
+                for expected in expected_parts:
+                    self.assertIn(expected, friendly)
+                self.assertNotIn('gain-only', friendly.lower())
+                self.assertNotIn('row-shift', friendly.lower())
+                self.assertNotIn('repaired-reference', friendly.lower())
+        phase_task_message = asi676mc_calibration.task_failure_message(
+            specific_failures[-1][0]
+        )
+        self.assertIn('bad.fit', phase_task_message)
+        self.assertIn('5.3%', phase_task_message)
+        self.assertIn('10.0%', phase_task_message)
+        self.assertIn('colour-only correction', phase_task_message)
 
         safety_failure = asi676mc_calibration._friendly_failure_message(
             'normal-frame validation mutated C:\\private\\normal.fit'
@@ -2174,7 +2414,7 @@ class TestAsi676mcWebCalibration(unittest.TestCase):
         self.assertIn('function showCalibrationSetupView()', template)
         self.assertIn('function showCalibrationProgressView()', template)
         self.assertIn(
-            'function showCalibrationFailure(sessionId, message)',
+            'function showCalibrationFailure(sessionId, message, reportAvailable)',
             template,
         )
         self.assertIn(
@@ -2326,6 +2566,14 @@ class TestAsi676mcWebCalibration(unittest.TestCase):
         )
         self.assertEqual(asi676mc_calibration.MAX_FILE_COUNT, 80)
         self.assertEqual(asi676mc_calibration.DATABASE_MAX_FILES, 200)
+        self.assertEqual(
+            asi676mc_calibration.DATABASE_MAX_BYTES,
+            5 * 1024 * 1024 * 1024 // 2,
+        )
+        self.assertEqual(
+            asi676mc_calibration.MAX_SESSION_BYTES,
+            2 * 1024 * 1024 * 1024,
+        )
         self.assertIn('def _can_save_standard_configuration()', views_source)
         self.assertIn('def _asi676mc_feature_enabled()', views_source)
         self.assertIn('if not _asi676mc_feature_enabled():', views_source)


### PR DESCRIPTION
### Problem

A database calibration could fail because one otherwise usable frame group narrowly missed the final comparison against colour-only correction. Basically a bad frame was successfully recognized and repaired, but the result, while clearly repaired visually, didn't show quite enough improvement to pass the strict validation rules. This caused the entire calibration to fail even when the remaining groups clearly passed validation and the required minimum of seven groups was reached or more eligible groups were available in the database. It could occur with any requested group count or combination of frames. The failure messages were unclear and several reasons for a failed calibration resulted in exactly the same text.

### Changes

- Stage up to three additional database frame groups as reserves.
- Set aside up to three narrowly inconclusive groups, promote available reserves, and repeat the fit.
- Reduce the final group count only when no reserves remain; the existing minimum of seven still applies.
- Keep all other validation failures as hard failures.
- Raise the database staging limit from 2 GiB to 2.5 GiB to accommodate reserves.
- Provide clearer, failure-specific messages on the page, in task results, logs, and downloadable reports.
- Allow downloading a report for failed calibrations.

Manual uploads, progressive database searches, calibration limits, settings application, and the existing page layout remain unchanged.

### Testing

133 tests and 204 parameterized subtests pass.