### PR TITLE
Fix: throttle TLE downloads and add exponential backoff

### DIFF
--- a/indi_allsky/allsky.py
+++ b/indi_allsky/allsky.py
@@ -48,6 +48,9 @@ from .flask.models import IndiAllSkyDbStarTrailsVideoTable
 from .flask.models import IndiAllSkyDbPanoramaImageTable
 from .flask.models import IndiAllSkyDbPanoramaVideoTable
 from .flask.models import IndiAllSkyDbTaskQueueTable
+from .flask.models import IndiAllSkyDbTleDataTable
+
+from . import constants
 
 from sqlalchemy import or_
 from sqlalchemy.orm.exc import NoResultFound
@@ -113,7 +116,35 @@ class IndiAllSky(object):
         self.cleanup_tasks_time = now_time   # run asap
         self.aurora_tasks_time = now_time    # run asap
         self.smoke_tasks_time = now_time     # run asap
-        self.sat_data_tasks_time = now_time  # run asap
+        # satellite tle task time based on persistent state and cache freshness
+        try:
+            sat_next_attempt = int(self._miscDb.getState('SATELLITE_TLE_NEXT_ATTEMPT_TS'))
+        except (NoResultFound, ValueError, TypeError):
+            sat_next_attempt = 0
+
+        if sat_next_attempt > now_time:
+            self.sat_data_tasks_time = sat_next_attempt
+        else:
+            try:
+                sat_last_ts = int(self._miscDb.getState('SATELLITE_TLE_TS'))
+            except (NoResultFound, ValueError, TypeError):
+                sat_last_ts = 0
+
+            if not sat_last_ts:
+                with app.app_context():
+                    latest_sat = IndiAllSkyDbTleDataTable.query\
+                        .filter(IndiAllSkyDbTleDataTable.group == constants.SATELLITE_VISUAL)\
+                        .order_by(IndiAllSkyDbTleDataTable.createDate.desc())\
+                        .first()
+                    if latest_sat and latest_sat.createDate:
+                        sat_last_ts = int(latest_sat.createDate.timestamp())
+                        self._miscDb.setState('SATELLITE_TLE_TS', sat_last_ts)
+
+            if sat_last_ts and (sat_last_ts + self.sat_data_tasks_offset > now_time):
+                self.sat_data_tasks_time = sat_last_ts + self.sat_data_tasks_offset
+            else:
+                self.sat_data_tasks_time = now_time  # run asap
+
         self.backup_tasks_time = now_time    # run asap
         self.allskymap_tasks_time = now_time  # run asap
 
@@ -1469,10 +1500,19 @@ class IndiAllSky(object):
 
         # satellite tle data update
         if self.sat_data_tasks_time < now_time:
-            self.sat_data_tasks_time = now_time + self.smoke_tasks_offset
+            self.sat_data_tasks_time = now_time + self.sat_data_tasks_offset
 
-            logger.info('Creating satellite tle data update task')
-            self._updateSatelliteTleData()
+            # check if backoff cooldown is active
+            try:
+                sat_next_attempt = int(self._miscDb.getState('SATELLITE_TLE_NEXT_ATTEMPT_TS'))
+            except (NoResultFound, ValueError, TypeError):
+                sat_next_attempt = 0
+
+            if sat_next_attempt > now_time:
+                self.sat_data_tasks_time = sat_next_attempt
+            else:
+                logger.info('Creating satellite tle data update task')
+                self._updateSatelliteTleData()
 
 
         # check if we need to backup database

--- a/indi_allsky/satellite_download.py
+++ b/indi_allsky/satellite_download.py
@@ -1,17 +1,21 @@
 
-#from datetime import datetime
-#from datetime import timedelta
+import time
+from datetime import datetime
+from datetime import timedelta
 import socket
 import ssl
 import urllib3.exceptions
 import requests
 import logging
 
+from sqlalchemy.orm.exc import NoResultFound
+
 from . import constants
 
 from .flask import db
 from .flask.miscDb import miscDb
 from .flask.models import IndiAllSkyDbTleDataTable
+from .flask.models import NotificationCategory
 
 
 logger = logging.getLogger('indi_allsky')
@@ -21,72 +25,186 @@ class IndiAllskyUpdateSatelliteData(object):
 
     tle_urls = {
         constants.SATELLITE_VISUAL    : 'https://celestrak.org/NORAD/elements/gp.php?GROUP=visual&FORMAT=tle',
-        constants.SATELLITE_STARLINK  : 'https://celestrak.org/NORAD/elements/gp.php?GROUP=starlink&FORMAT=tle',
-        constants.SATELLITE_STATIONS  : 'https://celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=tle',
     }
+
+    RATE_LIMIT_BASE_DELAY = 7200       # 2 hours (CelesTrak GP update frequency)
+    ERROR_BASE_DELAY = 900             # 15 minutes (network/server errors)
+    MAX_BACKOFF_DELAY = 86400          # 24 hours
+    FRESHNESS_MIN_INTERVAL = 86400     # 24 hours minimum freshness
 
 
     def __init__(self, config):
         self.config = config
 
         self._miscDb = miscDb(self.config)
+        self.last_status_code = None
 
 
-    def update(self):
+    def _calculate_backoff(self, is_rate_limit, fail_count):
+        base = self.RATE_LIMIT_BASE_DELAY if is_rate_limit else self.ERROR_BASE_DELAY
+        return min(base * (2 ** max(0, fail_count - 1)), self.MAX_BACKOFF_DELAY)
+
+
+    def _record_failure(self, is_rate_limit, error_msg, status_code=None):
+        now_time = time.time()
+        try:
+            fail_count = int(self._miscDb.getState('SATELLITE_TLE_FAIL_COUNT'))
+        except (NoResultFound, ValueError, TypeError):
+            fail_count = 0
+
+        fail_count += 1
+        self._miscDb.setState('SATELLITE_TLE_FAIL_COUNT', fail_count)
+
+        delay = self._calculate_backoff(is_rate_limit, fail_count)
+        next_attempt = int(now_time + delay)
+        self._miscDb.setState('SATELLITE_TLE_NEXT_ATTEMPT_TS', next_attempt)
+
+        delay_h = delay // 3600
+        delay_m = (delay % 3600) // 60
+        time_str = f'{delay_h}h' if delay_h > 0 else f'{delay_m}m'
+
+        if is_rate_limit:
+            notice_msg = f'CelesTrak TLE rate limit reached (HTTP {status_code}). Backing off for {time_str}.'
+        else:
+            notice_msg = f'CelesTrak TLE download failed: {error_msg}. Retrying in {time_str}.'
+
+        logger.warning(
+            '%s Next attempt at %s (failure count: %d)',
+            notice_msg,
+            datetime.fromtimestamp(next_attempt).strftime('%Y-%m-%d %H:%M:%S'),
+            fail_count,
+        )
+
+        try:
+            self._miscDb.addNotification(
+                NotificationCategory.GENERAL,
+                'satellite_tle_error',
+                notice_msg,
+                expire=timedelta(seconds=delay * 2),
+            )
+        except Exception as e:
+            logger.error('Failed to add satellite TLE notification: %s', str(e))
+
+
+    def _record_success(self):
+        now_time = int(time.time())
+        self._miscDb.setState('SATELLITE_TLE_TS', now_time)
+        self._miscDb.setState('SATELLITE_TLE_FAIL_COUNT', 0)
+        self._miscDb.setState('SATELLITE_TLE_NEXT_ATTEMPT_TS', 0)
+        try:
+            self._miscDb.clearNotification(NotificationCategory.GENERAL, 'satellite_tle_error')
+        except Exception as e:
+            logger.debug('Unable to clear satellite TLE notification: %s', str(e))
+
+
+    def update(self, force=False):
+        now_time = time.time()
+
+        if not force:
+            # Check if cooldown is active
+            try:
+                next_attempt = int(self._miscDb.getState('SATELLITE_TLE_NEXT_ATTEMPT_TS'))
+            except (NoResultFound, ValueError, TypeError):
+                next_attempt = 0
+
+            if next_attempt > now_time:
+                remaining = int(next_attempt - now_time)
+                rem_h = remaining // 3600
+                rem_m = (remaining % 3600) // 60
+                time_str = f'{rem_h}h {rem_m}m' if rem_h > 0 else f'{rem_m}m'
+                logger.info('Skipping satellite TLE update: cooldown active for %s', time_str)
+                return False
+
+            # Check if local data is fresh (< 2 hours old)
+            try:
+                last_update = int(self._miscDb.getState('SATELLITE_TLE_TS'))
+            except (NoResultFound, ValueError, TypeError):
+                last_update = 0
+
+            if not last_update:
+                latest_entry = IndiAllSkyDbTleDataTable.query\
+                    .filter(IndiAllSkyDbTleDataTable.group == constants.SATELLITE_VISUAL)\
+                    .order_by(IndiAllSkyDbTleDataTable.createDate.desc())\
+                    .first()
+                if latest_entry and latest_entry.createDate:
+                    last_update = int(latest_entry.createDate.timestamp())
+                    self._miscDb.setState('SATELLITE_TLE_TS', last_update)
+
+            if last_update and (now_time - last_update) < self.FRESHNESS_MIN_INTERVAL:
+                age_m = int((now_time - last_update) // 60)
+                logger.info('Skipping satellite TLE update: cached data is fresh (%d minutes old)', age_m)
+                return True
+
         for group, tle_url in self.tle_urls.items():
+            self.last_status_code = None
+            tle_data = None
+            err_msg = None
+
             try:
                 tle_data = self.download_tle(tle_url)
             except socket.gaierror as e:
-                logger.error('Name resolution error: %s', str(e))
-                continue
+                err_msg = f'DNS resolution error: {e}'
             except socket.timeout as e:
-                logger.error('Timeout error: %s', str(e))
-                continue
+                err_msg = f'Socket timeout: {e}'
             except requests.exceptions.ConnectTimeout as e:
-                logger.error('Connection timeout: %s', str(e))
-                continue
+                err_msg = f'Connection timeout: {e}'
             except requests.exceptions.ConnectionError as e:
-                logger.error('Connection error: %s', str(e))
-                continue
+                err_msg = f'Connection error: {e}'
             except requests.exceptions.ReadTimeout as e:
-                logger.error('Connection error: %s', str(e))
-                continue
+                err_msg = f'Read timeout: {e}'
             except urllib3.exceptions.ReadTimeoutError as e:
-                logger.error('Connection error: %s', str(e))
-                continue
-            except ssl.SSLCertVerificationError as e:
-                logger.error('Certificate error: %s', str(e))
-                continue
-            except requests.exceptions.SSLError as e:
-                logger.error('Certificate error: %s', str(e))
-                continue
+                err_msg = f'Read timeout: {e}'
+            except (ssl.SSLCertVerificationError, requests.exceptions.SSLError) as e:
+                err_msg = f'SSL error: {e}'
+            except requests.exceptions.RequestException as e:
+                err_msg = f'Request error: {e}'
 
+            if err_msg:
+                logger.error('Satellite TLE download error: %s', err_msg)
+                self._record_failure(is_rate_limit=False, error_msg=err_msg)
+                return False
 
-            if isinstance(tle_data, type(None)):
-                # HTTP error condition
-                continue
+            if self.last_status_code in (403, 429):
+                err_msg = f'Rate limited (HTTP {self.last_status_code})'
+                self._record_failure(is_rate_limit=True, error_msg=err_msg, status_code=self.last_status_code)
+                return False
+            elif self.last_status_code and self.last_status_code >= 400:
+                err_msg = f'HTTP error {self.last_status_code}'
+                self._record_failure(is_rate_limit=False, error_msg=err_msg, status_code=self.last_status_code)
+                return False
 
+            if not tle_data:
+                err_msg = 'Empty response received'
+                self._record_failure(is_rate_limit=False, error_msg=err_msg)
+                return False
 
-            # flush group entries
+            entries = self.parse_tle(group, tle_data)
+            if entries is None:
+                err_msg = 'Error parsing TLE data'
+                self._record_failure(is_rate_limit=False, error_msg=err_msg)
+                return False
+
+            # Purge non-visual groups (removes legacy Starlink/Stations)
+            IndiAllSkyDbTleDataTable.query\
+                .filter(IndiAllSkyDbTleDataTable.group != group)\
+                .delete()
+
+            # Flush current group entries
             IndiAllSkyDbTleDataTable.query\
                 .filter(IndiAllSkyDbTleDataTable.group == group)\
                 .delete()
-            #db.session.commit()
+
+            if len(entries) > 0:
+                db.session.bulk_insert_mappings(IndiAllSkyDbTleDataTable, entries)
+                db.session.commit()
+
+            logger.warning('Updated %d satellites', len(entries))
+
+        self._record_success()
+        return True
 
 
-            self.import_entries(group, tle_data)
-
-
-
-        # remove old entries
-        #now_minus_30d = datetime.now() - timedelta(days=30)
-        #IndiAllSkyDbTleDataTable.query\
-        #    .filter(IndiAllSkyDbTleDataTable.createDate < now_minus_30d)\
-        #    .delete()
-        #db.session.commit()
-
-
-    def import_entries(self, group, tle_data):
+    def parse_tle(self, group, tle_data):
         tle_entry_list = list()
 
         tle_iter = iter(tle_data.splitlines())
@@ -96,21 +214,12 @@ class IndiAllskyUpdateSatelliteData(object):
             except StopIteration:
                 break
 
-
-            #if line.startswith('#'):
-            #    continue
-            #elif line == "":
-            #    continue
-
-
             try:
                 line1 = next(tle_iter)
                 line2 = next(tle_iter)
             except StopIteration:
                 logger.error('Error parsing TLE data')
-                db.session.rollback()
-                return
-
+                return None
 
             ### https://en.wikipedia.org/wiki/Two-line_element_set
             try:
@@ -119,11 +228,7 @@ class IndiAllskyUpdateSatelliteData(object):
                 assert len(line2) == 69
             except AssertionError:
                 logger.error('Error parsing TLE data')
-                db.session.rollback()
-                return
-
-
-            #logger.warning('Title: %s %s %s', title, line1, line2)
+                return None
 
             tle_entry = {
                 'title' : title.strip().upper(),
@@ -133,20 +238,32 @@ class IndiAllskyUpdateSatelliteData(object):
             }
             tle_entry_list.append(tle_entry)
 
+        return tle_entry_list
 
-        db.session.bulk_insert_mappings(IndiAllSkyDbTleDataTable, tle_entry_list)
-        db.session.commit()
+
+    def import_entries(self, group, tle_data):
+        tle_entry_list = self.parse_tle(group, tle_data)
+        if tle_entry_list is None:
+            db.session.rollback()
+            return None
+
+        if len(tle_entry_list) > 0:
+            db.session.bulk_insert_mappings(IndiAllSkyDbTleDataTable, tle_entry_list)
+            db.session.commit()
 
         logger.warning('Updated %d satellites', len(tle_entry_list))
+        return len(tle_entry_list)
 
 
     def download_tle(self, url):
         logger.warning('Downloading %s', url)
         r = requests.get(url, allow_redirects=True, verify=True, timeout=(15.0, 30.0))
+        self.last_status_code = r.status_code
 
         if r.status_code >= 400:
             logger.error('URL returned %d', r.status_code)
             return None
 
         return r.text
+
 

--- a/indi_allsky/video.py
+++ b/indi_allsky/video.py
@@ -2404,9 +2404,12 @@ class VideoWorker(Process):
         task.setRunning()
 
         satellite = IndiAllskyUpdateSatelliteData(self.config)
-        satellite.update()
+        success = satellite.update()
 
-        task.setSuccess('Satellite data updated')
+        if success:
+            task.setSuccess('Satellite data updated')
+        else:
+            task.setFailed('Satellite data update deferred or failed')
 
 
     def backupDatabase(self, task, **kwargs):

--- a/tests/core/test_satellite_download.py
+++ b/tests/core/test_satellite_download.py
@@ -1,0 +1,396 @@
+import time
+import socket
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from indi_allsky.satellite_download import IndiAllskyUpdateSatelliteData
+from indi_allsky.flask.models import (
+    IndiAllSkyDbTleDataTable,
+    IndiAllSkyDbNotificationTable,
+    NotificationCategory,
+)
+from indi_allsky import constants
+
+
+# Sample Valid TLE — title must be <= 24 chars, lines 1 and 2 must be exactly 69 chars
+VALID_TITLE = "ISS (ZARYA)             "  # 24 chars exactly
+VALID_LINE1 = "1 25544U 98067A   21264.51782528  .00002893  00000-0  60680-4 0  9998"  # 69 chars
+VALID_LINE2 = "2 25544  51.6449 208.5765 0001327  66.2683  48.1373 15.48919755303825"  # 69 chars
+
+VALID_TLE = f"{VALID_TITLE}\n{VALID_LINE1}\n{VALID_LINE2}\n"
+
+MULTI_TLE = (
+    f"{VALID_TITLE}\n{VALID_LINE1}\n{VALID_LINE2}\n"
+    f"NOAA 15                 \n{VALID_LINE1}\n{VALID_LINE2}\n"
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_tle_table(flask_app, db):
+    """Ensure TLE and notification tables are clean before and after each test."""
+    with flask_app.app_context():
+        db.session.query(IndiAllSkyDbTleDataTable).delete()
+        db.session.query(IndiAllSkyDbNotificationTable).delete()
+        db.session.commit()
+    yield
+    with flask_app.app_context():
+        db.session.query(IndiAllSkyDbTleDataTable).delete()
+        db.session.query(IndiAllSkyDbNotificationTable).delete()
+        db.session.commit()
+
+
+def test_init_stores_config(flask_app):
+    """__init__ stores config and configures visual-only group"""
+    config = {'test_key': 'test_value'}
+    updater = IndiAllskyUpdateSatelliteData(config)
+    assert updater.config == config
+    assert updater._miscDb is not None
+    assert list(updater.tle_urls.keys()) == [constants.SATELLITE_VISUAL]
+
+
+@patch('indi_allsky.satellite_download.requests.get')
+def test_download_tle_success(mock_get, flask_app):
+    """download_tle - success returns text"""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.text = VALID_TLE
+    mock_get.return_value = mock_resp
+
+    updater = IndiAllskyUpdateSatelliteData({})
+    result = updater.download_tle("http://example.com/tle")
+
+    assert result == VALID_TLE
+    assert updater.last_status_code == 200
+    mock_get.assert_called_once_with(
+        "http://example.com/tle",
+        allow_redirects=True,
+        verify=True,
+        timeout=(15.0, 30.0),
+    )
+
+
+@patch('indi_allsky.satellite_download.requests.get')
+def test_download_tle_http_error(mock_get, flask_app):
+    """download_tle - HTTP error returns None and records status code"""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 404
+    mock_get.return_value = mock_resp
+
+    updater = IndiAllskyUpdateSatelliteData({})
+    result = updater.download_tle("http://example.com/tle")
+
+    assert result is None
+    assert updater.last_status_code == 404
+
+
+def test_import_entries_valid(flask_app, db):
+    """import_entries - valid TLE data creates DB entries"""
+    updater = IndiAllskyUpdateSatelliteData({})
+    group = constants.SATELLITE_VISUAL
+
+    count = updater.import_entries(group, VALID_TLE)
+    assert count == 1
+
+    entries = db.session.query(IndiAllSkyDbTleDataTable).filter_by(group=group).all()
+    assert len(entries) == 1
+    assert entries[0].title == "ISS (ZARYA)"
+    assert entries[0].line1.startswith("1 25544U")
+    assert entries[0].line2.startswith("2 25544")
+
+
+def test_import_entries_multiple(flask_app, db):
+    """import_entries - multiple TLE entries"""
+    updater = IndiAllskyUpdateSatelliteData({})
+    group = constants.SATELLITE_VISUAL
+
+    count = updater.import_entries(group, MULTI_TLE)
+    assert count == 2
+
+    entries = db.session.query(IndiAllSkyDbTleDataTable).filter_by(group=group).all()
+    assert len(entries) == 2
+
+
+def test_import_entries_invalid_title(flask_app, db):
+    """import_entries - title > 24 chars triggers assertion and rollback"""
+    updater = IndiAllskyUpdateSatelliteData({})
+    group = constants.SATELLITE_VISUAL
+
+    bad_title = "A" * 25
+    invalid_tle = f"{bad_title}\n{VALID_LINE1}\n{VALID_LINE2}\n"
+
+    result = updater.import_entries(group, invalid_tle)
+    assert result is None
+
+    entries = db.session.query(IndiAllSkyDbTleDataTable).filter_by(group=group).all()
+    assert len(entries) == 0
+
+
+def test_import_entries_incomplete_data(flask_app, db):
+    """import_entries - incomplete TLE data triggers rollback"""
+    updater = IndiAllskyUpdateSatelliteData({})
+    group = constants.SATELLITE_VISUAL
+
+    incomplete_tle = f"ISS (ZARYA)\n{VALID_LINE1}\n"
+
+    result = updater.import_entries(group, incomplete_tle)
+    assert result is None
+
+    entries = db.session.query(IndiAllSkyDbTleDataTable).filter_by(group=group).all()
+    assert len(entries) == 0
+
+
+def test_import_entries_empty(flask_app, db):
+    """import_entries - empty input produces no entries"""
+    updater = IndiAllskyUpdateSatelliteData({})
+    group = constants.SATELLITE_VISUAL
+
+    count = updater.import_entries(group, "")
+    assert count == 0
+
+    entries = db.session.query(IndiAllSkyDbTleDataTable).filter_by(group=group).all()
+    assert len(entries) == 0
+
+
+@patch('indi_allsky.satellite_download.requests.get')
+def test_update_success(mock_get, flask_app, db):
+    """update - successful flow: downloads visual only, updates timestamp, resets fail count"""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.text = VALID_TLE
+    mock_get.return_value = mock_resp
+
+    updater = IndiAllskyUpdateSatelliteData({})
+    success = updater.update(force=True)
+
+    assert success is True
+    entries = db.session.query(IndiAllSkyDbTleDataTable).filter_by(group=constants.SATELLITE_VISUAL).all()
+    assert len(entries) == 1
+
+    last_ts = int(updater._miscDb.getState('SATELLITE_TLE_TS'))
+    assert last_ts > 0
+    fail_count = int(updater._miscDb.getState('SATELLITE_TLE_FAIL_COUNT'))
+    assert fail_count == 0
+
+
+@patch('indi_allsky.satellite_download.requests.get')
+def test_update_freshness_skip(mock_get, flask_app):
+    """update - skips download if cached data is less than 24 hours old"""
+    updater = IndiAllskyUpdateSatelliteData({})
+    now = int(time.time())
+    updater._miscDb.setState('SATELLITE_TLE_TS', now - 43200)  # 12 hours old
+
+    success = updater.update(force=False)
+    assert success is True
+    mock_get.assert_not_called()
+
+
+@patch('indi_allsky.satellite_download.requests.get')
+def test_update_cooldown_active_skip(mock_get, flask_app):
+    """update - skips download if cooldown is active"""
+    updater = IndiAllskyUpdateSatelliteData({})
+    now = int(time.time())
+    updater._miscDb.setState('SATELLITE_TLE_NEXT_ATTEMPT_TS', now + 3600)  # in cooldown for 1 hour
+
+    success = updater.update(force=False)
+    assert success is False
+    mock_get.assert_not_called()
+
+
+@patch('indi_allsky.satellite_download.requests.get')
+def test_update_rate_limit_backoff(mock_get, flask_app, db):
+    """update - HTTP 403 / 429 sets exponential cooldown (starts at 2 hours) and creates notification"""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 403
+    mock_get.return_value = mock_resp
+
+    updater = IndiAllskyUpdateSatelliteData({})
+
+    # First rate-limit hit: 2 hours delay
+    now = time.time()
+    success = updater.update(force=True)
+    assert success is False
+
+    fail_count = int(updater._miscDb.getState('SATELLITE_TLE_FAIL_COUNT'))
+    assert fail_count == 1
+    next_ts = int(updater._miscDb.getState('SATELLITE_TLE_NEXT_ATTEMPT_TS'))
+    assert next_ts >= int(now + 7100)
+
+    # Verify notification created
+    notices = db.session.query(IndiAllSkyDbNotificationTable).filter_by(
+        item='satellite_tle_error',
+        category=NotificationCategory.GENERAL,
+    ).all()
+    assert len(notices) == 1
+    assert 'rate limit reached' in notices[0].notification
+
+    # Second rate-limit hit: exponential increase to 4 hours delay
+    now2 = time.time()
+    success2 = updater.update(force=True)
+    assert success2 is False
+
+    fail_count2 = int(updater._miscDb.getState('SATELLITE_TLE_FAIL_COUNT'))
+    assert fail_count2 == 2
+    next_ts2 = int(updater._miscDb.getState('SATELLITE_TLE_NEXT_ATTEMPT_TS'))
+    assert next_ts2 >= int(now2 + 14300)
+
+
+@patch('indi_allsky.satellite_download.requests.get')
+def test_update_network_error_backoff(mock_get, flask_app, db):
+    """update - network error sets exponential cooldown (starts at 15 minutes) and creates notification"""
+    mock_get.side_effect = socket.gaierror("DNS failed")
+
+    updater = IndiAllskyUpdateSatelliteData({})
+    now = time.time()
+    success = updater.update(force=True)
+    assert success is False
+
+    fail_count = int(updater._miscDb.getState('SATELLITE_TLE_FAIL_COUNT'))
+    assert fail_count == 1
+    next_ts = int(updater._miscDb.getState('SATELLITE_TLE_NEXT_ATTEMPT_TS'))
+    assert next_ts >= int(now + 890)
+
+    notices = db.session.query(IndiAllSkyDbNotificationTable).filter_by(
+        item='satellite_tle_error',
+        category=NotificationCategory.GENERAL,
+    ).all()
+    assert len(notices) == 1
+    assert 'DNS resolution error' in notices[0].notification
+
+
+@patch('indi_allsky.satellite_download.requests.get')
+def test_update_clears_notification_on_success(mock_get, flask_app, db):
+    """update - success clears previous error notification and resets fail count"""
+    updater = IndiAllskyUpdateSatelliteData({})
+
+    # Manually seed failure state and notification
+    updater._miscDb.setState('SATELLITE_TLE_FAIL_COUNT', 3)
+    updater._miscDb.setState('SATELLITE_TLE_NEXT_ATTEMPT_TS', int(time.time()) + 3600)
+    updater._miscDb.addNotification(
+        NotificationCategory.GENERAL,
+        'satellite_tle_error',
+        'Previous failure',
+    )
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.text = VALID_TLE
+    mock_get.return_value = mock_resp
+
+    success = updater.update(force=True)
+    assert success is True
+
+    # Assert notification was cleared
+    now = datetime.now()
+    active_notices = db.session.query(IndiAllSkyDbNotificationTable).filter(
+        IndiAllSkyDbNotificationTable.item == 'satellite_tle_error',
+        IndiAllSkyDbNotificationTable.expireDate > now,
+        IndiAllSkyDbNotificationTable.ack == False,
+    ).all()
+    assert len(active_notices) == 0
+
+    assert int(updater._miscDb.getState('SATELLITE_TLE_FAIL_COUNT')) == 0
+    assert int(updater._miscDb.getState('SATELLITE_TLE_NEXT_ATTEMPT_TS')) == 0
+
+
+@patch('indi_allsky.satellite_download.requests.get')
+def test_update_purges_legacy_groups(mock_get, flask_app, db):
+    """update - purges legacy groups (e.g. Starlink and Stations) from the DB"""
+    # Seed legacy Starlink and Stations records
+    legacy_starlink = IndiAllSkyDbTleDataTable(
+        title="STARLINK-1234",
+        line1=VALID_LINE1,
+        line2=VALID_LINE2,
+        group=constants.SATELLITE_STARLINK,
+    )
+    legacy_stations = IndiAllSkyDbTleDataTable(
+        title="TIANGONG",
+        line1=VALID_LINE1,
+        line2=VALID_LINE2,
+        group=constants.SATELLITE_STATIONS,
+    )
+    db.session.add(legacy_starlink)
+    db.session.add(legacy_stations)
+    db.session.commit()
+
+    assert db.session.query(IndiAllSkyDbTleDataTable).count() == 2
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.text = VALID_TLE
+    mock_get.return_value = mock_resp
+
+    updater = IndiAllskyUpdateSatelliteData({})
+    success = updater.update(force=True)
+    assert success is True
+
+    # Legacy records must be gone, only 1 visual record present
+    all_entries = db.session.query(IndiAllSkyDbTleDataTable).all()
+    assert len(all_entries) == 1
+    assert all_entries[0].group == constants.SATELLITE_VISUAL
+
+
+def test_allsky_sat_task_scheduling_fresh(flask_app, tmp_path):
+    """IndiAllSky startup schedules sat task 3 days out when TLE data is fresh"""
+    from indi_allsky.allsky import IndiAllSky
+    from indi_allsky.flask.miscDb import miscDb
+
+    mock_config = {
+        'LOCATION_LATITUDE': -34.9285,
+        'LOCATION_LONGITUDE': 138.6007,
+        'LOCATION_ELEVATION': 50,
+        'IMAGE_FOLDER': str(tmp_path),
+        'VARLIB_FOLDER': str(tmp_path),
+        'UPLOAD_WORKERS': 1,
+    }
+
+    misc_db = miscDb(mock_config)
+    now = int(time.time())
+    misc_db.setState('SATELLITE_TLE_TS', now - 3600)  # 1 hour ago
+    misc_db.setState('SATELLITE_TLE_NEXT_ATTEMPT_TS', 0)
+
+    with patch('indi_allsky.allsky.IndiAllSkyConfig') as mock_cfg_cls:
+        mock_cfg_inst = MagicMock()
+        mock_cfg_inst.config = mock_config
+        mock_cfg_inst.config_id = 1
+        mock_cfg_inst.config_level = 1
+        mock_cfg_cls.return_value = mock_cfg_inst
+
+        with patch('indi_allsky.allsky.__config_level__', 1):
+            allsky = IndiAllSky()
+            # Must be scheduled for last_ts + 259200
+            expected = (now - 3600) + allsky.sat_data_tasks_offset
+            assert abs(allsky.sat_data_tasks_time - expected) < 5
+
+
+def test_allsky_sat_task_scheduling_cooldown(flask_app, tmp_path):
+    """IndiAllSky startup schedules sat task at cooldown timestamp if active"""
+    from indi_allsky.allsky import IndiAllSky
+    from indi_allsky.flask.miscDb import miscDb
+
+    mock_config = {
+        'LOCATION_LATITUDE': -34.9285,
+        'LOCATION_LONGITUDE': 138.6007,
+        'LOCATION_ELEVATION': 50,
+        'IMAGE_FOLDER': str(tmp_path),
+        'VARLIB_FOLDER': str(tmp_path),
+        'UPLOAD_WORKERS': 1,
+    }
+
+    misc_db = miscDb(mock_config)
+    now = int(time.time())
+    cooldown_target = now + 7200
+    misc_db.setState('SATELLITE_TLE_NEXT_ATTEMPT_TS', cooldown_target)
+
+    with patch('indi_allsky.allsky.IndiAllSkyConfig') as mock_cfg_cls:
+        mock_cfg_inst = MagicMock()
+        mock_cfg_inst.config = mock_config
+        mock_cfg_inst.config_id = 1
+        mock_cfg_inst.config_level = 1
+        mock_cfg_cls.return_value = mock_cfg_inst
+
+        with patch('indi_allsky.allsky.__config_level__', 1):
+            allsky = IndiAllSky()
+            assert allsky.sat_data_tasks_time == cooldown_target
+


### PR DESCRIPTION
- Drop unused Starlink and Stations groups, downloading only the visual group
- Purge legacy non-visual groups from the database on update
- Add a 24-hour freshness guard to prevent redundant fetches on service restarts
- Implement exponential backoff for HTTP 403/429 rate limits and network errors
- Post notifications on download failure and clear them on success
- Fix loop offset in allsky.py to use sat_data_tasks_offset (3 days) instead of smoke_tasks_offset
- Check persistent TLE timestamps on process startup before scheduling
- Add test suite for satellite download and scheduling

Fixes #3138