### PR TITLE
Add selectable bitrate and file-size estimates to mini timelapses

### DIFF
--- a/indi_allsky/flask/forms.py
+++ b/indi_allsky/flask/forms.py
@@ -9684,11 +9684,31 @@ class IndiAllskyMiniTimelapseForm(FlaskForm):
         ('60', '60 FPS'),
     )
 
+    BITRATE_SELECT_choices = {
+        'Compact files': (
+            ('2500k', '2.5 Mbps — about 19 MB/min'),
+            ('5000k', '5 Mbps — about 38 MB/min'),
+        ),
+        'Balanced': (
+            ('10000k', '10 Mbps — about 75 MB/min'),
+            ('15000k', '15 Mbps — about 113 MB/min'),
+        ),
+        'High quality': (
+            ('20000k', '20 Mbps — about 150 MB/min'),
+            ('30000k', '30 Mbps — about 225 MB/min'),
+        ),
+        'Very high quality / large files': (
+            ('40000k', '40 Mbps — about 300 MB/min'),
+            ('50000k', '50 Mbps — about 375 MB/min'),
+        ),
+    }
+
     CAMERA_ID                        = HiddenField('Camera ID', validators=[DataRequired()])
     IMAGE_ID                         = HiddenField('Image ID', validators=[DataRequired()])
     PRE_SECONDS_SELECT               = SelectField('Before selected image', choices=SECONDS_choices, validators=[DataRequired()])
     POST_SECONDS_SELECT              = SelectField('After selected image', choices=SECONDS_choices, validators=[DataRequired()])
     FRAMERATE_SELECT                 = SelectField('Speed', choices=FRAMERATE_SELECT_choices, validators=[DataRequired()])
+    BITRATE_SELECT                   = SelectField('Quality', choices=BITRATE_SELECT_choices, validators=[DataRequired()])
     NOTE                             = StringField('Description', validators=[DataRequired()])
 
 

--- a/indi_allsky/flask/forms.py
+++ b/indi_allsky/flask/forms.py
@@ -9689,7 +9689,7 @@ class IndiAllskyMiniTimelapseForm(FlaskForm):
             ('2500k', '2.5 Mbps — about 19 MB/min'),
             ('5000k', '5 Mbps — about 38 MB/min'),
         ),
-        'Balanced': (
+        'Medium files': (
             ('10000k', '10 Mbps — about 75 MB/min'),
             ('15000k', '15 Mbps — about 113 MB/min'),
         ),

--- a/indi_allsky/flask/forms.py
+++ b/indi_allsky/flask/forms.py
@@ -9693,11 +9693,11 @@ class IndiAllskyMiniTimelapseForm(FlaskForm):
             ('10000k', '10 Mbps — about 75 MB/min'),
             ('15000k', '15 Mbps — about 113 MB/min'),
         ),
-        'High quality': (
+        'Large files': (
             ('20000k', '20 Mbps — about 150 MB/min'),
             ('30000k', '30 Mbps — about 225 MB/min'),
         ),
-        'Very high quality / large files': (
+        'Very large files': (
             ('40000k', '40 Mbps — about 300 MB/min'),
             ('50000k', '50 Mbps — about 375 MB/min'),
         ),
@@ -9708,7 +9708,7 @@ class IndiAllskyMiniTimelapseForm(FlaskForm):
     PRE_SECONDS_SELECT               = SelectField('Before selected image', choices=SECONDS_choices, validators=[DataRequired()])
     POST_SECONDS_SELECT              = SelectField('After selected image', choices=SECONDS_choices, validators=[DataRequired()])
     FRAMERATE_SELECT                 = SelectField('Speed', choices=FRAMERATE_SELECT_choices, validators=[DataRequired()])
-    BITRATE_SELECT                   = SelectField('Quality', choices=BITRATE_SELECT_choices, validators=[DataRequired()])
+    BITRATE_SELECT                   = SelectField('Bitrate/File size', choices=BITRATE_SELECT_choices, validators=[DataRequired()])
     NOTE                             = StringField('Description', validators=[DataRequired()])
 
 

--- a/indi_allsky/flask/templates/mini_generate.html
+++ b/indi_allsky/flask/templates/mini_generate.html
@@ -1391,7 +1391,7 @@ $( document ).ready(function() {
                     </div>
                 </div>
                 <div class="tw:text-xs tw:text-base-content/60">
-                    Before and after set the time range around the selected image. Speed controls playback; quality controls bitrate and file size.
+                    Before and after set the time range around the selected image. Speed controls playback; bitrate controls file size.
                 </div>
 
                 <div id="panorama-controls" class="tw:flex tw:flex-col tw:gap-3 tw:pt-2 tw:border-t tw:border-base-300" style="display: none;">

--- a/indi_allsky/flask/templates/mini_generate.html
+++ b/indi_allsky/flask/templates/mini_generate.html
@@ -1156,13 +1156,30 @@ function generationFrameRange() {
 
 function updateVideoLength() {
     var image_count = generationFrameCount();
-    var duration_seconds = Math.round((image_count / parseFloat(framerate)) * 10) / 10;
+    var exact_duration_seconds = image_count / parseFloat(framerate);
+    var duration_seconds = Math.round(exact_duration_seconds * 10) / 10;
     var frame_range = generationFrameRange();
     var length_text = image_count + ' frames';
     if(frame_range) {
         length_text += ' · ' + frame_range;
     }
-    $('#video_length').text(length_text + ' · about ' + duration_seconds + ' seconds');
+
+    var bitrate_match = String($('#BITRATE_SELECT').val() || '').match(/^(\d+)([km])$/);
+    var size_text = '';
+    if(bitrate_match) {
+        var bitrate_kbps = parseInt(bitrate_match[1]);
+        if(bitrate_match[2] === 'm') {
+            bitrate_kbps *= 1000;
+        }
+        var estimated_megabytes = bitrate_kbps * exact_duration_seconds / 8000;
+        if(estimated_megabytes >= 1000) {
+            size_text = ' · estimated ' + (estimated_megabytes / 1000).toFixed(1) + ' GB';
+        } else {
+            size_text = ' · estimated ' + estimated_megabytes.toFixed(1) + ' MB';
+        }
+    }
+
+    $('#video_length').text(length_text + ' · about ' + duration_seconds + ' seconds' + size_text);
 }
 
 function setPreviewLoading(loading) {
@@ -1336,7 +1353,7 @@ $( document ).ready(function() {
                     </div>
                 </div>
 
-                <div id="timing-controls" class="tw:grid tw:grid-cols-1 tw:sm:grid-cols-3 tw:gap-3 tw:items-end">
+                <div id="timing-controls" class="tw:grid tw:grid-cols-1 tw:sm:grid-cols-2 tw:lg:grid-cols-4 tw:gap-3 tw:items-end">
                     <div class="tw:form-control tw:w-full">
                         <label class="tw:label tw:pb-1">
                             <span class="tw:label-text tw:text-xs tw:font-bold tw:text-base-content/60 tw:uppercase tw:tracking-wider">
@@ -1363,9 +1380,18 @@ $( document ).ready(function() {
                         </label>
                         {{ form_mini_timelapse.FRAMERATE_SELECT(class='tw:select tw:select-bordered tw:select-sm tw:h-10 tw:bg-base-100 tw:w-full tw:text-sm tw:focus:outline-none tw:focus:border-primary') }}
                     </div>
+
+                    <div class="tw:form-control tw:w-full">
+                        <label class="tw:label tw:pb-1">
+                            <span class="tw:label-text tw:text-xs tw:font-bold tw:text-base-content/60 tw:uppercase tw:tracking-wider">
+                                {{ form_mini_timelapse.BITRATE_SELECT.label.text }}
+                            </span>
+                        </label>
+                        {{ form_mini_timelapse.BITRATE_SELECT(class='tw:select tw:select-bordered tw:select-sm tw:h-10 tw:bg-base-100 tw:w-full tw:text-sm tw:focus:outline-none tw:focus:border-primary') }}
+                    </div>
                 </div>
                 <div class="tw:text-xs tw:text-base-content/60">
-                    Before and after set the time range around the selected image. Speed controls how quickly those images play.
+                    Before and after set the time range around the selected image. Speed controls playback; quality controls bitrate and file size.
                 </div>
 
                 <div id="panorama-controls" class="tw:flex tw:flex-col tw:gap-3 tw:pt-2 tw:border-t tw:border-base-300" style="display: none;">
@@ -1615,6 +1641,10 @@ $("#FRAMERATE_SELECT").on("change", function() {
     updateVideoLength();
 });
 
+$("#BITRATE_SELECT").on("change", function() {
+    updateVideoLength();
+});
+
 
 $('#form_mini_timelapse').on('submit', function(event) {
     event.preventDefault();
@@ -1628,6 +1658,7 @@ $('#form_mini_timelapse').on('submit', function(event) {
         'PRE_SECONDS' : parseInt($('#PRE_SECONDS_SELECT').val()),
         'POST_SECONDS' : parseInt($('#POST_SECONDS_SELECT').val()),
         'FRAMERATE' : $('#FRAMERATE_SELECT').val(),
+        'BITRATE' : $('#BITRATE_SELECT').val(),
         'NOTE' : $('#NOTE').val(),
         'CROP_X' : panorama_start_selection['x'],
         'CROP_Y' : panorama_start_selection['y'],

--- a/indi_allsky/flask/templates/mini_generate.html
+++ b/indi_allsky/flask/templates/mini_generate.html
@@ -8,6 +8,7 @@
 var camera_id = {{ camera_id }};
 var timestamp = {{ timestamp | int }};
 var panorama_data = {{ panorama | tojson }};
+var standard_video = {{ standard_video | tojson }};
 var source_type = {{ source_type | tojson }};
 var endDate_timestamp;  // set later
 var history_seconds;  // set later
@@ -672,6 +673,7 @@ function drawPanoramaEditor() {
 
     drawPanoramaOutputPreview();
     updatePanoramaFields();
+    updateBitrateHint();
 }
 
 function drawPanoramaOutputPreview() {
@@ -1154,6 +1156,76 @@ function generationFrameRange() {
     return start_datetime + ' – ' + end_datetime;
 }
 
+function selectedBitrateKbps() {
+    var bitrate_match = String($('#BITRATE_SELECT').val() || '').match(/^(\d+)([km])$/);
+    if(!bitrate_match) {
+        return null;
+    }
+
+    var bitrate_kbps = parseInt(bitrate_match[1]);
+    if(bitrate_match[2] === 'm') {
+        bitrate_kbps *= 1000;
+    }
+    return bitrate_kbps;
+}
+
+function formatGuideMbps(value) {
+    var decimal_places = value < 1 ? 2 : (value < 10 ? 1 : 0);
+    return parseFloat(value.toFixed(decimal_places)).toString();
+}
+
+function updateBitrateHint() {
+    var hint = $('#bitrate_hint');
+    var output_width;
+    var output_height;
+    if(source_type === 'panorama') {
+        output_width = panorama_selection['width'];
+        output_height = panorama_selection['height'];
+    } else {
+        output_width = standard_video['width'];
+        output_height = standard_video['height'];
+    }
+
+    var selected_bitrate_kbps = selectedBitrateKbps();
+    var output_framerate = parseFloat(framerate);
+    if(!output_width || !output_height || !selected_bitrate_kbps || !output_framerate) {
+        hint.hide();
+        return;
+    }
+
+    // Approximate H.264 guidance derived from common resolution/FPS targets.
+    // Higher frame rates benefit from temporal compression, so their per-frame
+    // range is slightly lower.
+    var lower_bits_per_pixel = output_framerate > 30 ? 0.09 : 0.12;
+    var upper_bits_per_pixel = output_framerate > 30 ? 0.18 : 0.24;
+    var pixel_rate = output_width * output_height * output_framerate;
+    var lower_mbps = pixel_rate * lower_bits_per_pixel / 1000000;
+    var upper_mbps = pixel_rate * upper_bits_per_pixel / 1000000;
+    var selected_mbps = selected_bitrate_kbps / 1000;
+    var assessment;
+    if(selected_mbps < lower_mbps) {
+        assessment = 'compact; fine detail may soften';
+    } else if(selected_mbps > upper_mbps) {
+        assessment = 'generous';
+    } else {
+        assessment = 'balanced';
+    }
+
+    var hint_text = (
+        output_width + '×' + output_height + ' at ' + output_framerate + ' FPS'
+        + ' · selected bitrate is ' + assessment
+        + ' · rough H.264 guide: ' + formatGuideMbps(lower_mbps)
+        + '–' + formatGuideMbps(upper_mbps) + ' Mbps'
+    );
+    if(
+        standard_video['codec'] !== 'libx264'
+        && String(standard_video['codec']).indexOf('h264_') !== 0
+    ) {
+        hint_text += ' · current codec may differ';
+    }
+    hint.text(hint_text).show();
+}
+
 function updateVideoLength() {
     var image_count = generationFrameCount();
     var exact_duration_seconds = image_count / parseFloat(framerate);
@@ -1164,13 +1236,9 @@ function updateVideoLength() {
         length_text += ' · ' + frame_range;
     }
 
-    var bitrate_match = String($('#BITRATE_SELECT').val() || '').match(/^(\d+)([km])$/);
+    var bitrate_kbps = selectedBitrateKbps();
     var size_text = '';
-    if(bitrate_match) {
-        var bitrate_kbps = parseInt(bitrate_match[1]);
-        if(bitrate_match[2] === 'm') {
-            bitrate_kbps *= 1000;
-        }
+    if(bitrate_kbps) {
         var estimated_megabytes = bitrate_kbps * exact_duration_seconds / 8000;
         if(estimated_megabytes >= 1000) {
             size_text = ' · estimated ' + (estimated_megabytes / 1000).toFixed(1) + ' GB';
@@ -1180,6 +1248,7 @@ function updateVideoLength() {
     }
 
     $('#video_length').text(length_text + ' · about ' + duration_seconds + ' seconds' + size_text);
+    updateBitrateHint();
 }
 
 function setPreviewLoading(loading) {
@@ -1392,6 +1461,7 @@ $( document ).ready(function() {
                 </div>
                 <div class="tw:text-xs tw:text-base-content/60">
                     Before and after set the time range around the selected image. Speed controls playback; bitrate controls file size.
+                    <div id="bitrate_hint" class="tw:mt-1 tw:font-medium tw:text-base-content/70" style="display: none;"></div>
                 </div>
 
                 <div id="panorama-controls" class="tw:flex tw:flex-col tw:gap-3 tw:pt-2 tw:border-t tw:border-base-300" style="display: none;">

--- a/indi_allsky/flask/views.py
+++ b/indi_allsky/flask/views.py
@@ -11688,7 +11688,7 @@ class AjaxMiniTimelapseGeneratorView(BaseView):
             request_values['bitrate'] is not None
             and not re.fullmatch(r'\d+[km]', request_values['bitrate'])
         ):
-            return None, 'Choose a valid video quality, then try again.'
+            return None, 'Choose a valid bitrate/file size, then try again.'
         if (
             request_values['pre_seconds'] < 1
             or request_values['pre_seconds'] > 43200

--- a/indi_allsky/flask/views.py
+++ b/indi_allsky/flask/views.py
@@ -11458,6 +11458,42 @@ class MiniTimelapseGeneratorView(TemplateView):
     image_loop_view = 'indi_allsky.js_image_loop_view'
 
 
+    @staticmethod
+    def _getStandardVideoDimensions(image_entry, vf_scale):
+        try:
+            source_width = int(image_entry.width)
+            source_height = int(image_entry.height)
+        except (TypeError, ValueError):
+            return None, None
+        if source_width < 1 or source_height < 1:
+            return None, None
+
+        if not vf_scale:
+            return source_width, source_height
+
+        height_match = re.fullmatch(r'-[12]:(\d+)', vf_scale)
+        if height_match:
+            output_height = int(height_match.group(1))
+            if output_height < 1:
+                return None, None
+            output_width = round(source_width * output_height / source_height)
+            return max(2, round(output_width / 2) * 2), output_height
+
+        percentage_match = re.fullmatch(r'iw\*(\.\d+):(ih\*\.\d+|-2)', vf_scale)
+        if not percentage_match:
+            return None, None
+
+        width_factor = float(percentage_match.group(1))
+        output_width = max(2, round((source_width * width_factor) / 2) * 2)
+        if percentage_match.group(2) == '-2':
+            output_height = round(source_height * output_width / source_width)
+        else:
+            height_factor = float(percentage_match.group(2).split('*')[1])
+            output_height = round(source_height * height_factor)
+
+        return output_width, max(2, round(output_height / 2) * 2)
+
+
     def _getPanoramaContext(self, image_entry):
         panorama_enabled = bool(
             self.indi_allsky_config.get('FISH2PANO', {}).get('ENABLE', False)
@@ -11622,8 +11658,17 @@ class MiniTimelapseGeneratorView(TemplateView):
         use_night_config = self.indi_allsky_config.get('TIMELAPSE', {}).get('USE_NIGHT_CONFIG', True)
         if use_night_config or image_entry.night:
             bitrate = str(self.indi_allsky_config.get('FFMPEG_BITRATE', '5000k'))
+            vf_scale = self.indi_allsky_config.get('FFMPEG_VFSCALE', '')
         else:
             bitrate = str(self.indi_allsky_config.get('FFMPEG_BITRATE_DAY', '5000k'))
+            vf_scale = self.indi_allsky_config.get('FFMPEG_VFSCALE_DAY', '')
+
+        standard_width, standard_height = self._getStandardVideoDimensions(image_entry, vf_scale)
+        context['standard_video'] = {
+            'width'  : standard_width,
+            'height' : standard_height,
+            'codec'  : self.indi_allsky_config.get('FFMPEG_CODEC', 'libx264'),
+        }
 
 
         form_data = {

--- a/indi_allsky/flask/views.py
+++ b/indi_allsky/flask/views.py
@@ -11619,15 +11619,38 @@ class MiniTimelapseGeneratorView(TemplateView):
             context['source_type'] = 'standard'
 
 
+        use_night_config = self.indi_allsky_config.get('TIMELAPSE', {}).get('USE_NIGHT_CONFIG', True)
+        if use_night_config or image_entry.night:
+            bitrate = str(self.indi_allsky_config.get('FFMPEG_BITRATE', '5000k'))
+        else:
+            bitrate = str(self.indi_allsky_config.get('FFMPEG_BITRATE_DAY', '5000k'))
+
+
         form_data = {
             'CAMERA_ID'             : self.camera.id,
             'IMAGE_ID'              : image_entry.id,
             'PRE_SECONDS_SELECT'    : '240',
             'POST_SECONDS_SELECT'   : '120',
             'FRAMERATE_SELECT'      : '10',
+            'BITRATE_SELECT'        : bitrate,
         }
 
-        context['form_mini_timelapse'] = IndiAllskyMiniTimelapseForm(data=form_data)
+        form_mini_timelapse = IndiAllskyMiniTimelapseForm(data=form_data)
+        bitrate_choices = dict(form_mini_timelapse.BITRATE_SELECT_choices)
+        preset_bitrates = {
+            value
+            for choices in bitrate_choices.values()
+            for value, label in choices
+        }
+        if bitrate not in preset_bitrates:
+            bitrate_choices = {
+                'Configured default': (
+                    (bitrate, '{0:s} — configured default'.format(bitrate)),
+                ),
+                **bitrate_choices,
+            }
+        form_mini_timelapse.BITRATE_SELECT.choices = bitrate_choices
+        context['form_mini_timelapse'] = form_mini_timelapse
 
         return context
 
@@ -11649,6 +11672,7 @@ class AjaxMiniTimelapseGeneratorView(BaseView):
                 'pre_seconds' : int(request_data['PRE_SECONDS']),
                 'post_seconds': int(request_data['POST_SECONDS']),
                 'framerate'   : float(request_data['FRAMERATE']),
+                'bitrate'     : request_data.get('BITRATE'),
                 'note'        : str(request_data.get('NOTE') or ''),
             }
         except (KeyError, TypeError, ValueError):
@@ -11658,6 +11682,13 @@ class AjaxMiniTimelapseGeneratorView(BaseView):
             return None, 'Enter a description for this video.'
         if len(request_values['note']) > 255:
             return None, 'Keep the description to 255 characters or fewer.'
+        if request_values['bitrate'] is not None:
+            request_values['bitrate'] = str(request_values['bitrate'])
+        if (
+            request_values['bitrate'] is not None
+            and not re.fullmatch(r'\d+[km]', request_values['bitrate'])
+        ):
+            return None, 'Choose a valid video quality, then try again.'
         if (
             request_values['pre_seconds'] < 1
             or request_values['pre_seconds'] > 43200

--- a/indi_allsky/flask/views.py
+++ b/indi_allsky/flask/views.py
@@ -11671,6 +11671,23 @@ class MiniTimelapseGeneratorView(TemplateView):
         }
 
 
+        bitrate_choices = dict(IndiAllskyMiniTimelapseForm.BITRATE_SELECT_choices)
+
+        def bitrate_kbps(value):
+            bitrate_match = re.fullmatch(r'(\d+)([km])', value)
+            if not bitrate_match:
+                return None
+
+            multiplier = 1000 if bitrate_match.group(2) == 'm' else 1
+            return int(bitrate_match.group(1)) * multiplier
+
+        preset_bitrates = {
+            bitrate_kbps(value): value
+            for choices in bitrate_choices.values()
+            for value, label in choices
+        }
+        bitrate = preset_bitrates.get(bitrate_kbps(bitrate), bitrate)
+
         form_data = {
             'CAMERA_ID'             : self.camera.id,
             'IMAGE_ID'              : image_entry.id,
@@ -11681,13 +11698,7 @@ class MiniTimelapseGeneratorView(TemplateView):
         }
 
         form_mini_timelapse = IndiAllskyMiniTimelapseForm(data=form_data)
-        bitrate_choices = dict(form_mini_timelapse.BITRATE_SELECT_choices)
-        preset_bitrates = {
-            value
-            for choices in bitrate_choices.values()
-            for value, label in choices
-        }
-        if bitrate not in preset_bitrates:
+        if bitrate not in preset_bitrates.values():
             bitrate_choices = {
                 'Configured default': (
                     (bitrate, '{0:s} — configured default'.format(bitrate)),

--- a/indi_allsky/video.py
+++ b/indi_allsky/video.py
@@ -783,6 +783,7 @@ class VideoWorker(Process):
         pre_seconds = int(kwargs['pre_seconds'])
         post_seconds = int(kwargs['post_seconds'])
         framerate = float(kwargs['framerate'])
+        bitrate_override = kwargs.get('bitrate')
         note = str(kwargs['note'])
 
 
@@ -1177,6 +1178,9 @@ class VideoWorker(Process):
                 bitrate = self.config.get('FFMPEG_BITRATE_DAY', '5000k')
                 vf_scale = self.config.get('FFMPEG_VFSCALE_DAY', '')
                 ffmpeg_extra_options = self.config.get('FFMPEG_EXTRA_OPTIONS_DAY', '')
+
+        if bitrate_override:
+            bitrate = str(bitrate_override)
 
 
         pan_command_file = None


### PR DESCRIPTION
## Summary

When generating mini-timelapses I often wonder how big the resulting file may be and whether that can be shared via messenger apps etc. without dumping 100 MB on someone. Currently, mini-timelapses use the bitrate selection from Config that also determines the bitrate for the end of day/night timelapses. Changing these every time I need a lower bitrate is tedious. This adds a selectable **Bitrate/File size** setting to all three mini-timelapse modes. The configured day/night FFmpeg bitrate is used as the default. If it matches a preset - including equivalent forms such as `5m` and `5000k` - the preset is selected without adding a duplicate option.

## Changes

- Added bitrate presets from 2.5 Mbps through 50 Mbps, grouped by approximate file size.
- Passes the selected bitrate through the generation job to FFmpeg.
- Shows an estimated output file size based on the selected bitrate and final video duration.
- Shows resolution- and frame-rate-aware H.264 bitrate guidance.
- Minor tweaks and fixes that came up