### PR TITLE
Improve loop and mini-timelapse preview playback

### DIFF
--- a/indi_allsky/flask/templates/loop_canvas.html
+++ b/indi_allsky/flask/templates/loop_canvas.html
@@ -292,6 +292,12 @@ $( document ).ready(function() {
                 <span id="loader_loop" class="tw:loading tw:loading-spinner tw:loading-xs tw:text-primary" style="display: none;"></span>
             </div>
 
+            {% if image_loop_view == 'indi_allsky.js_image_loop_view' and panorama__enable %}
+                <a href="{{ url_for('indi_allsky.panorama_loop_canvas_view', timestamp=timestamp) }}" class="tw:btn tw:btn-sm tw:btn-outline">Panorama loop</a>
+            {% elif image_loop_view == 'indi_allsky.js_panorama_loop_view' %}
+                <a href="{{ url_for('indi_allsky.image_loop_canvas_view', timestamp=timestamp) }}" class="tw:btn tw:btn-sm tw:btn-outline">Normal loop</a>
+            {% endif %}
+
         </div>
     </form>
 

--- a/indi_allsky/flask/templates/loop_canvas.html
+++ b/indi_allsky/flask/templates/loop_canvas.html
@@ -9,7 +9,6 @@
 <script type="text/javascript">
 var camera_id = {{ camera_id }};
 var refreshInterval = {{ refreshInterval | int }};
-var loadCountdown = 0;  // load immediately
 var timestamp = {{ timestamp | int }};
 var history_seconds;  // set later
 var frame_delay_ms;  // set later
@@ -20,6 +19,12 @@ var json_data = {
     'message' : '',
 };
 var fullscreen = false;  //initial state
+var playback_controller = new AbortController();
+var loop_timer;
+var refresh_timer;
+var list_request;
+var request_id = 0;
+var restart_pending = false;
 
 function init() {
     loadImages();
@@ -28,62 +33,126 @@ function init() {
 
 async function loop() {
     console.log('Starting loop');
+    var signal = playback_controller.signal;
 
     while(json_data['image_list'].length == 0) {
         await sleep(100);
+        if (signal.aborted) return;
     }
 
     // prevent concurrent updates to list
-    var image_list_copy = JSON.parse(JSON.stringify(json_data['image_list']));
-
+    var image_list_copy = json_data['image_list'].slice().reverse();
     if (rock) {
-        for (var i = 0; i < image_list_copy.length; i++) {
-            showImage(image_list_copy[i]);
-            await sleep(frame_delay_ms);
-        };
-    };
+        image_list_copy = json_data['image_list'].concat(image_list_copy);
+    }
 
-    for (var i = image_list_copy.length - 1; i >= 0; i--) {
-        showImage(image_list_copy[i]);
+    // Keep at most four frames loading or decoded ahead of playback.
+    var buffer = [];
+    var next_frame = 0;
+    while (next_frame < Math.min(4, image_list_copy.length)) {
+        buffer.push(loadFrame(image_list_copy[next_frame++], signal));
+    }
+
+    while (buffer.length && !signal.aborted) {
+        var img = await buffer.shift();
+        if (signal.aborted) return;
+        if (next_frame < image_list_copy.length) {
+            buffer.push(loadFrame(image_list_copy[next_frame++], signal));
+        }
+        if (!img) {
+            continue;
+        }
+        showImage(img);
         await sleep(frame_delay_ms);
-    };
+    }
 
-    setTimeout(loop, 3000);
+    if (!signal.aborted) {
+        loop_timer = setTimeout(loop, 3000);
+    }
 }
 
-function showImage(entry) {
+function restartLoop() {
+    playback_controller.abort();
+    clearTimeout(loop_timer);
+    playback_controller = new AbortController();
+    loop();
+}
+
+function loadFrame(entry, signal) {
+    return new Promise(function(resolve) {
+        var img = new Image();
+        var settled = false;
+        var timeout = setTimeout(cancel, 15000);
+
+        function finish(frame) {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            clearTimeout(timeout);
+            signal.removeEventListener('abort', cancel);
+            img.onload = null;
+            img.onerror = null;
+            if (!frame) {
+                img.src = '';
+            }
+            resolve(frame);
+        }
+
+        function cancel() { finish(null); }
+        signal.addEventListener('abort', cancel, { once: true });
+        if (signal.aborted) {
+            cancel();
+            return;
+        }
+
+        img.onload = function() {
+            if (img.decode) {
+                img.decode().then(function() { finish(img); }, cancel);
+            } else {
+                finish(img);
+            }
+        };
+        img.onerror = cancel;
+        img.src = entry["url"];
+    });
+}
+
+function showImage(img) {
     var canvas = document.getElementById("canvas");
     var context = canvas.getContext("2d");
 
-    var img = new Image();
-    img.onload = function() {
+    if (canvas.width !== window.innerWidth || canvas.height !== window.innerHeight) {
         canvas.setAttribute("width", window.innerWidth);
         canvas.setAttribute("height", window.innerHeight);
-
-        var hRatio = canvas.width  / this.width;
-        var vRatio = canvas.height / this.height;
-        var ratio  = Math.min ( hRatio, vRatio );
-        var centerShift_x = ( canvas.width - this.width * ratio ) / 2;
-        var centerShift_y = ( canvas.height - this.height * ratio ) / 2;
-
-        context.drawImage(this, 0, 0, this.width, this.height,
-            centerShift_x, centerShift_y, this.width * ratio, this.height * ratio);
-    };
-
-    img.src = entry["url"];
-}
-
-function loadImages() {
-    if(loadCountdown <= 0) {
-        loadCountdown = refreshInterval;
-
-        console.log('Loading next images');
-        loadJS("{{ url_for(image_loop_view) }}", {'camera_id' : camera_id, 'limit_s' : history_seconds, 'timestamp' : timestamp}, function() {});
     }
 
-    loadCountdown -= 1000;
+    var hRatio = canvas.width  / img.width;
+    var vRatio = canvas.height / img.height;
+    var ratio  = Math.min ( hRatio, vRatio );
+    var centerShift_x = ( canvas.width - img.width * ratio ) / 2;
+    var centerShift_y = ( canvas.height - img.height * ratio ) / 2;
 
-    setTimeout(loadImages, 1000);
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    context.drawImage(img, 0, 0, img.width, img.height,
+        centerShift_x, centerShift_y, img.width * ratio, img.height * ratio);
+}
+
+function loadImages(restart = false) {
+    clearTimeout(refresh_timer);
+    restart_pending = restart_pending || restart;
+
+    function scheduleRefresh() {
+        refresh_timer = setTimeout(loadImages, refreshInterval);
+    }
+
+    loadJS("{{ url_for(image_loop_view) }}", {'camera_id' : camera_id, 'limit_s' : history_seconds, 'timestamp' : timestamp}, function() {
+        if (restart_pending) {
+            restart_pending = false;
+            restartLoop();
+        }
+        scheduleRefresh();
+    }, scheduleRefresh);
 }
 
 function sleep(time) {
@@ -96,12 +165,16 @@ function loadJS(url, data, onDone, onError) {
 
     $("#loader_loop").show();
 
-    $.ajax({
+    var current_request = ++request_id;
+    if (list_request) list_request.abort();
+    list_request = $.ajax({
         type: "GET",
+        timeout: 15000,
         url: url,
         contentType: "application/json",
         data: data,
         success: function(rdata){
+            if (current_request !== request_id) return;
             $("#loader_loop").hide();
             json_data = rdata;
             const msg = json_data['message'];
@@ -112,11 +185,14 @@ function loadJS(url, data, onDone, onError) {
                 $('#message').html('');
                 $('#message-wrapper').hide();
             }
+            onDone();
         },
         error: function(rdata){
+            if (current_request !== request_id) return;
             $("#loader_loop").hide();
             onError(rdata.status);
             $('#message').text('Error loading data. Please check the logs.');
+            $('#message-wrapper').show();
         },
     });
 }
@@ -237,8 +313,7 @@ $( document ).ready(function() {
 $("#HISTORY_SELECT").on("change", function() {
     history_seconds = $('#HISTORY_SELECT').val();
     console.log('Changing loop history: ' + history_seconds);
-
-    loadCountdown = 0;
+    loadImages(true);
 
     if(localStorage) {
         page_settings["history_seconds"] = history_seconds;

--- a/indi_allsky/flask/templates/loop_img.html
+++ b/indi_allsky/flask/templates/loop_img.html
@@ -278,6 +278,12 @@ $( document ).ready(function() {
                 <span id="loader_loop" class="tw:loading tw:loading-spinner tw:loading-xs tw:text-primary" style="display: none;"></span>
             </div>
 
+            {% if image_loop_view == 'indi_allsky.js_image_loop_view' and panorama__enable %}
+                <a href="{{ url_for('indi_allsky.panorama_loop_view', timestamp=timestamp) }}" class="tw:btn tw:btn-sm tw:btn-outline">Panorama loop</a>
+            {% elif image_loop_view == 'indi_allsky.js_panorama_loop_view' %}
+                <a href="{{ url_for('indi_allsky.image_loop_view', timestamp=timestamp) }}" class="tw:btn tw:btn-sm tw:btn-outline">Normal loop</a>
+            {% endif %}
+
         </div>
     </form>
 

--- a/indi_allsky/flask/templates/loop_img.html
+++ b/indi_allsky/flask/templates/loop_img.html
@@ -19,6 +19,12 @@ var json_data = {
     'message' : '',
 };
 var fullscreen = false;  //initial state
+var playback_controller = new AbortController();
+var loop_timer;
+var refresh_timer;
+var list_request;
+var request_id = 0;
+var restart_pending = false;
 
 function init() {
     loadNextImage();
@@ -27,43 +33,112 @@ function init() {
 
 async function loop() {
     console.log('Starting loop');
+    var signal = playback_controller.signal;
 
     while(json_data['image_list'].length == 0) {
         await sleep(100);
+        if (signal.aborted) return;
     }
 
     // prevent concurrent updates to list
-    var image_list_copy = JSON.parse(JSON.stringify(json_data['image_list']));
-
+    var image_list_copy = json_data['image_list'].slice().reverse();
     if (rock) {
-        for (var i = 0; i < image_list_copy.length; i++) {
-            showImage(image_list_copy[i]);
-            await sleep(frame_delay_ms);
-        };
-    };
+        image_list_copy = json_data['image_list'].concat(image_list_copy);
+    }
 
-    for (var i = image_list_copy.length - 1; i >= 0; i--) {
-        showImage(image_list_copy[i]);
+    // Keep at most four frames loading or decoded ahead of playback.
+    var buffer = [];
+    var next_frame = 0;
+    while (next_frame < Math.min(4, image_list_copy.length)) {
+        buffer.push(loadFrame(image_list_copy[next_frame++], signal));
+    }
+
+    while (buffer.length && !signal.aborted) {
+        var img = await buffer.shift();
+        if (signal.aborted) return;
+        if (next_frame < image_list_copy.length) {
+            buffer.push(loadFrame(image_list_copy[next_frame++], signal));
+        }
+        if (!img) {
+            continue;
+        }
+        showImage(img);
         await sleep(frame_delay_ms);
-    };
+    }
 
-    setTimeout(loop, 3000);
+    if (!signal.aborted) {
+        loop_timer = setTimeout(loop, 3000);
+    }
 }
 
-function showImage(entry) {
-    var img = new Image();
-    img.onload = function() {
-        $('#loop-image').attr({
-            'src': this.src,
-        });
-    };
-
-    img.src = entry["url"];
+function restartLoop() {
+    playback_controller.abort();
+    clearTimeout(loop_timer);
+    playback_controller = new AbortController();
+    loop();
 }
 
-function loadNextImage() {
-    loadJS("{{ url_for(image_loop_view) }}", {'camera_id' : camera_id, 'limit_s' : history_seconds, 'timestamp' : timestamp}, function() {});
-    setTimeout(loadNextImage, refreshInterval);
+function loadFrame(entry, signal) {
+    return new Promise(function(resolve) {
+        var img = new Image();
+        var settled = false;
+        var timeout = setTimeout(cancel, 15000);
+
+        function finish(frame) {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            clearTimeout(timeout);
+            signal.removeEventListener('abort', cancel);
+            img.onload = null;
+            img.onerror = null;
+            if (!frame) {
+                img.src = '';
+            }
+            resolve(frame);
+        }
+
+        function cancel() { finish(null); }
+        signal.addEventListener('abort', cancel, { once: true });
+        if (signal.aborted) {
+            cancel();
+            return;
+        }
+
+        img.onload = function() {
+            if (img.decode) {
+                img.decode().then(function() { finish(img); }, cancel);
+            } else {
+                finish(img);
+            }
+        };
+        img.onerror = cancel;
+        img.src = entry["url"];
+    });
+}
+
+function showImage(img) {
+    $('#loop-image').attr({
+        'src': img.src,
+    });
+}
+
+function loadNextImage(restart = false) {
+    clearTimeout(refresh_timer);
+    restart_pending = restart_pending || restart;
+
+    function scheduleRefresh() {
+        refresh_timer = setTimeout(loadNextImage, refreshInterval);
+    }
+
+    loadJS("{{ url_for(image_loop_view) }}", {'camera_id' : camera_id, 'limit_s' : history_seconds, 'timestamp' : timestamp}, function() {
+        if (restart_pending) {
+            restart_pending = false;
+            restartLoop();
+        }
+        scheduleRefresh();
+    }, scheduleRefresh);
 }
 
 function sleep(time) {
@@ -76,12 +151,16 @@ function loadJS(url, data, onDone, onError) {
 
     $("#loader_loop").show();
 
-    $.ajax({
+    var current_request = ++request_id;
+    if (list_request) list_request.abort();
+    list_request = $.ajax({
         type: "GET",
+        timeout: 15000,
         url: url,
         contentType: "application/json",
         data: data,
         success: function(rdata){
+            if (current_request !== request_id) return;
             $("#loader_loop").hide();
             json_data = rdata;
             const msg = json_data['message'];
@@ -92,11 +171,14 @@ function loadJS(url, data, onDone, onError) {
                 $('#message').html('');
                 $('#message-wrapper').hide();
             }
+            onDone();
         },
         error: function(rdata){
+            if (current_request !== request_id) return;
             $("#loader_loop").hide();
             onError(rdata.status);
             $('#message').text('Error loading data. Please check the logs.');
+            $('#message-wrapper').show();
         },
     });
 }
@@ -221,6 +303,7 @@ $( document ).ready(function() {
 $("#HISTORY_SELECT").on("change", function() {
     history_seconds = $('#HISTORY_SELECT').val();
     console.log('Changing loop history: ' + history_seconds);
+    loadNextImage(true);
 
     if(localStorage) {
         page_settings["history_seconds"] = history_seconds;

--- a/indi_allsky/flask/templates/mini_generate.html
+++ b/indi_allsky/flask/templates/mini_generate.html
@@ -36,6 +36,7 @@ var panorama_end_image = null;
 var panorama_preview_progress = 0;
 var panorama_drag = null;
 var preview_revision = 0;  // invalidates old requests, delays, and image loads
+var preview_controller = new AbortController();
 var preview_resize_observer = null;
 // The animation preview stays bounded, while preflight checks the complete
 // generation period on the server.
@@ -92,6 +93,7 @@ function init() {
 }
 
 async function loop(revision) {
+    var signal = preview_controller.signal;
     while(json_data['image_list'].length == 0) {
         if(revision !== preview_revision) {
             return;
@@ -104,14 +106,27 @@ async function loop(revision) {
     }
 
     // prevent concurrent updates to list
-    var image_list_copy = json_data['image_list'].slice();
+    var image_list_copy = json_data['image_list'].slice().reverse();
 
-    for (var i = image_list_copy.length - 1; i >= 0; i--) {
+    // Keep at most four frames loading or decoded ahead of playback.
+    var buffer = [];
+    var next_frame = 0;
+    while(next_frame < Math.min(4, image_list_copy.length)) {
+        buffer.push(loadFrame(image_list_copy[next_frame++], signal));
+    }
+
+    while(buffer.length && !signal.aborted) {
+        var frame = await buffer.shift();
         if(revision !== preview_revision) {
             return;
         }
-
-        showImage(image_list_copy[i], revision);
+        if(next_frame < image_list_copy.length) {
+            buffer.push(loadFrame(image_list_copy[next_frame++], signal));
+        }
+        if(!frame) {
+            continue;
+        }
+        showImage(frame.image, frame.entry, revision);
         await sleep(1000 / parseFloat(framerate));
     }
 
@@ -123,25 +138,64 @@ async function loop(revision) {
 }
 
 
-function showImage(entry, revision) {
-    if(source_type === 'panorama') {
-        var preview_image = new Image();
-        preview_image.onload = function() {
-            if(
-                revision !== preview_revision
-                || source_type !== 'panorama'
-                || this.naturalWidth !== panorama_data['width']
-                || this.naturalHeight !== panorama_data['height']
-            ) {
+function loadFrame(entry, signal) {
+    return new Promise(function(resolve) {
+        var image = new Image();
+        var settled = false;
+        var timeout = setTimeout(cancel, 15000);
+
+        function finish(frame) {
+            if(settled) {
                 return;
             }
+            settled = true;
+            clearTimeout(timeout);
+            signal.removeEventListener('abort', cancel);
+            image.onload = null;
+            image.onerror = null;
+            if(!frame) {
+                image.src = '';
+            }
+            resolve(frame ? { image: frame, entry: entry } : null);
+        }
 
-            panorama_preview_image = this;
-            panorama_preview_entry = entry;
-            panorama_preview_progress = panoramaFrameProgress(entry);
-            drawPanoramaOutputPreview();
+        function cancel() { finish(null); }
+        signal.addEventListener('abort', cancel, { once: true });
+        if(signal.aborted) {
+            cancel();
+            return;
+        }
+
+        image.onload = function() {
+            if(image.decode) {
+                image.decode().then(function() { finish(image); }, cancel);
+            } else {
+                finish(image);
+            }
         };
-        preview_image.src = entry["url"];
+        image.onerror = cancel;
+        image.src = entry['url'];
+    });
+}
+
+
+function showImage(image, entry, revision) {
+    if(revision !== preview_revision) {
+        return;
+    }
+
+    if(source_type === 'panorama') {
+        if(
+            image.naturalWidth !== panorama_data['width']
+            || image.naturalHeight !== panorama_data['height']
+        ) {
+            return;
+        }
+
+        panorama_preview_image = image;
+        panorama_preview_entry = entry;
+        panorama_preview_progress = panoramaFrameProgress(entry);
+        drawPanoramaOutputPreview();
         return;
     }
 
@@ -149,19 +203,9 @@ function showImage(entry, revision) {
         return;
     }
 
-    var image = new Image();
-    image.onload = function() {
-        if(revision !== preview_revision || source_type !== 'standard') {
-            return;
-        }
-
-        $('#loop-image').attr({
-            'src': this.src,
-        });
-    };
-
-
-    image.src = entry["url"];
+    $('#loop-image').attr({
+        'src': image.src,
+    });
 }
 
 
@@ -1651,6 +1695,8 @@ function updateImages() {
     history_seconds = pre_seconds + post_seconds;
     framerate = $('#FRAMERATE_SELECT').val();
     preview_revision += 1;
+    preview_controller.abort();
+    preview_controller = new AbortController();
     json_data['image_list'] = [];
     panorama_start_image = null;
     panorama_end_image = null;
@@ -1666,6 +1712,8 @@ function updateImages() {
 
 $('#SOURCE_TYPE').on('change', function() {
     preview_revision += 1;
+    preview_controller.abort();
+    preview_controller = new AbortController();
     json_data = {
         'image_list' : [],
         'message' : '',

--- a/indi_allsky/flask/views.py
+++ b/indi_allsky/flask/views.py
@@ -1162,6 +1162,7 @@ class ImageLoopCanvasView(TemplateView):
         context = super(ImageLoopCanvasView, self).get_context()
 
         context['image_loop_view'] = self.image_loop_view
+        context['panorama__enable'] = bool(self.indi_allsky_config.get('FISH2PANO', {}).get('ENABLE', False))
 
         context['timestamp'] = int(request.args.get('timestamp', 0))
 
@@ -1493,6 +1494,7 @@ class ImageLoopImgView(TemplateView):
         context = super(ImageLoopImgView, self).get_context()
 
         context['image_loop_view'] = self.image_loop_view
+        context['panorama__enable'] = bool(self.indi_allsky_config.get('FISH2PANO', {}).get('ENABLE', False))
 
         context['timestamp'] = int(request.args.get('timestamp', 0))
 

--- a/tests/flask/loop_playback.test.cjs
+++ b/tests/flask/loop_playback.test.cjs
@@ -1,4 +1,5 @@
-// Run with: node --test tests/loop_playback.test.cjs
+// Also run by test_loop_playback.py as part of the pytest suite.
+// Run directly with: node --test tests/flask/loop_playback.test.cjs
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -101,7 +102,7 @@ function player(template, frames, options = {}) {
         $, localStorage: { setItem() {} },
     });
     const source = fs.readFileSync(path.join(__dirname,
-        '../indi_allsky/flask/templates', template), 'utf8');
+        '../../indi_allsky/flask/templates', template), 'utf8');
     const script = source.match(/<script type="text\/javascript">([\s\S]*?)<\/script>/)[1]
         .replace(/\{\{[\s\S]*?\}\}/g, '0');
     vm.runInContext(script, context, { filename: template });

--- a/tests/flask/mini_preview_playback.test.cjs
+++ b/tests/flask/mini_preview_playback.test.cjs
@@ -1,0 +1,277 @@
+// Also run by test_mini_preview_playback.py as part of the pytest suite.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function player(sourceType, frames, options = {}) {
+    let now = 0;
+    let timerId = 0;
+    let active = 0;
+    let peakActive = 0;
+    const timers = new Map();
+    const displayed = [];
+    const requested = [];
+    const requests = [];
+    const handlers = new Map();
+    const values = {
+        '#SOURCE_TYPE': sourceType, '#PRE_SECONDS_SELECT': '60',
+        '#POST_SECONDS_SELECT': '60', '#FRAMERATE_SELECT': '50',
+        '#PAN_MODE': 'static',
+    };
+    const setTimeout = (callback, delay) => {
+        const id = ++timerId;
+        timers.set(id, { at: now + Number(delay), callback });
+        return id;
+    };
+    class Image {
+        constructor() {
+            this.naturalWidth = 1920;
+            this.naturalHeight = 1080;
+            this.complete = false;
+            if (options.noDecode) this.decode = undefined;
+        }
+        set src(src) {
+            this.url = src;
+            if (!src) {
+                this.release();
+                return;
+            }
+            requested.push(src);
+            this.pending = true;
+            peakActive = Math.max(peakActive, ++active);
+            const settings = options.loads?.[src] || {};
+            this.naturalWidth = settings.width || 1920;
+            if (settings.hang) return;
+            setTimeout(() => {
+                if (!this.url) return;
+                if (settings.error) {
+                    this.release();
+                    this.onerror?.();
+                } else {
+                    this.complete = true;
+                    if (options.noDecode) this.release();
+                    this.onload?.();
+                }
+            }, settings.delay || 0);
+        }
+        get src() { return this.url; }
+        release() {
+            if (this.pending) active--;
+            this.pending = false;
+        }
+        decode() {
+            const settings = options.loads?.[this.src] || {};
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    this.release();
+                    if (settings.decodeError) reject(new Error('Bad image'));
+                    else resolve();
+                }, settings.decodeDelay || 0);
+            });
+        }
+    }
+    const canvas = {
+        width: 300, height: 150,
+        getContext: () => ({
+            clearRect() {},
+            drawImage: (img, x, y, width, height) => displayed.push({
+                src: img.src, at: now, x, y, width, height,
+                progress: context.panorama_preview_progress,
+                entry: context.panorama_preview_entry,
+            }),
+        }),
+    };
+    const $ = (selector) => {
+        const element = {
+            ready() {},
+            on: (event, handler) => handlers.set(`${selector}:${event}`, handler),
+            val(value) {
+                if (value === undefined) return values[selector];
+                values[selector] = value;
+                return element;
+            },
+            attr(attributes) {
+                if (selector === '#loop-image' && attributes.src) {
+                    displayed.push({ src: attributes.src, at: now });
+                }
+                return element;
+            },
+        };
+        for (const method of ['show', 'hide', 'html', 'text', 'empty', 'prop',
+            'toggle', 'css', 'toggleClass', 'addClass', 'removeClass', 'appendTo']) {
+            element[method] = () => element;
+        }
+        return element;
+    };
+    $.ajax = (settings) => {
+        const request = { ...settings, aborted: false, abort() {
+            this.aborted = true;
+            settings.error({ status: 0 });
+        } };
+        requests.push(request);
+        return request;
+    };
+    const context = vm.createContext({
+        Image, AbortController, setTimeout, clearTimeout: (id) => timers.delete(id),
+        document: { getElementById: (id) => id === 'panorama-output-preview' ? canvas : null },
+        window: {}, $, console: { log() {} },
+    });
+    const source = fs.readFileSync(path.join(__dirname,
+        '../../indi_allsky/flask/templates/mini_generate.html'), 'utf8');
+    for (const script of source.matchAll(/<script(?: type="text\/javascript")?>([\s\S]*?)<\/script>/g)) {
+        vm.runInContext(script[1].replace(/\{\{([\s\S]*?)\}\}/g, (_, expression) => {
+            if (expression.trim() === 'panorama | tojson') {
+                return JSON.stringify({ available: true, width: 1920, height: 1080 });
+            }
+            if (expression.trim() === 'source_type | tojson') return JSON.stringify(sourceType);
+            return '0';
+        }), context, { filename: 'mini_generate.html' });
+    }
+    const entries = (urls) => urls.map((url, index) => ({ url, timestamp: 100 + urls.length - index - 1 }));
+    context.json_data.image_list = entries(frames);
+    context.framerate = '50';
+    context.history_seconds = 120;
+    context.endDate_timestamp = 60;
+    const completion = context.loop(context.preview_revision);
+
+    async function advance(milliseconds) {
+        const target = now + milliseconds;
+        await new Promise(setImmediate);
+        while (true) {
+            const next = [...timers.entries()].sort((a, b) => a[1].at - b[1].at)[0];
+            if (!next || next[1].at > target) break;
+            now = next[1].at;
+            timers.delete(next[0]);
+            next[1].callback();
+            await new Promise(setImmediate);
+        }
+        now = target;
+    }
+    function change(selector, value) {
+        values[selector] = value;
+        handlers.get(`${selector}:change`)();
+    }
+    function respond(index, urls) {
+        requests[index].success({ image_list: entries(urls), message: '' });
+    }
+    return { context, displayed, requested, requests, advance, change, respond,
+        completion, values, canvas, peakActive: () => peakActive, active: () => active };
+}
+
+for (const sourceType of ['standard', 'panorama']) {
+    test(`${sourceType}: decodes a bounded four-frame buffer and plays in order`, async () => {
+        const p = player(sourceType, ['h', 'g', 'f', 'e', 'd', 'c', 'b', 'a'], {
+            loads: { a: { delay: 80, decodeDelay: 20 } },
+        });
+        assert.deepEqual(p.requested, ['a', 'b', 'c', 'd']);
+        await p.advance(99);
+        assert.deepEqual(p.displayed, []);
+        await p.advance(201);
+        assert.deepEqual(p.displayed.map((f) => f.src), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']);
+        assert.deepEqual(p.displayed.map((f) => f.at), [100, 120, 140, 160, 180, 200, 220, 240]);
+        assert.ok(p.peakActive() <= 4);
+        await p.completion;
+    });
+
+    test(`${sourceType}: a slow frame holds the last image without a catch-up burst`, async () => {
+        const p = player(sourceType, ['c', 'b', 'a'], { loads: { b: { delay: 120 } } });
+        await p.advance(119);
+        assert.deepEqual(p.displayed.map((f) => f.src), ['a']);
+        await p.advance(61);
+        assert.deepEqual(p.displayed.map((f) => f.src), ['a', 'b', 'c']);
+        assert.deepEqual(p.displayed.map((f) => f.at), [0, 120, 140]);
+        await p.completion;
+    });
+
+    for (const stalled of [{ hang: true }, { decodeDelay: 15010 }]) {
+        test(`${sourceType}: skips load/decode failures and timeouts ${JSON.stringify(stalled)}`, async () => {
+            const p = player(sourceType, ['d', 'c', 'b', 'a'], {
+                loads: { a: { error: true }, b: { decodeError: true }, c: stalled },
+            });
+            await p.advance(14999);
+            assert.deepEqual(p.displayed, []);
+            await p.advance(101);
+            assert.deepEqual(p.displayed.map((f) => f.src), ['d']);
+            assert.equal(p.displayed[0].at, 15000);
+            await p.completion;
+        });
+    }
+
+    test(`${sourceType}: frame rate changes retain the three-second end pause`, async () => {
+        const p = player(sourceType, ['c', 'b', 'a']);
+        await p.advance(10);
+        p.change('#FRAMERATE_SELECT', '10');
+        await p.advance(3209);
+        assert.deepEqual(p.displayed.map((f) => f.at), [0, 20, 120]);
+        await p.advance(1);
+        assert.equal(p.displayed.at(-1).src, 'a');
+        assert.equal(p.displayed.at(-1).at, 3220);
+    });
+
+    for (const selector of ['#PRE_SECONDS_SELECT', '#POST_SECONDS_SELECT', '#SOURCE_TYPE']) {
+        test(`${sourceType}: ${selector} cancels buffered loads and ignores stale results`, async () => {
+            const p = player(sourceType, ['d', 'c', 'b', 'a'], {
+                loads: { a: { hang: true }, b: { decodeDelay: 500 }, c: { hang: true }, d: { hang: true } },
+            });
+            p.context.loadImages();
+            await p.advance(10);
+            p.change(selector, selector === '#SOURCE_TYPE'
+                ? (sourceType === 'standard' ? 'panorama' : 'standard') : '180');
+            assert.equal(p.requests.length, 2);
+            assert.equal(p.active(), 0);
+            if (selector !== '#SOURCE_TYPE') assert.equal(p.requests[1].data.limit_s, 240);
+            p.respond(1, ['new']);
+            p.respond(0, ['obsolete']);
+            await p.advance(600);
+            assert.deepEqual(p.displayed.map((f) => f.src), ['new']);
+            assert.ok(p.peakActive() <= 4);
+            await p.completion;
+        });
+    }
+
+    test(`${sourceType}: a selection change during the end pause starts only one new loop`, async () => {
+        const p = player(sourceType, ['old']);
+        await p.advance(100);
+        p.change('#PRE_SECONDS_SELECT', '180');
+        p.respond(0, ['new']);
+        await p.advance(3120);
+        assert.deepEqual(p.displayed.map((f) => f.src), ['old', 'new', 'new']);
+        assert.deepEqual(p.displayed.map((f) => f.at), [0, 200, 3220]);
+    });
+
+    test(`${sourceType}: waits for an empty list and works without Image.decode`, async () => {
+        const p = player(sourceType, [], { noDecode: true });
+        await p.advance(50);
+        assert.deepEqual(p.requested, []);
+        p.context.json_data.image_list = [{ url: 'a' }];
+        await p.advance(70);
+        assert.deepEqual(p.displayed.map((f) => f.src), ['a']);
+        assert.equal(p.displayed[0].at, 100);
+        await p.completion;
+    });
+}
+
+test('panorama preserves frame metadata for the crop and animated pan', async () => {
+    const p = player('panorama', ['c', 'b', 'a'], { loads: { b: { delay: 120 } } });
+    p.values['#PAN_MODE'] = 'linear';
+    p.context.json_data.panorama_preflight = {
+        start_reference: { timestamp: 100 }, end_reference: { timestamp: 102 },
+    };
+    p.context.panorama_start_selection = { x: 100, y: 20, width: 400, height: 200 };
+    p.context.panorama_end_selection = { x: 300, y: 60, width: 400, height: 200 };
+    await p.advance(180);
+    assert.deepEqual(p.displayed.map((f) => [f.src, f.entry.url, f.progress, f.x, f.y]), [
+        ['a', 'a', 0, 100, 20], ['b', 'b', 0.5, 200, 40], ['c', 'c', 1, 300, 60],
+    ]);
+    assert.ok(p.displayed.every((f) => f.width === 400 && f.height === 200));
+    await p.completion;
+});
+
+test('panorama continues to reject frames with incompatible dimensions', async () => {
+    const p = player('panorama', ['c', 'b', 'a'], { loads: { b: { width: 1000 } } });
+    await p.advance(100);
+    assert.deepEqual(p.displayed.map((f) => f.src), ['a', 'c']);
+    await p.completion;
+});

--- a/tests/flask/test_loop_playback.py
+++ b/tests/flask/test_loop_playback.py
@@ -1,0 +1,19 @@
+"""Run the loop player JavaScript regressions through the pytest suite."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def test_loop_playback():
+    node = shutil.which("node")
+    assert node is not None, "Node.js is required to run the loop playback tests"
+
+    result = subprocess.run(
+        [node, "--test", str(Path(__file__).with_name("loop_playback.test.cjs"))],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/flask/test_mini_preview_playback.py
+++ b/tests/flask/test_mini_preview_playback.py
@@ -1,0 +1,19 @@
+"""Run the mini-timelapse preview JavaScript regressions through pytest."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def test_mini_preview_playback():
+    node = shutil.which("node")
+    assert node is not None, "Node.js is required to run the mini preview tests"
+
+    result = subprocess.run(
+        [node, "--test", str(Path(__file__).with_name("mini_preview_playback.test.cjs"))],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/loop_playback.test.cjs
+++ b/tests/loop_playback.test.cjs
@@ -1,0 +1,304 @@
+// Run with: node --test tests/loop_playback.test.cjs
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+function player(template, frames, options = {}) {
+    let now = 0;
+    let timerId = 0;
+    let active = 0;
+    let peakActive = 0;
+    const timers = new Map();
+    const displayed = [];
+    const requested = [];
+    const resized = [];
+    const cleared = [];
+    const requests = [];
+    const handlers = new Map();
+    const values = { '#HISTORY_SELECT': '900' };
+    const setTimeout = (callback, delay) => {
+        const id = ++timerId;
+        timers.set(id, { at: now + Number(delay), callback });
+        return id;
+    };
+    const record = (src) => displayed.push({ src, at: now });
+    class Image {
+        constructor() {
+            this.width = 1920;
+            this.height = 1080;
+            if (options.noDecode) this.decode = undefined;
+        }
+        set src(src) {
+            this.url = src;
+            if (!src) {
+                this.release();
+                return;
+            }
+            requested.push(src);
+            this.pending = true;
+            peakActive = Math.max(peakActive, ++active);
+            const settings = options.loads?.[src] || {};
+            if (settings.hang) return;
+            setTimeout(() => {
+                if (!this.url) return;
+                if (settings.error) {
+                    this.onerror?.();
+                } else {
+                    if (options.noDecode) this.release();
+                    this.onload?.();
+                }
+            }, settings.delay || 0);
+        }
+        get src() { return this.url; }
+        release() {
+            if (this.pending) active--;
+            this.pending = false;
+        }
+        decode() {
+            const settings = options.loads?.[this.src] || {};
+            return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    this.release();
+                    if (settings.decodeError) reject(new Error('Bad image'));
+                    else resolve();
+                }, settings.decodeDelay || 0);
+            });
+        }
+    }
+    const canvas = {
+        width: 300, height: 150,
+        setAttribute(key, value) {
+            resized.push(key);
+            this[key] = value;
+        },
+        getContext: () => ({
+            clearRect: (...args) => cleared.push(args),
+            drawImage: (img) => record(img.src),
+        }),
+    };
+    const $ = (selector) => ({
+        ready() {},
+        on: (event, handler) => handlers.set(`${selector}:${event}`, handler),
+        val: () => values[selector],
+        attr: ({ src }) => record(src),
+        show() {}, hide() {}, html() {}, text() {},
+    });
+    $.ajax = (settings) => {
+        const request = { ...settings, aborted: false, abort() {
+            this.aborted = true;
+            settings.error({ status: 0 });
+        } };
+        requests.push(request);
+        return request;
+    };
+    const context = vm.createContext({
+        Image, AbortController, setTimeout, clearTimeout: (id) => timers.delete(id),
+        window: { innerWidth: 800, innerHeight: 600 },
+        document: { getElementById: () => canvas },
+        console: { log() {} },
+        $, localStorage: { setItem() {} },
+    });
+    const source = fs.readFileSync(path.join(__dirname,
+        '../indi_allsky/flask/templates', template), 'utf8');
+    const script = source.match(/<script type="text\/javascript">([\s\S]*?)<\/script>/)[1]
+        .replace(/\{\{[\s\S]*?\}\}/g, '0');
+    vm.runInContext(script, context, { filename: template });
+    vm.runInContext(source.match(/<script>([\s\S]*?)<\/script>/)[1], context);
+    context.json_data.image_list = frames.map((url) => ({ url }));
+    context.frame_delay_ms = 20;
+    context.refreshInterval = 1000;
+    context.history_seconds = '900';
+    context.page_settings = {};
+    context.rock = options.rock || false;
+    const completion = context.loop();
+
+    async function advance(milliseconds) {
+        const target = now + milliseconds;
+        // Let promises enqueue their timers before choosing the next deadline.
+        await new Promise(setImmediate);
+        while (true) {
+            const next = [...timers.entries()].sort((a, b) => a[1].at - b[1].at)[0];
+            if (!next || next[1].at > target) break;
+            now = next[1].at;
+            timers.delete(next[0]);
+            next[1].callback();
+            await new Promise(setImmediate);
+        }
+        now = target;
+    }
+    function changeHistory(value) {
+        values['#HISTORY_SELECT'] = value;
+        handlers.get('#HISTORY_SELECT:change')();
+    }
+    function respond(index, urls) {
+        requests[index].success({ image_list: urls.map((url) => ({ url })), message: urls.length ? '' : 'No Timelapse Data' });
+    }
+    const refresh = context.loadNextImage || context.loadImages;
+    return { context, displayed, requested, resized, cleared, advance, completion,
+        requests, changeHistory, respond, refresh,
+        peakActive: () => peakActive };
+}
+
+for (const template of ['loop_img.html', 'loop_canvas.html']) {
+    test(`${template}: buffers at most four frames and presents decoded frames in order at 50 FPS`, async () => {
+        const p = player(template, ['h', 'g', 'f', 'e', 'd', 'c', 'b', 'a'], {
+            loads: { a: { delay: 80, decodeDelay: 20 } },
+        });
+        assert.deepEqual(p.requested, ['a', 'b', 'c', 'd']);
+        await p.advance(99);
+        assert.deepEqual(p.displayed, []);
+        await p.advance(201);
+        assert.deepEqual(p.displayed.map((frame) => frame.src), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']);
+        assert.deepEqual(p.displayed.map((frame) => frame.at), [100, 120, 140, 160, 180, 200, 220, 240]);
+        assert.ok(p.peakActive() <= 4);
+        await p.completion;
+    });
+
+    test(`${template}: a slow frame holds the previous image without a catch-up burst`, async () => {
+        const p = player(template, ['c', 'b', 'a'], { loads: { b: { delay: 120 } } });
+        await p.advance(119);
+        assert.deepEqual(p.displayed, [{ src: 'a', at: 0 }]);
+        await p.advance(61);
+        assert.deepEqual(p.displayed, [{ src: 'a', at: 0 }, { src: 'b', at: 120 }, { src: 'c', at: 140 }]);
+        await p.completion;
+    });
+
+    for (const stalled of [{ hang: true }, { decodeDelay: 15010 }]) {
+        test(`${template}: skips failed images and timeouts, ignoring late decode completion ${JSON.stringify(stalled)}`, async () => {
+            const p = player(template, ['d', 'c', 'b', 'a'], {
+                loads: { a: { error: true }, b: { decodeError: true }, c: stalled },
+            });
+            await p.advance(14999);
+            assert.deepEqual(p.displayed, []);
+            await p.advance(101);
+            assert.deepEqual(p.displayed, [{ src: 'd', at: 15000 }]);
+            await p.completion;
+        });
+    }
+
+    test(`${template}: preserves Rock order and the three-second end pause`, async () => {
+        const p = player(template, ['c', 'b', 'a'], { rock: true });
+        await p.advance(3119);
+        assert.deepEqual(p.displayed.map((frame) => frame.src), ['c', 'b', 'a', 'a', 'b', 'c']);
+        await p.advance(1);
+        assert.deepEqual(p.displayed.at(-1), { src: 'c', at: 3120 });
+    });
+
+    test(`${template}: speed changes affect the next frame delay`, async () => {
+        const p = player(template, ['c', 'b', 'a']);
+        await p.advance(10);
+        p.context.frame_delay_ms = '100';
+        await p.advance(210);
+        assert.deepEqual(p.displayed.map((frame) => frame.at), [0, 20, 120]);
+        await p.completion;
+    });
+
+    test(`${template}: routine refresh still takes effect at the existing loop boundary`, async () => {
+        const p = player(template, ['b', 'a']);
+        await p.advance(10);
+        p.refresh();
+        p.respond(0, ['new']);
+        await p.advance(3030);
+        assert.deepEqual(p.displayed, [{ src: 'a', at: 0 }, { src: 'b', at: 20 }, { src: 'new', at: 3040 }]);
+    });
+
+    test(`${template}: history selection requests immediately and interrupts a sleeping pass`, async () => {
+        const p = player(template, ['c', 'b', 'a']);
+        await p.advance(10);
+        p.changeHistory('1800');
+        assert.equal(p.requests[0].data.limit_s, '1800');
+        assert.equal(p.context.page_settings.history_seconds, '1800');
+        p.respond(0, ['new']);
+        await p.advance(100);
+        assert.deepEqual(p.displayed, [{ src: 'a', at: 0 }, { src: 'new', at: 10 }]);
+    });
+
+    test(`${template}: switching history cancels old loading and decoding frames`, async () => {
+        const p = player(template, ['d', 'c', 'b', 'a'], {
+            loads: { a: { hang: true }, b: { decodeDelay: 500 }, c: { hang: true }, d: { hang: true } },
+        });
+        await p.advance(10);
+        p.changeHistory('1800');
+        p.respond(0, ['new']);
+        await p.advance(600);
+        assert.deepEqual(p.displayed, [{ src: 'new', at: 10 }]);
+        assert.ok(p.peakActive() <= 4);
+    });
+
+    test(`${template}: history change bypasses the endpoint pause without leaving a second loop`, async () => {
+        const p = player(template, ['old']);
+        await p.advance(100);
+        p.changeHistory('1800');
+        p.respond(0, ['new']);
+        await p.advance(3020);
+        assert.deepEqual(p.displayed, [{ src: 'old', at: 0 }, { src: 'new', at: 100 }, { src: 'new', at: 3120 }]);
+    });
+
+    test(`${template}: only the latest history response wins and refresh uses one timer`, async () => {
+        const p = player(template, ['old']);
+        p.refresh();
+        await p.advance(10);
+        p.changeHistory('1800');
+        p.changeHistory('900');
+        assert.equal(p.requests.length, 3);
+        assert.ok(p.requests[0].aborted && p.requests[1].aborted);
+        p.respond(1, ['obsolete']);
+        p.respond(2, ['latest']);
+        p.respond(0, ['also-obsolete']);
+        await p.advance(999);
+        assert.equal(p.requests.length, 3);
+        assert.deepEqual(p.displayed, [{ src: 'old', at: 0 }, { src: 'latest', at: 10 }]);
+        await p.advance(1);
+        assert.equal(p.requests.length, 4);
+        assert.equal(p.requests[3].data.limit_s, '900');
+    });
+
+    test(`${template}: failed history request keeps playback and retries the selected history`, async () => {
+        const p = player(template, ['b', 'a']);
+        await p.advance(10);
+        p.changeHistory('1800');
+        p.requests[0].error({ status: 503 });
+        await p.advance(1000);
+        assert.deepEqual(p.displayed.map((frame) => frame.src), ['a', 'b']);
+        assert.equal(p.requests[1].data.limit_s, '1800');
+        p.respond(1, ['new']);
+        await p.advance(0);
+        assert.deepEqual(p.displayed.at(-1), { src: 'new', at: 1010 });
+    });
+
+    test(`${template}: empty selected history holds the last frame and resumes on refresh`, async () => {
+        const p = player(template, ['b', 'a']);
+        await p.advance(10);
+        p.changeHistory('1800');
+        p.respond(0, []);
+        await p.advance(1000);
+        assert.deepEqual(p.displayed, [{ src: 'a', at: 0 }]);
+        p.respond(1, ['new']);
+        await p.advance(100);
+        assert.deepEqual(p.displayed.at(-1), { src: 'new', at: 1110 });
+    });
+
+    test(`${template}: waits for an empty list and supports browsers without decode`, async () => {
+        const p = player(template, [], { noDecode: true });
+        await p.advance(50);
+        assert.deepEqual(p.requested, []);
+        p.context.json_data.image_list = [{ url: 'a' }];
+        await p.advance(70);
+        assert.deepEqual(p.displayed, [{ src: 'a', at: 100 }]);
+        await p.completion;
+    });
+}
+
+test('canvas only resizes when needed and clears each frame', async () => {
+    const p = player('loop_canvas.html', ['c', 'b', 'a']);
+    await p.advance(20);
+    assert.deepEqual(p.resized, ['width', 'height']);
+    assert.equal(p.cleared.length, 2);
+    p.context.window.innerWidth = 1000;
+    await p.advance(40);
+    assert.deepEqual(p.resized, ['width', 'height', 'width', 'height']);
+    assert.deepEqual(p.cleared.at(-1), [0, 0, 1000, 600]);
+    await p.completion;
+});


### PR DESCRIPTION
Normal and panorama loops, including both mini-timelapse previews, currently load each image independently and display it as soon as loading finishes. On slower connections or at higher frame rates, images can arrive out of order, causing playback to jump backward and forward or display several frames in quick succession. In panorama mini-timelapse previews, this can also make the animated pan jump backward. Loop history changes also wait for the scheduled refresh and the current playback pass to finish.

This change:
- Preloads and decodes a bounded four-frame buffer, presenting frames in playback order and holding the current image while the next frame loads.
- Skips failed or timed-out images and prevents late completions from interrupting playback.
- Requests loop data immediately when the timespan changes and restarts playback when the new list arrives.
- Cancels obsolete loop requests and pending frames, including mini-timelapse frames when the selected period or source changes.
- Avoids resizing the loop canvas on every frame when its dimensions have not changed.
- Adds links between the normal and panorama loop players.

FPS controls, Rock behavior in the loop players, mini-timelapse cropping and animated pans, and the existing three-second end pause are preserved.

Validation: all 260 pytest tests pass, including the entry points for 51 JavaScript playback checks (29 loop and 22 mini-timelapse preview checks). The preview checks cover slow and out-of-order loads, decoding, failures, timeouts, selection changes, and panorama crop and pan behavior. Loop playback and history changes were also verified in the browser.
