### PR TITLE
Fix Process FITS detection when processing changes image dimensions

### DIFF
--- a/indi_allsky/flask/templates/imageprocessing.html
+++ b/indi_allsky/flask/templates/imageprocessing.html
@@ -107,7 +107,7 @@ var fullscreen = false;  //initial state
                 <!-- Process error hint -->
                 <div id="process-error-msg" class="tw:flex tw:items-center tw:gap-1.5 tw:text-error tw:text-xs tw:font-semibold" style="display: none;">
                     <i class="tw:icon-[lucide--triangle-alert] tw:w-3.5 tw:h-3.5"></i>
-                    Fix the errors below and try again
+                    <span id="process-error-text">Fix the errors below and try again</span>
                 </div>
 
                 <!-- Feedback Messages -->
@@ -1296,6 +1296,7 @@ field_names.concat(checkbox_field_names).forEach(item => {
 function submitProcessingData() {
     // Restore button and hide error hint
     $('#process-btn').attr('class', 'tw:btn tw:btn-primary tw:btn-sm tw:h-11 tw:px-6');
+    $('#process-error-text').text('Fix the errors below and try again');
     $('#process-error-msg').hide();
     $('#processing_time').text('Processing...');
     $("#loader_processing").show();
@@ -1387,6 +1388,7 @@ function submitProcessingData() {
                     if ($btn.length) $btn[0].click();
                 }
             } catch(e) {
+                $('#process-error-text').text('Processing failed (HTTP ' + rdata.status + '). Check the Webapp log for details.');
                 console.error('Error parsing validation response', e);
             }
             $("#loader_processing").hide();

--- a/indi_allsky/flask/views.py
+++ b/indi_allsky/flask/views.py
@@ -9626,6 +9626,52 @@ class JsonImageProcessingView(JsonView):
         )
 
 
+        run_detection = bool(request.json.get('RUN_DETECTION', False))
+        stars_count = 0
+        detections_count = 0
+        detect_method = p_config.get('DETECT_STARS_METHOD', 'template')
+
+        def runDetection():
+            nonlocal stars_count, detections_count, detect_method
+
+            if not run_detection:
+                return
+
+            from ..stars import IndiAllSkyStars
+            from ..detectLines import IndiAllskyDetectLines
+
+            # tuned per-run, the saved config is not modified
+            detect_method = str(request.json.get('DETECT_STARS_METHOD', detect_method))
+            p_config['DETECT_STARS_METHOD']         = detect_method
+            p_config['DETECT_STARS_THOLD']          = float(request.json['DETECT_STARS_THOLD'])
+            p_config['DETECT_STARS_SEP_THOLD']      = float(request.json['DETECT_STARS_SEP_THOLD'])
+            p_config['DETECT_STARS_SEP_MAX_RADIUS'] = int(request.json['DETECT_STARS_SEP_MAX_RADIUS'])
+            p_config['DETECT_METEORS_THOLD']        = int(request.json['DETECT_METEORS_THOLD'])
+            p_config['DETECT_DRAW']                 = True
+
+            detect_mask_path = Path(p_config.get('DETECT_MASK', ''))
+            if detect_mask_path.is_file():
+                indi_mask = cv2.imread(str(detect_mask_path), cv2.IMREAD_GRAYSCALE)
+            else:
+                indi_mask = None
+
+            mask_dict = {binning: indi_mask}
+
+            # lines before stars, as in the capture pipeline - star markers would
+            # otherwise be detected as lines
+            lines_detect_o = IndiAllskyDetectLines(p_config, mask=mask_dict)
+            detections_count = len(lines_detect_o.detectLines(image_processor.image, binning))
+
+            if detect_method == 'sep':
+                # imported on demand: sep is unavailable on some legacy platforms
+                from ..starsSep import IndiAllSkyStarsSEP
+                stars_detect_o = IndiAllSkyStarsSEP(p_config, mask=mask_dict)
+            else:
+                stars_detect_o = IndiAllSkyStars(p_config, mask=mask_dict)
+
+            stars_count = len(stars_detect_o.detectObjects(image_processor.image, binning))
+
+
         processing_start = time.time()
 
 
@@ -9652,6 +9698,8 @@ class JsonImageProcessingView(JsonView):
             image_processor.stack()  # populates self.image
 
             image_processor.convert_16bit_to_8bit()
+
+            runDetection()
 
 
             # rotation
@@ -9748,6 +9796,8 @@ class JsonImageProcessingView(JsonView):
 
             image_processor.convert_16bit_to_8bit()
 
+            runDetection()
+
 
             if p_config.get('IMAGE_ROTATE'):
                 image_processor.rotate_90()
@@ -9833,50 +9883,6 @@ class JsonImageProcessingView(JsonView):
 
 
                 image_processor.image = pano_data
-
-
-        # Interactive detection: draw stars/meteors on the preview image
-        run_detection = bool(request.json.get('RUN_DETECTION', False))
-        stars_count = 0
-        detections_count = 0
-
-        detect_method = p_config.get('DETECT_STARS_METHOD', 'template')
-
-        if run_detection:
-            from ..stars import IndiAllSkyStars
-            from ..detectLines import IndiAllskyDetectLines
-
-            # tuned per-run, the saved config is not modified
-            detect_method = str(request.json.get('DETECT_STARS_METHOD', detect_method))
-            p_config['DETECT_STARS_METHOD']         = detect_method
-            p_config['DETECT_STARS_THOLD']          = float(request.json['DETECT_STARS_THOLD'])
-            p_config['DETECT_STARS_SEP_THOLD']      = float(request.json['DETECT_STARS_SEP_THOLD'])
-            p_config['DETECT_STARS_SEP_MAX_RADIUS'] = int(request.json['DETECT_STARS_SEP_MAX_RADIUS'])
-            p_config['DETECT_METEORS_THOLD']        = int(request.json['DETECT_METEORS_THOLD'])
-            p_config['DETECT_DRAW']                 = True
-
-            detect_mask_path = Path(p_config.get('DETECT_MASK', ''))
-            if detect_mask_path.is_file():
-                indi_mask = cv2.imread(str(detect_mask_path), cv2.IMREAD_GRAYSCALE)
-            else:
-                indi_mask = None
-
-            mask_dict = {binning: indi_mask}
-
-            # lines before stars, as in the capture pipeline - star markers would
-            # otherwise be detected as lines
-            lines_detect_o = IndiAllskyDetectLines(p_config, mask=mask_dict)
-            detections_count = len(lines_detect_o.detectLines(image_processor.image, binning))
-
-            if detect_method == 'sep':
-                # imported on demand: sep is unavailable on some legacy platforms
-                from ..starsSep import IndiAllSkyStarsSEP
-                stars_detect_o = IndiAllSkyStarsSEP(p_config, mask=mask_dict)
-            else:
-                stars_detect_o = IndiAllSkyStars(p_config, mask=mask_dict)
-
-            stars_count = len(stars_detect_o.detectObjects(image_processor.image, binning))
-
 
         processing_elapsed_s = time.time() - processing_start
         app.logger.info('Image processed in %0.4f s', processing_elapsed_s)

--- a/indi_allsky/flask/views.py
+++ b/indi_allsky/flask/views.py
@@ -9626,6 +9626,10 @@ class JsonImageProcessingView(JsonView):
         )
 
 
+        processing_start = time.time()
+
+
+        # Interactive detection: draw stars/meteors on the preview image
         run_detection = bool(request.json.get('RUN_DETECTION', False))
         stars_count = 0
         detections_count = 0
@@ -9670,9 +9674,6 @@ class JsonImageProcessingView(JsonView):
                 stars_detect_o = IndiAllSkyStars(p_config, mask=mask_dict)
 
             stars_count = len(stars_detect_o.detectObjects(image_processor.image, binning))
-
-
-        processing_start = time.time()
 
 
         message_list = list()


### PR DESCRIPTION
## Summary

This fixes the detection-tuning controls under **Tools → Process FITS** when cropping or borders change the preview image dimensions.

Interactive star and meteor detection now runs immediately after conversion to 8-bit and before rotation, cropping, and borders. This matches the ordering used by the normal capture pipeline and keeps the image dimensions aligned with the configured detection mask.

The existing detection methods and settings remain unchanged. Any detected markers are carried through the remaining preview transformations normally.

The error banner also now displays the HTTP status and directs the user to the Webapp log when an unexpected non-validation error occurs, instead of incorrectly telling them to fix nonexistent form errors.

Fixes #3095