### PR TITLE
Fix: FITS viewer for remote and S3 images on web-only instances

### DIFF
--- a/indi_allsky/flask/forms.py
+++ b/indi_allsky/flask/forms.py
@@ -7387,7 +7387,9 @@ class IndiAllskyFitsImageViewer(FlaskForm):
     def __init__(self, *args, **kwargs):
         super(IndiAllskyFitsImageViewer, self).__init__(*args, **kwargs)
 
+        self.s3_prefix = kwargs.get('s3_prefix', '')
         self.camera_id = kwargs.get('camera_id')
+        self.local = kwargs.get('local', True)
 
 
     def getYears(self):
@@ -7395,6 +7397,17 @@ class IndiAllskyFitsImageViewer(FlaskForm):
             self.model.createDate_year,
         )\
             .filter(self.model.camera_id == self.camera_id)
+
+
+        if not self.local:
+            # Do not serve local assets
+            years_query = years_query\
+                .filter(
+                    or_(
+                        self.model.remote_url != sa_null(),
+                        self.model.s3_key != sa_null(),
+                    )
+                )
 
 
         years_query = years_query\
@@ -7423,7 +7436,18 @@ class IndiAllskyFitsImageViewer(FlaskForm):
                     self.model.camera_id == self.camera_id,
                     self.model.createDate_year == year,
                 )
-        )
+            )
+
+
+        if not self.local:
+            # Do not serve local assets
+            months_query = months_query\
+                .filter(
+                    or_(
+                        self.model.remote_url != sa_null(),
+                        self.model.s3_key != sa_null(),
+                    )
+                )
 
 
         months_query = months_query\
@@ -7454,7 +7478,18 @@ class IndiAllskyFitsImageViewer(FlaskForm):
                     self.model.createDate_year == year,
                     self.model.createDate_month == month,
                 )
-        )
+            )
+
+
+        if not self.local:
+            # Do not serve local assets
+            days_query = days_query\
+                .filter(
+                    or_(
+                        self.model.remote_url != sa_null(),
+                        self.model.s3_key != sa_null(),
+                    )
+                )
 
 
         days_query = days_query\
@@ -7485,7 +7520,18 @@ class IndiAllskyFitsImageViewer(FlaskForm):
                     self.model.createDate_month == month,
                     self.model.createDate_day == day,
                 )
-        )
+            )
+
+
+        if not self.local:
+            # Do not serve local assets
+            hours_query = hours_query\
+                .filter(
+                    or_(
+                        self.model.remote_url != sa_null(),
+                        self.model.s3_key != sa_null(),
+                    )
+                )
 
 
         hours_query = hours_query\
@@ -7514,7 +7560,18 @@ class IndiAllskyFitsImageViewer(FlaskForm):
                     self.model.createDate_day == day,
                     self.model.createDate_hour == hour,
                 )
-        )
+            )
+
+
+        if not self.local:
+            # Do not serve local assets
+            images_query = images_query\
+                .filter(
+                    or_(
+                        self.model.remote_url != sa_null(),
+                        self.model.s3_key != sa_null(),
+                    )
+                )
 
 
         images_query = images_query\
@@ -7540,7 +7597,11 @@ class IndiAllskyFitsImageViewer(FlaskForm):
                     role_names,
                 )
 
-            fits_url = img.getUrl(local=True)
+            try:
+                fits_url = img.getUrl(s3_prefix=self.s3_prefix, local=self.local)
+            except ValueError as e:
+                app.logger.error('Error determining relative file name: %s', str(e))
+                continue
 
             image_dict = dict()
             image_dict['id'] = img.id
@@ -7566,7 +7627,18 @@ class IndiAllskyFitsImageViewerPreload(IndiAllskyFitsImageViewer):
         last_fits_image = db.session.query(
             self.model,
         )\
-            .filter(self.model.camera_id == self.camera_id)\
+            .filter(self.model.camera_id == self.camera_id)
+
+        if not self.local:
+            last_fits_image = last_fits_image\
+                .filter(
+                    or_(
+                        self.model.remote_url != sa_null(),
+                        self.model.s3_key != sa_null(),
+                    )
+                )
+
+        last_fits_image = last_fits_image\
             .order_by(self.model.createDate.desc())\
             .first()
 

--- a/indi_allsky/flask/models.py
+++ b/indi_allsky/flask/models.py
@@ -157,12 +157,87 @@ class IndiAllSkyDbFileBase(db.Model):
             if self.remote_url:
                 return self.remote_url
             elif self.s3_key:
-                return '{0:s}/{1:s}'.format(str(s3_prefix), self.s3_key)
+                prefix = str(s3_prefix).rstrip('/')
+                key = str(self.s3_key).lstrip('/')
+                return '{0:s}/{1:s}'.format(prefix, key)
 
 
-        rel_filename_p = self.getRelativePath()
+        try:
+            rel_filename_p = self.getRelativePath()
+            return Path('images').joinpath(rel_filename_p)
+        except ValueError:
+            return Path(self.filename)
 
-        return Path('images').joinpath(rel_filename_p)
+
+    def getLocalOrCachedPath(self, s3_prefix='', timeout=30.0):
+        try:
+            filename_p = self.getFilesystemPath()
+            if filename_p.is_file():
+                return filename_p
+        except Exception:
+            filename_p = Path(self.filename)
+
+        # If not on local filesystem, check for remote asset
+        if not s3_prefix and hasattr(self, 'camera') and self.camera and self.camera.s3_prefix:
+            s3_prefix = self.camera.s3_prefix
+
+        if self.remote_url:
+            remote_url = self.remote_url
+        elif s3_prefix and self.s3_key:
+            prefix = str(s3_prefix).rstrip('/')
+            key = str(self.s3_key).lstrip('/')
+            remote_url = '{0:s}/{1:s}'.format(prefix, key)
+        else:
+            return None
+
+        if not str(remote_url).startswith(('http://', 'https://')):
+            return None
+
+        import hashlib
+        import tempfile
+        import os
+        import time
+        import logging
+
+        remote_url_str = str(remote_url)
+        suffix = filename_p.suffix if filename_p.suffix else '.fit'
+
+        cache_dir = Path(tempfile.gettempdir()).joinpath('indi_allsky_cache')
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        url_hash = hashlib.sha256(remote_url_str.encode('utf-8')).hexdigest()
+        cached_path = cache_dir.joinpath(f"{url_hash}{suffix}")
+
+        if cached_path.is_file() and cached_path.stat().st_size > 0:
+            return cached_path
+
+        temp_path = cached_path.with_suffix(f".tmp_{os.getpid()}_{time.time_ns()}")
+        try:
+            import requests
+            with requests.get(remote_url_str, stream=True, timeout=timeout) as r:
+                r.raise_for_status()
+                with open(temp_path, 'wb') as f:
+                    for chunk in r.iter_content(chunk_size=65536):
+                        if chunk:
+                            f.write(chunk)
+
+            temp_path.replace(cached_path)
+            return cached_path
+        except Exception as e:
+            if temp_path.exists():
+                try:
+                    temp_path.unlink()
+                except OSError:
+                    pass
+
+            logger = logging.getLogger('indi_allsky')
+            try:
+                if app:
+                    logger = app.logger
+            except Exception:
+                pass
+            logger.error('Failed to download remote file from %s: %s', remote_url_str, str(e))
+            return None
 
 
     def getFilesystemPath(self):

--- a/indi_allsky/flask/static/css/dist.css
+++ b/indi_allsky/flask/static/css/dist.css
@@ -19,6 +19,7 @@
     --tw-container-lg: 32rem;
     --tw-container-xl: 36rem;
     --tw-container-2xl: 42rem;
+    --tw-container-3xl: 48rem;
     --tw-container-4xl: 56rem;
     --tw-container-5xl: 64rem;
     --tw-text-xs: 0.75rem;
@@ -35,8 +36,6 @@
     --tw-text-2xl--line-height: calc(2 / 1.5);
     --tw-text-3xl: 1.875rem;
     --tw-text-3xl--line-height: calc(2.25 / 1.875);
-    --tw-text-4xl: 2.25rem;
-    --tw-text-4xl--line-height: calc(2.5 / 2.25);
     --tw-font-weight-medium: 500;
     --tw-font-weight-semibold: 600;
     --tw-font-weight-bold: 700;
@@ -2748,6 +2747,9 @@
   .tw\:top-1\/2 {
     top: calc(1 / 2 * 100%);
   }
+  .tw\:top-2 {
+    top: calc(var(--tw-spacing) * 2);
+  }
   .tw\:top-4 {
     top: calc(var(--tw-spacing) * 4);
   }
@@ -2769,8 +2771,8 @@
   .tw\:left-0 {
     left: 0px;
   }
-  .tw\:left-1\/2 {
-    left: calc(1 / 2 * 100%);
+  .tw\:left-2 {
+    left: calc(var(--tw-spacing) * 2);
   }
   .tw\:left-3\.5 {
     left: calc(var(--tw-spacing) * 3.5);
@@ -3797,6 +3799,9 @@
   .tw\:ml-0\.5 {
     margin-left: calc(var(--tw-spacing) * 0.5);
   }
+  .tw\:ml-1 {
+    margin-left: var(--tw-spacing);
+  }
   .tw\:ml-2 {
     margin-left: calc(var(--tw-spacing) * 2);
   }
@@ -4101,19 +4106,6 @@
     mask-size: 100% 100%;
     --svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cg fill='none' stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'%3E%3Cpath d='M12 15V3m9 12v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4'/%3E%3Cpath d='m7 10l5 5l5-5'/%3E%3C/g%3E%3C/svg%3E");
   }
-  .tw\:icon-\[lucide--edit\] {
-    display: inline-block;
-    width: 1em;
-    height: 1em;
-    background-color: currentColor;
-    -webkit-mask-image: var(--svg);
-    mask-image: var(--svg);
-    -webkit-mask-repeat: no-repeat;
-    mask-repeat: no-repeat;
-    -webkit-mask-size: 100% 100%;
-    mask-size: 100% 100%;
-    --svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cg fill='none' stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'%3E%3Cpath d='M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7'/%3E%3Cpath d='M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z'/%3E%3C/g%3E%3C/svg%3E");
-  }
   .tw\:icon-\[lucide--external-link\] {
     display: inline-block;
     width: 1em;
@@ -4309,6 +4301,19 @@
     mask-size: 100% 100%;
     --svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cg fill='none' stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'%3E%3Cpath d='M16 10h2m-2 4h2M6.17 15a3 3 0 0 1 5.66 0'/%3E%3Ccircle cx='9' cy='11' r='2'/%3E%3Crect width='20' height='14' x='2' y='5' rx='2'/%3E%3C/g%3E%3C/svg%3E");
   }
+  .tw\:icon-\[lucide--image-off\] {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    background-color: currentColor;
+    -webkit-mask-image: var(--svg);
+    mask-image: var(--svg);
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: 100% 100%;
+    mask-size: 100% 100%;
+    --svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cg fill='none' stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'%3E%3Cpath d='m2 2l20 20M10.41 10.41a2 2 0 1 1-2.83-2.83m5.92 5.92L6 21m12-9l3 3'/%3E%3Cpath d='M3.59 3.59A2 2 0 0 0 3 5v14a2 2 0 0 0 2 2h14c.55 0 1.052-.22 1.41-.59M21 15V5a2 2 0 0 0-2-2H9'/%3E%3C/g%3E%3C/svg%3E");
+  }
   .tw\:icon-\[lucide--image\] {
     display: inline-block;
     width: 1em;
@@ -4399,19 +4404,6 @@
     -webkit-mask-size: 100% 100%;
     mask-size: 100% 100%;
     --svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cg fill='none' stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'%3E%3Cpath d='M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z'/%3E%3Cpath d='M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12'/%3E%3Cpath d='M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17'/%3E%3C/g%3E%3C/svg%3E");
-  }
-  .tw\:icon-\[lucide--layout\] {
-    display: inline-block;
-    width: 1em;
-    height: 1em;
-    background-color: currentColor;
-    -webkit-mask-image: var(--svg);
-    mask-image: var(--svg);
-    -webkit-mask-repeat: no-repeat;
-    mask-repeat: no-repeat;
-    -webkit-mask-size: 100% 100%;
-    mask-size: 100% 100%;
-    --svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cg fill='none' stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'%3E%3Crect width='18' height='18' x='3' y='3' rx='2'/%3E%3Cpath d='M3 9h18M9 21V9'/%3E%3C/g%3E%3C/svg%3E");
   }
   .tw\:icon-\[lucide--library\] {
     display: inline-block;
@@ -4646,19 +4638,6 @@
     -webkit-mask-size: 100% 100%;
     mask-size: 100% 100%;
     --svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath fill='none' stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M12 2v10m6.4-5.4a9 9 0 1 1-12.77.04'/%3E%3C/svg%3E");
-  }
-  .tw\:icon-\[lucide--printer\] {
-    display: inline-block;
-    width: 1em;
-    height: 1em;
-    background-color: currentColor;
-    -webkit-mask-image: var(--svg);
-    mask-image: var(--svg);
-    -webkit-mask-repeat: no-repeat;
-    mask-repeat: no-repeat;
-    -webkit-mask-size: 100% 100%;
-    mask-size: 100% 100%;
-    --svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cg fill='none' stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='2'%3E%3Cpath d='M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2M6 9V3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v6'/%3E%3Crect width='12' height='8' x='6' y='14' rx='1'/%3E%3C/g%3E%3C/svg%3E");
   }
   .tw\:icon-\[lucide--radio\] {
     display: inline-block;
@@ -5300,9 +5279,6 @@
   .tw\:min-h-\[70vh\] {
     min-height: 70vh;
   }
-  .tw\:min-h-\[350px\] {
-    min-height: 350px;
-  }
   .tw\:min-h-full {
     min-height: 100%;
   }
@@ -5341,9 +5317,6 @@
   .tw\:w-6 {
     width: calc(var(--tw-spacing) * 6);
   }
-  .tw\:w-7 {
-    width: calc(var(--tw-spacing) * 7);
-  }
   .tw\:w-8 {
     width: calc(var(--tw-spacing) * 8);
   }
@@ -5362,17 +5335,11 @@
   .tw\:w-32 {
     width: calc(var(--tw-spacing) * 32);
   }
-  .tw\:w-36 {
-    width: calc(var(--tw-spacing) * 36);
-  }
   .tw\:w-44 {
     width: calc(var(--tw-spacing) * 44);
   }
   .tw\:w-48 {
     width: calc(var(--tw-spacing) * 48);
-  }
-  .tw\:w-80 {
-    width: calc(var(--tw-spacing) * 80);
   }
   .tw\:w-\[1px\] {
     width: 1px;
@@ -5391,6 +5358,9 @@
   }
   .tw\:max-w-2xl {
     max-width: var(--tw-container-2xl);
+  }
+  .tw\:max-w-3xl {
+    max-width: var(--tw-container-3xl);
   }
   .tw\:max-w-4xl {
     max-width: var(--tw-container-4xl);
@@ -5437,10 +5407,6 @@
   .tw\:grow {
     flex-grow: 1;
   }
-  .tw\:-translate-x-1\/2 {
-    --tw-translate-x: calc(calc(1 / 2 * 100%) * -1);
-    translate: var(--tw-translate-x) var(--tw-translate-y);
-  }
   .tw\:-translate-y-1\/2 {
     --tw-translate-y: calc(calc(1 / 2 * 100%) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
@@ -5471,6 +5437,9 @@
       outline-offset: 2px;
     }
   }
+  .tw\:cursor-move {
+    cursor: move;
+  }
   .tw\:cursor-not-allowed {
     cursor: not-allowed;
   }
@@ -5482,6 +5451,9 @@
   }
   .tw\:resize-none {
     resize: none;
+  }
+  .tw\:list-disc {
+    list-style-type: disc;
   }
   .tw\:list-none {
     list-style-type: none;
@@ -5593,8 +5565,10 @@
   .tw\:gap-8 {
     gap: calc(var(--tw-spacing) * 8);
   }
-  .tw\:gap-12 {
-    gap: calc(var(--tw-spacing) * 12);
+  :where(.tw\:space-y-1 > :not(:last-child)) {
+    --tw-space-y-reverse: 0;
+    margin-block-start: calc(var(--tw-spacing) * var(--tw-space-y-reverse));
+    margin-block-end: calc(var(--tw-spacing) * calc(1 - var(--tw-space-y-reverse)));
   }
   :where(.tw\:space-y-1\.5 > :not(:last-child)) {
     --tw-space-y-reverse: 0;
@@ -5652,6 +5626,9 @@
   }
   .tw\:self-center {
     align-self: center;
+  }
+  .tw\:self-start {
+    align-self: flex-start;
   }
   .tw\:truncate {
     overflow: hidden;
@@ -5925,6 +5902,12 @@
       background-color: color-mix(in oklab, var(--color-base-200) 35%, transparent);
     }
   }
+  .tw\:bg-base-200\/40 {
+    background-color: var(--color-base-200);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-base-200) 40%, transparent);
+    }
+  }
   .tw\:bg-base-200\/50 {
     background-color: var(--color-base-200);
     @supports (color: color-mix(in lab, red, red)) {
@@ -6117,10 +6100,6 @@
       background-color: color-mix(in oklab, var(--color-warning) 20%, transparent);
     }
   }
-  .tw\:bg-gradient-to-r {
-    --tw-gradient-position: to right in oklab;
-    background-image: linear-gradient(var(--tw-gradient-stops));
-  }
   @layer daisyui.l1.l2.l3 {
     .tw\:btn-outline {
       --btn-bg: #0000;
@@ -6140,14 +6119,6 @@
       --btn-shadow: 0 0 0 0 oklch(0% 0 0/0);
     }
   }
-  .tw\:from-primary {
-    --tw-gradient-from: var(--color-primary);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
-  }
-  .tw\:to-secondary {
-    --tw-gradient-to: var(--color-secondary);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
-  }
   @layer daisyui.l1.l2 {
     .tw\:loading-spinner {
       mask-image: url("data:image/svg+xml,%3Csvg width='24' height='24' stroke='black' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cg transform-origin='center'%3E%3Ccircle cx='12' cy='12' r='9.5' fill='none' stroke-width='3' stroke-linecap='round'%3E%3CanimateTransform attributeName='transform' type='rotate' from='0 12 12' to='360 12 12' dur='8s' repeatCount='indefinite'/%3E%3Canimate attributeName='stroke-dasharray' values='0,150;42,150;42,150' keyTimes='0;0.475;1' dur='6s' repeatCount='indefinite'/%3E%3Canimate attributeName='stroke-dashoffset' values='0;-16;-59' keyTimes='0;0.475;1' dur='6s' repeatCount='indefinite'/%3E%3C/circle%3E%3C/g%3E%3C/svg%3E");
@@ -6157,9 +6128,6 @@
         mask-image: url("data:image/svg+xml,%3Csvg width='24' height='24' stroke='black' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cg transform-origin='center'%3E%3Ccircle cx='12' cy='12' r='9.5' fill='none' stroke-width='3' stroke-linecap='round'%3E%3CanimateTransform attributeName='transform' type='rotate' from='0 12 12' to='360 12 12' dur='2s' repeatCount='indefinite'/%3E%3Canimate attributeName='stroke-dasharray' values='0,150;42,150;42,150' keyTimes='0;0.475;1' dur='1.5s' repeatCount='indefinite'/%3E%3Canimate attributeName='stroke-dashoffset' values='0;-16;-59' keyTimes='0;0.475;1' dur='1.5s' repeatCount='indefinite'/%3E%3C/circle%3E%3C/g%3E%3C/svg%3E");
       }
     }
-  }
-  .tw\:bg-clip-text {
-    background-clip: text;
   }
   .tw\:object-contain {
     object-fit: contain;
@@ -6303,9 +6271,6 @@
   .tw\:pt-6 {
     padding-top: calc(var(--tw-spacing) * 6);
   }
-  .tw\:pt-8 {
-    padding-top: calc(var(--tw-spacing) * 8);
-  }
   .tw\:pr-4 {
     padding-right: calc(var(--tw-spacing) * 4);
   }
@@ -6368,10 +6333,6 @@
     font-size: var(--tw-text-3xl);
     line-height: var(--tw-leading, var(--tw-text-3xl--line-height));
   }
-  .tw\:text-4xl {
-    font-size: var(--tw-text-4xl);
-    line-height: var(--tw-leading, var(--tw-text-4xl--line-height));
-  }
   .tw\:text-base {
     font-size: var(--tw-text-base);
     line-height: var(--tw-leading, var(--tw-text-base--line-height));
@@ -6405,17 +6366,11 @@
   .tw\:text-\[0\.5rem\] {
     font-size: 0.5rem;
   }
-  .tw\:text-\[0\.75rem\] {
-    font-size: 0.75rem;
-  }
   .tw\:text-\[0\.563rem\] {
     font-size: 0.563rem;
   }
   .tw\:text-\[0\.625rem\] {
     font-size: 0.625rem;
-  }
-  .tw\:text-\[0\.781rem\] {
-    font-size: 0.781rem;
   }
   .tw\:text-\[0\.875rem\] {
     font-size: 0.875rem;
@@ -6425,9 +6380,6 @@
   }
   .tw\:text-\[0\.6875rem\] {
     font-size: 0.6875rem;
-  }
-  .tw\:text-\[10px\] {
-    font-size: 10px;
   }
   .tw\:leading-relaxed {
     --tw-leading: var(--tw-leading-relaxed);
@@ -6568,9 +6520,6 @@
       color: var(--color-primary);
       --range-thumb: var(--color-primary-content);
     }
-    .tw\:progress-primary {
-      color: var(--color-primary);
-    }
     .tw\:progress-warning {
       color: var(--color-warning);
     }
@@ -6682,9 +6631,6 @@
   }
   .tw\:text-success-content {
     color: var(--color-success-content);
-  }
-  .tw\:text-transparent {
-    color: transparent;
   }
   .tw\:text-warning {
     color: var(--color-warning);
@@ -7095,6 +7041,9 @@
       border-color: color-mix(in oklab, var(--color-base-content) 20%, transparent);
     }
   }
+  .tw\:focus\:border-primary:focus {
+    border-color: var(--color-primary);
+  }
   .tw\:focus\:outline-none:focus {
     --tw-outline-style: none;
     outline-style: none;
@@ -7102,6 +7051,9 @@
   @media (width >= 40rem) {
     .tw\:sm\:grid-cols-2 {
       grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    .tw\:sm\:grid-cols-3 {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
     .tw\:sm\:grid-cols-\[10rem_1fr\] {
       grid-template-columns: 10rem 1fr;
@@ -8842,48 +8794,6 @@ calendar-select-month::part(option):disabled, calendar-select-year::part(option)
   inherits: false;
   initial-value: solid;
 }
-@property --tw-gradient-position {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-gradient-from {
-  syntax: "<color>";
-  inherits: false;
-  initial-value: #0000;
-}
-@property --tw-gradient-via {
-  syntax: "<color>";
-  inherits: false;
-  initial-value: #0000;
-}
-@property --tw-gradient-to {
-  syntax: "<color>";
-  inherits: false;
-  initial-value: #0000;
-}
-@property --tw-gradient-stops {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-gradient-via-stops {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-gradient-from-position {
-  syntax: "<length-percentage>";
-  inherits: false;
-  initial-value: 0%;
-}
-@property --tw-gradient-via-position {
-  syntax: "<length-percentage>";
-  inherits: false;
-  initial-value: 50%;
-}
-@property --tw-gradient-to-position {
-  syntax: "<length-percentage>";
-  inherits: false;
-  initial-value: 100%;
-}
 @property --tw-leading {
   syntax: "*";
   inherits: false;
@@ -9073,15 +8983,6 @@ calendar-select-month::part(option):disabled, calendar-select-year::part(option)
       --tw-space-y-reverse: 0;
       --tw-divide-y-reverse: 0;
       --tw-border-style: solid;
-      --tw-gradient-position: initial;
-      --tw-gradient-from: #0000;
-      --tw-gradient-via: #0000;
-      --tw-gradient-to: #0000;
-      --tw-gradient-stops: initial;
-      --tw-gradient-via-stops: initial;
-      --tw-gradient-from-position: 0%;
-      --tw-gradient-via-position: 50%;
-      --tw-gradient-to-position: 100%;
       --tw-leading: initial;
       --tw-font-weight: initial;
       --tw-tracking: initial;

--- a/indi_allsky/flask/views.py
+++ b/indi_allsky/flask/views.py
@@ -4847,9 +4847,19 @@ class FitsImageViewerView(FormView):
         }
 
 
+        local = True  # default to local assets
+        if self.web_nonlocal_images:
+            if self.web_local_images_admin and self.verify_admin_network():
+                pass
+            else:
+                local = False
+
+
         context['form_fits_viewer'] = IndiAllskyFitsImageViewerPreload(
             data=form_data,
             camera_id=self.camera.id,
+            s3_prefix=self.s3_prefix,
+            local=local,
         )
 
         return context
@@ -4873,9 +4883,19 @@ class AjaxFitsImageViewerView(BaseView):
         self.cameraSetup(camera_id=camera_id)
 
 
+        local = True  # default to local assets
+        if self.web_nonlocal_images:
+            if self.web_local_images_admin and self.verify_admin_network():
+                pass
+            else:
+                local = False
+
+
         form_viewer = IndiAllskyFitsImageViewer(
             data=request.json,
             camera_id=camera_id,
+            s3_prefix=self.s3_prefix,
+            local=local,
         )
 
 
@@ -5018,13 +5038,24 @@ class Fits2JpegView(BaseView):
         self.cameraSetup(camera_id=fits_entry.camera_id)
 
 
-        filename_p = Path(fits_entry.getFilesystemPath())
+        try:
+            filename_p = fits_entry.getLocalOrCachedPath(s3_prefix=self.s3_prefix)
+        except Exception as e:
+            app.logger.error('Error resolving FITS file: %s', str(e))
+            filename_p = None
+
+        if not filename_p or not filename_p.is_file():
+            return 'FITS not found', 404
 
 
         p_config = self.indi_allsky_config.copy()
 
 
-        hdulist = fits.open(filename_p)
+        try:
+            hdulist = fits.open(filename_p)
+        except OSError as e:
+            app.logger.error('Failed to open FITS file %s: %s', filename_p, str(e))
+            return 'Bad FITS file', 500
 
         exposure = float(hdulist[0].header.get('EXPTIME', 0))
         exposure_av = Array(ctypes.c_int32, [int(exposure * 1000000)])
@@ -5056,8 +5087,8 @@ class Fits2JpegView(BaseView):
         processing_start = time.time()
 
 
-        # use mtime for date
-        image_date = datetime.fromtimestamp(filename_p.stat().st_mtime)
+        # use createDate for date
+        image_date = fits_entry.createDate or datetime.fromtimestamp(filename_p.stat().st_mtime)
 
 
         image_processor.update_astrometric_data(image_date)
@@ -9387,11 +9418,19 @@ class JsonImageProcessingView(JsonView):
                 'processing_elapsed_s' : 0.0,
                 'message' : 'No FITS images found',
             }
-            return jsonify(json_data)
+        try:
+            filename_p = fits_entry.getLocalOrCachedPath(s3_prefix=self.s3_prefix)
+        except Exception as e:
+            app.logger.error('Error resolving FITS file: %s', str(e))
+            filename_p = None
 
-
-
-        filename_p = Path(fits_entry.getFilesystemPath())
+        if not filename_p or not filename_p.is_file():
+            json_data = {
+                'image_b64' : None,
+                'processing_elapsed_s' : 0.0,
+                'message' : 'FITS file not found',
+            }
+            return jsonify(json_data), 404
 
 
         p_config = self.indi_allsky_config.copy()
@@ -9583,7 +9622,16 @@ class JsonImageProcessingView(JsonView):
         p_config['LIGHTGRAPH_OVERLAY']['FONT_COLOR'] = [int(x) for x in lightgraph_overlay__font_color_str.split(',')]
 
 
-        hdulist = fits.open(filename_p)
+        try:
+            hdulist = fits.open(filename_p)
+        except OSError as e:
+            app.logger.error('Failed to open FITS file %s: %s', filename_p, str(e))
+            json_data = {
+                'image_b64' : None,
+                'processing_elapsed_s' : 0.0,
+                'message' : 'Bad FITS file',
+            }
+            return jsonify(json_data), 500
 
         exposure = float(hdulist[0].header.get('EXPTIME', 0))
         exposure_av = Array(ctypes.c_int32, [int(exposure * 1000000)])
@@ -9622,8 +9670,8 @@ class JsonImageProcessingView(JsonView):
         if disable_processing:
             # just return original image with no processing
 
-            # use mtime for date
-            image_date = datetime.fromtimestamp(filename_p.stat().st_mtime)
+            # use createDate for date
+            image_date = fits_entry.createDate or datetime.fromtimestamp(filename_p.stat().st_mtime)
 
             image_processor.add(
                 filename_p,
@@ -9669,12 +9717,22 @@ class JsonImageProcessingView(JsonView):
                     .limit(p_config['IMAGE_STACK_COUNT'] - 1)
 
                 for f_image in fits_image_query:
-                    f_image_p = f_image.getFilesystemPath()
+                    try:
+                        f_image_p = f_image.getLocalOrCachedPath(s3_prefix=self.s3_prefix)
+                    except Exception as e:
+                        app.logger.error('Error resolving stacked FITS file: %s', str(e))
+                        f_image_p = None
 
-                    # use mtime for date
-                    pre_image_date = datetime.fromtimestamp(f_image_p.stat().st_mtime)
+                    if not f_image_p or not f_image_p.is_file():
+                        continue
 
-                    alt_hdulist = fits.open(f_image_p)
+                    # use createDate for date
+                    pre_image_date = f_image.createDate or datetime.fromtimestamp(f_image_p.stat().st_mtime)
+
+                    try:
+                        alt_hdulist = fits.open(f_image_p)
+                    except OSError:
+                        continue
                     alt_exposure = float(alt_hdulist[0].header.get('EXPTIME', 0))
                     alt_gain = float(alt_hdulist[0].header.get('GAIN', 0))
                     alt_binning = int(alt_hdulist[0].header.get('XBINNING', 1))
@@ -9696,8 +9754,8 @@ class JsonImageProcessingView(JsonView):
                 message_list.append('Stacked {0:d} images'.format(p_config['IMAGE_STACK_COUNT']))
 
 
-            # use mtime for date
-            image_date = datetime.fromtimestamp(filename_p.stat().st_mtime)
+            # use createDate for date
+            image_date = fits_entry.createDate or datetime.fromtimestamp(filename_p.stat().st_mtime)
 
 
             image_processor.update_astrometric_data(image_date)

--- a/tests/flask/test_fits_viewer.py
+++ b/tests/flask/test_fits_viewer.py
@@ -1,0 +1,761 @@
+import os
+import tempfile
+import io
+from pathlib import Path
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+import pytest
+import requests
+from astropy.io import fits
+from passlib.hash import argon2
+
+from indi_allsky import constants
+from indi_allsky.config import IndiAllSkyConfigBase
+from indi_allsky.flask.forms import (
+    IndiAllskyFitsImageViewer,
+    IndiAllskyFitsImageViewerPreload,
+    IndiAllskyImageProcessingForm,
+)
+from indi_allsky.flask.models import (
+    IndiAllSkyDbCameraTable,
+    IndiAllSkyDbConfigTable,
+    IndiAllSkyDbUserTable,
+    IndiAllSkyDbFitsImageTable,
+)
+
+
+def _generate_dummy_fits_bytes(width=100, height=100):
+    """Generate in-memory FITS file bytes with standard headers."""
+    data = np.full((height, width), 500, dtype=np.uint16)
+    hdu = fits.PrimaryHDU(data)
+    hdu.header['EXPTIME'] = 1.0
+    hdu.header['GAIN'] = 100.0
+    hdu.header['XBINNING'] = 1
+    hdu.header['CCD-TEMP'] = 20.0
+    buf = io.BytesIO()
+    hdu.writeto(buf)
+    return buf.getvalue()
+
+
+@pytest.fixture
+def populated_fits_env(flask_app, db, tmp_path):
+    """Seed test database with camera, config, admin user, and dummy FITS files."""
+    with flask_app.app_context():
+        cfg = dict(IndiAllSkyConfigBase._base_config)
+        cfg['IMAGE_FOLDER'] = str(tmp_path / 'images')
+        cfg['VARLIB_FOLDER'] = str(tmp_path / 'varlib')
+        cfg['LOCATION_LATITUDE'] = -34.9285
+        cfg['LOCATION_LONGITUDE'] = 138.6007
+        cfg['LOCATION_ELEVATION'] = 50
+        cfg['NIGHT_SUN_ALT_DEG'] = -6.0
+        cfg['CAMERA_INTERFACE'] = 'indi_simulator_ccd'
+
+        config_entry = IndiAllSkyDbConfigTable(
+            data=cfg,
+            level='1.0',
+            note='test',
+        )
+        db.session.add(config_entry)
+
+        camera = IndiAllSkyDbCameraTable(
+            name='main_camera',
+            uuid='cam-main-uuid-1',
+            driver='indi_simulator_ccd',
+            friendlyName='Main Camera',
+            latitude=-34.9285,
+            longitude=138.6007,
+            elevation=50,
+            nightSunAlt=-6.0,
+            lensFocalLength=2.5,
+            lensFocalRatio=1.4,
+            lensImageCircle=1000,
+            width=100,
+            height=100,
+            pixelSize=2.9,
+            cfa=constants.CFA_RGGB,
+            owner='Admin',
+            local=True,
+            minExposure=0.0001,
+            maxExposure=60.0,
+            minGain=0,
+            maxGain=100,
+            minBinning=1,
+            maxBinning=4,
+            s3_prefix='https://mybucket.s3.amazonaws.com/allsky',
+            web_nonlocal_images=False,
+        )
+        db.session.add(camera)
+
+        admin_user = IndiAllSkyDbUserTable(
+            username='admin',
+            password=argon2.hash('AdminPassword123!'),
+            email='admin@example.org',
+            name='Admin User',
+            active=True,
+            admin=True,
+            staff=True,
+        )
+        db.session.add(admin_user)
+        db.session.commit()
+        yield
+
+
+@pytest.fixture
+def auth_client(flask_app, populated_fits_env):
+    """Provide an authenticated test client logged in as admin."""
+    client = flask_app.test_client()
+    res = client.post(
+        '/indi-allsky/login',
+        json={'USERNAME': 'admin', 'PASSWORD': 'AdminPassword123!', 'NEXT': ''},
+    )
+    assert res.status_code == 200
+    return client
+
+
+# ==============================================================================
+# Model Tests: IndiAllSkyDbFileBase / IndiAllSkyDbFitsImageTable
+# ==============================================================================
+
+def test_get_url_local(flask_app, db):
+    """Test getUrl() with local=True returns relative local URL."""
+    with flask_app.app_context():
+        fits_img = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename='/var/www/html/allsky/images/20260908/fits/test.fit',
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+            dayDate=datetime(2026, 9, 8).date(),
+        )
+        db.session.add(fits_img)
+        db.session.commit()
+
+        local_url = fits_img.getUrl(local=True)
+        assert str(local_url) == 'images/20260908/fits/test.fit'
+
+
+def test_get_url_remote_url(flask_app, db):
+    """Test getUrl() with local=False returns remote_url when set."""
+    with flask_app.app_context():
+        fits_img = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename='/var/www/html/allsky/images/20260908/fits/test.fit',
+            remote_url='https://cdn.example.org/fits/test.fit',
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+            dayDate=datetime(2026, 9, 8).date(),
+        )
+        db.session.add(fits_img)
+        db.session.commit()
+
+        url = fits_img.getUrl(local=False)
+        assert url == 'https://cdn.example.org/fits/test.fit'
+
+
+@pytest.mark.parametrize(
+    'prefix, key, expected',
+    [
+        (
+            'https://s3.example.com/bucket',
+            'cam_1/fits/image.fits',
+            'https://s3.example.com/bucket/cam_1/fits/image.fits',
+        ),
+        (
+            'https://s3.example.com/bucket/',
+            'cam_1/fits/image.fits',
+            'https://s3.example.com/bucket/cam_1/fits/image.fits',
+        ),
+        (
+            'https://s3.example.com/bucket/',
+            '/cam_1/fits/image.fits',
+            'https://s3.example.com/bucket/cam_1/fits/image.fits',
+        ),
+        (
+            'https://s3.example.com/bucket',
+            '/cam_1/fits/image.fits',
+            'https://s3.example.com/bucket/cam_1/fits/image.fits',
+        ),
+    ],
+)
+def test_get_url_s3_prefix_and_key(flask_app, db, prefix, key, expected):
+    """Test getUrl() formats S3 URL properly and normalizes slashes."""
+    with flask_app.app_context():
+        fits_img = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename='/var/www/html/allsky/images/20260908/fits/test.fit',
+            s3_key=key,
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+            dayDate=datetime(2026, 9, 8).date(),
+        )
+        db.session.add(fits_img)
+        db.session.commit()
+
+        url = fits_img.getUrl(s3_prefix=prefix, local=False)
+        assert url == expected
+
+
+def test_get_url_nonlocal_fallback_to_local(flask_app, db):
+    """Test getUrl() falls back to local URL if local=False but no remote URL or S3 key exists."""
+    with flask_app.app_context():
+        fits_img = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename='/var/www/html/allsky/images/20260908/fits/test.fit',
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+            dayDate=datetime(2026, 9, 8).date(),
+        )
+        db.session.add(fits_img)
+        db.session.commit()
+
+        url = fits_img.getUrl(local=False)
+        assert str(url) == 'images/20260908/fits/test.fit'
+
+
+def test_get_local_or_cached_path_local_hit(flask_app, db, tmp_path):
+    """Test getLocalOrCachedPath returns Path to existing local file without remote request."""
+    local_file = tmp_path / 'test.fit'
+    local_file.write_bytes(b'DUMMY_FITS_DATA')
+
+    with flask_app.app_context():
+        fits_img = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename=str(local_file),
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+            dayDate=datetime(2026, 9, 8).date(),
+        )
+        db.session.add(fits_img)
+        db.session.commit()
+
+        with patch('requests.get') as mock_get:
+            result = fits_img.getLocalOrCachedPath()
+            assert result == local_file
+            mock_get.assert_not_called()
+
+
+def test_get_local_or_cached_path_remote_download_and_cache(flask_app, db):
+    """Test getLocalOrCachedPath downloads missing file from remote URL and caches it."""
+    dummy_fits_data = _generate_dummy_fits_bytes(50, 50)
+    remote_url = 'https://s3.example.com/allsky/cam_1/fits/image.fits'
+
+    with flask_app.app_context():
+        fits_img = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename='/nonexistent/local/path/image.fits',
+            remote_url=remote_url,
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+            dayDate=datetime(2026, 9, 8).date(),
+        )
+        db.session.add(fits_img)
+        db.session.commit()
+
+        # Mock streaming response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.__enter__.return_value = mock_response
+        mock_response.iter_content.return_value = [dummy_fits_data]
+        mock_response.raise_for_status = MagicMock()
+
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            cached_path = fits_img.getLocalOrCachedPath()
+
+            assert cached_path is not None
+            assert cached_path.is_file()
+            assert cached_path.name.endswith('.fits')
+            assert cached_path.read_bytes() == dummy_fits_data
+            mock_get.assert_called_once_with(remote_url, stream=True, timeout=30.0)
+
+            # Subsequent call should hit cache without calling requests.get again
+            mock_get.reset_mock()
+            second_path = fits_img.getLocalOrCachedPath()
+            assert second_path == cached_path
+            mock_get.assert_not_called()
+
+        if cached_path and cached_path.is_file():
+            cached_path.unlink()
+
+
+def test_get_local_or_cached_path_s3_key_fallback(flask_app, db):
+    """Test getLocalOrCachedPath downloads using s3_prefix + s3_key when remote_url is None."""
+    dummy_fits_data = _generate_dummy_fits_bytes(50, 50)
+    s3_prefix = 'https://mybucket.s3.amazonaws.com/allsky'
+    s3_key = 'cam_1/fits/20260908/image.fits'
+
+    with flask_app.app_context():
+        fits_img = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename='/nonexistent/local/path/image.fits',
+            s3_key=s3_key,
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+            dayDate=datetime(2026, 9, 8).date(),
+        )
+        db.session.add(fits_img)
+        db.session.commit()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.__enter__.return_value = mock_response
+        mock_response.iter_content.return_value = [dummy_fits_data]
+        mock_response.raise_for_status = MagicMock()
+
+        with patch('requests.get', return_value=mock_response) as mock_get:
+            cached_path = fits_img.getLocalOrCachedPath(s3_prefix=s3_prefix)
+
+            assert cached_path is not None
+            assert cached_path.is_file()
+            assert cached_path.read_bytes() == dummy_fits_data
+            mock_get.assert_called_once_with(
+                'https://mybucket.s3.amazonaws.com/allsky/cam_1/fits/20260908/image.fits',
+                stream=True,
+                timeout=30.0,
+            )
+
+        if cached_path and cached_path.is_file():
+            cached_path.unlink()
+
+
+def test_get_local_or_cached_path_remote_404_returns_none(flask_app, db):
+    """Test getLocalOrCachedPath returns None when remote download fails with 404."""
+    with flask_app.app_context():
+        fits_img = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename='/nonexistent/local/path/image.fits',
+            remote_url='https://s3.example.com/allsky/missing.fits',
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+            dayDate=datetime(2026, 9, 8).date(),
+        )
+        db.session.add(fits_img)
+        db.session.commit()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.__enter__.return_value = mock_response
+        mock_response.raise_for_status.side_effect = requests.HTTPError('404 Not Found')
+
+        with patch('requests.get', return_value=mock_response):
+            result = fits_img.getLocalOrCachedPath()
+            assert result is None
+
+
+def test_get_local_or_cached_path_connection_error_returns_none(flask_app, db):
+    """Test getLocalOrCachedPath returns None when connection fails."""
+    with flask_app.app_context():
+        fits_img = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename='/nonexistent/local/path/image.fits',
+            remote_url='https://s3.example.com/allsky/error.fits',
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+            dayDate=datetime(2026, 9, 8).date(),
+        )
+        db.session.add(fits_img)
+        db.session.commit()
+
+        with patch('requests.get', side_effect=requests.ConnectionError('Network unreachable')):
+            result = fits_img.getLocalOrCachedPath()
+            assert result is None
+
+
+def test_get_local_or_cached_path_no_sources_returns_none(flask_app, db):
+    """Test getLocalOrCachedPath returns None when local file is missing and no remote URL/key."""
+    with flask_app.app_context():
+        fits_img = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename='/nonexistent/local/path/image.fits',
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+            dayDate=datetime(2026, 9, 8).date(),
+        )
+        db.session.add(fits_img)
+        db.session.commit()
+
+        result = fits_img.getLocalOrCachedPath()
+        assert result is None
+
+
+# ==============================================================================
+# Form Tests: IndiAllskyFitsImageViewer & IndiAllskyFitsImageViewerPreload
+# ==============================================================================
+
+def test_fits_form_filters_local_vs_nonlocal(flask_app, db):
+    """Test IndiAllskyFitsImageViewer filters out local-only images when local=False."""
+    now = datetime(2026, 9, 8, 22, 15, 0, tzinfo=timezone.utc)
+
+    with flask_app.app_context():
+        # Image 1: local-only
+        img_local = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename='/var/www/html/allsky/images/20260908/fits/local_only.fit',
+            createDate=now,
+            createDate_year=now.year,
+            createDate_month=now.month,
+            createDate_day=now.day,
+            createDate_hour=now.hour,
+            dayDate=now.date(),
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+        )
+        # Image 2: S3 remote
+        img_remote = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename='/var/www/html/allsky/images/20260908/fits/remote_s3.fit',
+            s3_key='cam_1/fits/20260908/remote_s3.fit',
+            createDate=now,
+            createDate_year=now.year,
+            createDate_month=now.month,
+            createDate_day=now.day,
+            createDate_hour=now.hour,
+            dayDate=now.date(),
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+        )
+        db.session.add(img_local)
+        db.session.add(img_remote)
+        db.session.commit()
+
+    with flask_app.test_request_context():
+        # When local=True: both images returned, download links use local URLs
+        form_local = IndiAllskyFitsImageViewer(
+            camera_id=1,
+            local=True,
+            s3_prefix='https://mybucket.s3.amazonaws.com/allsky',
+        )
+        images_local = form_local.getImages(now.year, now.month, now.day, now.hour)
+        assert len(images_local) == 2
+        for item in images_local:
+            assert item['fits'].startswith('images/')
+
+        # When local=False: only S3 remote image returned, download link points to S3 URL
+        form_nonlocal = IndiAllskyFitsImageViewer(
+            camera_id=1,
+            local=False,
+            s3_prefix='https://mybucket.s3.amazonaws.com/allsky',
+        )
+        images_nonlocal = form_nonlocal.getImages(now.year, now.month, now.day, now.hour)
+        assert len(images_nonlocal) == 1
+        assert images_nonlocal[0]['fits'] == 'https://mybucket.s3.amazonaws.com/allsky/cam_1/fits/20260908/remote_s3.fit'
+
+
+def test_fits_preload_form_filtering(flask_app, db):
+    """Test IndiAllskyFitsImageViewerPreload filters out local-only records when local=False."""
+    now = datetime(2026, 9, 8, 22, 15, 0, tzinfo=timezone.utc)
+
+    with flask_app.app_context():
+        # Local-only image
+        img_local = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename='/var/www/html/allsky/images/20260908/fits/local_only.fit',
+            createDate=now,
+            createDate_year=now.year,
+            createDate_month=now.month,
+            createDate_day=now.day,
+            createDate_hour=now.hour,
+            dayDate=now.date(),
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+        )
+        db.session.add(img_local)
+        db.session.commit()
+
+    with flask_app.test_request_context():
+        # In non-local mode with only a local-only image, preload form has no choices
+        form_preload = IndiAllskyFitsImageViewerPreload(
+            camera_id=1,
+            local=False,
+            s3_prefix='https://mybucket.s3.amazonaws.com/allsky',
+        )
+        assert form_preload.YEAR_SELECT.choices == (('', 'None'),)
+
+        # In local mode, year choice is available
+        form_preload_local = IndiAllskyFitsImageViewerPreload(
+            camera_id=1,
+            local=True,
+            s3_prefix='https://mybucket.s3.amazonaws.com/allsky',
+        )
+        assert form_preload_local.YEAR_SELECT.choices == [(2026, '2026')]
+
+
+# ==============================================================================
+# View Tests: FitsImageViewerView, AjaxFitsImageViewerView, Fits2JpegView, JsonImageProcessingView
+# ==============================================================================
+
+def test_fits_viewer_page_renders(auth_client):
+    """Test GET /indi-allsky/fitsimageviewer renders 200 OK."""
+    response = auth_client.get('/indi-allsky/fitsimageviewer?camera_id=1')
+    assert response.status_code == 200
+    assert b'FITS' in response.data or b'fits' in response.data
+
+
+def test_ajax_fits_image_viewer_nonlocal_s3_url(auth_client, flask_app, db):
+    """Test Ajax endpoint returns S3 URLs in IMAGE_DATA when camera is configured for nonlocal images."""
+    now = datetime(2026, 9, 8, 22, 15, 0, tzinfo=timezone.utc)
+
+    with flask_app.app_context():
+        camera = db.session.get(IndiAllSkyDbCameraTable, 1)
+        camera.web_nonlocal_images = True
+        camera.s3_prefix = 'https://mybucket.s3.amazonaws.com/allsky'
+
+        fits_row = IndiAllSkyDbFitsImageTable(
+            camera_id=camera.id,
+            filename='/var/www/html/allsky/images/20260908/fits/test.fit',
+            s3_key='cam_1/fits/20260908/test.fit',
+            createDate=now,
+            createDate_year=now.year,
+            createDate_month=now.month,
+            createDate_day=now.day,
+            createDate_hour=now.hour,
+            dayDate=now.date(),
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+        )
+        db.session.add(fits_row)
+        db.session.commit()
+
+    ajax_payload = {
+        'CAMERA_ID': 1,
+        'YEAR_SELECT': 2026,
+        'MONTH_SELECT': 9,
+        'DAY_SELECT': 8,
+        'HOUR_SELECT': 22,
+    }
+    response = auth_client.post('/indi-allsky/ajax/fitsimageviewer', json=ajax_payload)
+    assert response.status_code == 200
+    data = response.get_json()
+
+    assert 'IMAGE_DATA' in data
+    assert len(data['IMAGE_DATA']) == 1
+    # Verify S3 URL is present in the fits key for download
+    assert data['IMAGE_DATA'][0]['fits'] == 'https://mybucket.s3.amazonaws.com/allsky/cam_1/fits/20260908/test.fit'
+    # Verify preview URL points to fits2jpeg endpoint
+    assert data['IMAGE_DATA'][0]['url'].startswith('/indi-allsky/fits2jpeg?id=')
+
+
+def test_ajax_fits_image_viewer_local_url(auth_client, flask_app, db):
+    """Test Ajax endpoint returns local URLs in IMAGE_DATA when camera has local images."""
+    now = datetime(2026, 9, 8, 22, 15, 0, tzinfo=timezone.utc)
+
+    with flask_app.app_context():
+        camera = db.session.get(IndiAllSkyDbCameraTable, 1)
+        camera.web_nonlocal_images = False
+
+        fits_row = IndiAllSkyDbFitsImageTable(
+            camera_id=camera.id,
+            filename='/var/www/html/allsky/images/20260908/fits/test_local.fit',
+            s3_key='cam_1/fits/20260908/test_local.fit',
+            createDate=now,
+            createDate_year=now.year,
+            createDate_month=now.month,
+            createDate_day=now.day,
+            createDate_hour=now.hour,
+            dayDate=now.date(),
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+        )
+        db.session.add(fits_row)
+        db.session.commit()
+
+    ajax_payload = {
+        'CAMERA_ID': 1,
+        'YEAR_SELECT': 2026,
+        'MONTH_SELECT': 9,
+        'DAY_SELECT': 8,
+        'HOUR_SELECT': 22,
+    }
+    response = auth_client.post('/indi-allsky/ajax/fitsimageviewer', json=ajax_payload)
+    assert response.status_code == 200
+    data = response.get_json()
+
+    assert 'IMAGE_DATA' in data
+    assert len(data['IMAGE_DATA']) == 1
+    assert data['IMAGE_DATA'][0]['fits'].startswith('images/')
+
+
+def test_fits2jpeg_local_file_success(auth_client, flask_app, db, tmp_path):
+    """Test GET /indi-allsky/fits2jpeg with existing local FITS file returns 200 image/jpeg."""
+    fits_file = tmp_path / 'test_local.fits'
+    fits_file.write_bytes(_generate_dummy_fits_bytes(100, 100))
+
+    now = datetime(2026, 9, 8, 22, 15, 0, tzinfo=timezone.utc)
+
+    with flask_app.app_context():
+        fits_row = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename=str(fits_file),
+            createDate=now,
+            createDate_year=now.year,
+            createDate_month=now.month,
+            createDate_day=now.day,
+            createDate_hour=now.hour,
+            dayDate=now.date(),
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+        )
+        db.session.add(fits_row)
+        db.session.commit()
+        fits_id = fits_row.id
+
+    response = auth_client.get(f'/indi-allsky/fits2jpeg?id={fits_id}')
+    assert response.status_code == 200
+    assert response.content_type == 'image/jpeg'
+    assert len(response.data) > 0
+
+
+def test_fits2jpeg_remote_download_cached_success(auth_client, flask_app, db):
+    """Test GET /indi-allsky/fits2jpeg downloads remote S3 file, caches it, and returns 200 image/jpeg."""
+    dummy_fits_data = _generate_dummy_fits_bytes(100, 100)
+    now = datetime(2026, 9, 8, 22, 15, 0, tzinfo=timezone.utc)
+
+    with flask_app.app_context():
+        camera = db.session.get(IndiAllSkyDbCameraTable, 1)
+        camera.s3_prefix = 'https://mybucket.s3.amazonaws.com/allsky'
+
+        fits_row = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename='/nonexistent/on/web_only/instance/remote.fits',
+            s3_key='cam_1/fits/20260908/remote.fits',
+            createDate=now,
+            createDate_year=now.year,
+            createDate_month=now.month,
+            createDate_day=now.day,
+            createDate_hour=now.hour,
+            dayDate=now.date(),
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+        )
+        db.session.add(fits_row)
+        db.session.commit()
+        fits_id = fits_row.id
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.__enter__.return_value = mock_response
+    mock_response.iter_content.return_value = [dummy_fits_data]
+    mock_response.raise_for_status = MagicMock()
+
+    with patch('requests.get', return_value=mock_response):
+        response = auth_client.get(f'/indi-allsky/fits2jpeg?id={fits_id}')
+        assert response.status_code == 200
+        assert response.content_type == 'image/jpeg'
+
+
+def test_fits2jpeg_file_not_found_returns_404(auth_client, flask_app, db):
+    """Test GET /indi-allsky/fits2jpeg returns 404 (not 500) when FITS cannot be found or downloaded."""
+    now = datetime(2026, 9, 8, 22, 15, 0, tzinfo=timezone.utc)
+
+    with flask_app.app_context():
+        fits_row = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename='/nonexistent/missing.fits',
+            remote_url='https://s3.example.com/missing.fits',
+            createDate=now,
+            createDate_year=now.year,
+            createDate_month=now.month,
+            createDate_day=now.day,
+            createDate_hour=now.hour,
+            dayDate=now.date(),
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+        )
+        db.session.add(fits_row)
+        db.session.commit()
+        fits_id = fits_row.id
+
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.__enter__.return_value = mock_response
+    mock_response.raise_for_status.side_effect = requests.HTTPError('404 Not Found')
+
+    with patch('requests.get', return_value=mock_response):
+        response = auth_client.get(f'/indi-allsky/fits2jpeg?id={fits_id}')
+        assert response.status_code == 404
+
+
+def test_fits2jpeg_corrupt_file_returns_500(auth_client, flask_app, db, tmp_path):
+    """Test GET /indi-allsky/fits2jpeg returns 500 when FITS file is corrupted."""
+    corrupt_file = tmp_path / 'corrupt.fits'
+    corrupt_file.write_bytes(b'NOT_A_VALID_FITS_FILE_HEADER')
+
+    now = datetime(2026, 9, 8, 22, 15, 0, tzinfo=timezone.utc)
+
+    with flask_app.app_context():
+        fits_row = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename=str(corrupt_file),
+            createDate=now,
+            createDate_year=now.year,
+            createDate_month=now.month,
+            createDate_day=now.day,
+            createDate_hour=now.hour,
+            dayDate=now.date(),
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+        )
+        db.session.add(fits_row)
+        db.session.commit()
+        fits_id = fits_row.id
+
+    response = auth_client.get(f'/indi-allsky/fits2jpeg?id={fits_id}')
+    assert response.status_code == 500
+    assert b'Bad FITS file' in response.data
+
+
+def test_json_image_processing_missing_file_returns_404(auth_client, flask_app, db):
+    """Test POST /indi-allsky/js/processing returns 404 when FITS file cannot be found."""
+    now = datetime(2026, 9, 8, 22, 15, 0, tzinfo=timezone.utc)
+
+    with flask_app.app_context():
+        fits_row = IndiAllSkyDbFitsImageTable(
+            camera_id=1,
+            filename='/nonexistent/missing_for_processing.fits',
+            createDate=now,
+            createDate_year=now.year,
+            createDate_month=now.month,
+            createDate_day=now.day,
+            createDate_hour=now.hour,
+            dayDate=now.date(),
+            exposure=1.0,
+            gain=100.0,
+            binmode=1,
+        )
+        db.session.add(fits_row)
+        db.session.commit()
+        fits_id = fits_row.id
+
+        payload = {
+            'CAMERA_ID': 1,
+            'FRAME_TYPE': 'fits',
+            'FITS_ID': fits_id,
+            'OUTPUT_IMAGE_TYPE': 'jpg',
+            'DISABLE_PROCESSING': False,
+        }
+
+        import wtforms
+        with patch.object(wtforms.Form, 'validate', lambda self, extra_validators=None: True):
+            response = auth_client.post('/indi-allsky/js/processing', json=payload)
+            assert response.status_code == 404
+            data = response.get_json()
+            assert data['message'] == 'FITS file not found'


### PR DESCRIPTION
- Cache remote FITS files locally when generating JPEG previews in fits2jpeg and image processing
- Return remote/S3 download URLs instead of local paths when non-local
- Filter dates and dropdown choices by remote/S3 availability when local images are disabled
- Use database createDate for timestamp calculations instead of file mtime

Closes #3135 

Draft while awaiting testing by the reporter